### PR TITLE
Fix parser on Windows

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -70,7 +70,7 @@ func isAlphanumeric(r rune) bool {
 func isKeyChar(r rune) bool {
 	// "Keys start with the first non-whitespace character and end with the last
 	// non-whitespace character before the equals sign."
-	return !(isSpace(r) || r == '\n' || r == eof || r == '=')
+	return !(isSpace(r) || r == '\r' || r == '\n' || r == eof || r == '=')
 }
 
 func isDigit(r rune) bool {


### PR DESCRIPTION
The parser wasn't handling Windows line endings. This fixes https://github.com/pelletier/go-toml/issues/15.
