### PR TITLE
Int overflow in queryparser

### DIFF
--- a/match_test.go
+++ b/match_test.go
@@ -2,7 +2,6 @@ package toml
 
 import (
 	"fmt"
-	"math"
 	"testing"
 )
 
@@ -110,7 +109,7 @@ func TestPathSliceStart(t *testing.T) {
 	assertPath(t,
 		"$[123:]",
 		buildPath(
-			newMatchSliceFn(123, math.MaxInt64, 1),
+			newMatchSliceFn(123, MaxInt, 1),
 		))
 }
 
@@ -134,7 +133,7 @@ func TestPathSliceStartStep(t *testing.T) {
 	assertPath(t,
 		"$[123::7]",
 		buildPath(
-			newMatchSliceFn(123, math.MaxInt64, 7),
+			newMatchSliceFn(123, MaxInt, 7),
 		))
 }
 
@@ -150,7 +149,7 @@ func TestPathSliceStep(t *testing.T) {
 	assertPath(t,
 		"$[::7]",
 		buildPath(
-			newMatchSliceFn(0, math.MaxInt64, 7),
+			newMatchSliceFn(0, MaxInt, 7),
 		))
 }
 

--- a/queryparser.go
+++ b/queryparser.go
@@ -9,8 +9,9 @@ package toml
 
 import (
 	"fmt"
-	"math"
 )
+
+const MaxInt = int(^uint(0) >> 1)
 
 type queryParser struct {
 	flow         chan token
@@ -203,7 +204,7 @@ loop: // labeled loop for easy breaking
 
 func (p *queryParser) parseSliceExpr() queryParserStateFn {
 	// init slice to grab all elements
-	start, end, step := 0, math.MaxInt64, 1
+	start, end, step := 0, MaxInt, 1
 
 	// parse optional start
 	tok := p.getToken()


### PR DESCRIPTION
### Symptoms

Running `go build -o test_program_bin src/github.com/pelletier/go-toml/cmd/test_program.go` (excerpt from `test.sh`) yields `./queryparser.go:206: constant 9223372036854775807 overflows int`.
### Expected behavior

The build should finish and create the binary.
### Environment
- OS X 10.9
- Go i386 binary distribution
- GOARCH=386
### Notes
- Works fine on cross-compiled i386 linux (host is amd64 linux).
