### PR TITLE
Accept underscores in integers

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -527,6 +527,8 @@ func (l *tomlLexer) lexNumber() tomlLexStateFn {
 			}
 		} else if isDigit(next) {
 			digitSeen = true
+		} else if next == '_' {
+			l.pos++
 		} else {
 			l.backup()
 			break

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -434,6 +434,27 @@ func TestKeyEqualNumber(t *testing.T) {
 		token{Position{1, 7}, tokenFloat, "-4.2"},
 		token{Position{1, 11}, tokenEOF, ""},
 	})
+
+	testFlow(t, "foo = 1_000", []token{
+		token{Position{1, 1}, tokenKey, "foo"},
+		token{Position{1, 5}, tokenEqual, "="},
+		token{Position{1, 7}, tokenInteger, "1_000"},
+		token{Position{1, 12}, tokenEOF, ""},
+	})
+
+	testFlow(t, "foo = 5_349_221", []token{
+		token{Position{1, 1}, tokenKey, "foo"},
+		token{Position{1, 5}, tokenEqual, "="},
+		token{Position{1, 7}, tokenInteger, "5_349_221"},
+		token{Position{1, 16}, tokenEOF, ""},
+	})
+
+	testFlow(t, "foo = 1_2_3_4_5", []token{
+		token{Position{1, 1}, tokenKey, "foo"},
+		token{Position{1, 5}, tokenEqual, "="},
+		token{Position{1, 7}, tokenInteger, "1_2_3_4_5"},
+		token{Position{1, 16}, tokenEOF, ""},
+	})
 }
 
 func TestMultiline(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -224,7 +224,8 @@ func (p *tomlParser) parseRvalue() interface{} {
 	case tokenFalse:
 		return false
 	case tokenInteger:
-		val, err := strconv.ParseInt(tok.val, 10, 64)
+		cleanedVal := strings.Replace(tok.val, "_", "", -1)
+		val, err := strconv.ParseInt(cleanedVal, 10, 64)
 		if err != nil {
 			p.raiseError(tok, "%s", err)
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -68,6 +68,23 @@ func TestSimpleNumbers(t *testing.T) {
 	})
 }
 
+func TestIntegersWithUnderscores(t *testing.T) {
+	tree, err := Load("a = 1_000")
+	assertTree(t, tree, err, map[string]interface{}{
+		"a": int64(1000),
+	})
+
+	tree, err = Load("a = 5_349_221")
+	assertTree(t, tree, err, map[string]interface{}{
+		"a": int64(5349221),
+	})
+
+	tree, err = Load("a = 1_2_3_4_5")
+	assertTree(t, tree, err, map[string]interface{}{
+		"a": int64(12345),
+	})
+}
+
 func TestFloatsWithExponents(t *testing.T) {
 	tree, err := Load("a = 5e+22\nb = 5E+22\nc = -5e+22\nd = -5e-22\ne = 6.626e-34")
 	assertTree(t, tree, err, map[string]interface{}{


### PR DESCRIPTION
For large numbers, you may use underscores to enhance readability. Each underscore must be surrounded by at least one digit.

```toml
1_000
5_349_221
1_2_3_4_5     # valid but inadvisable
```

cc @eanderton 