### PR TITLE
Accept spaces in keys

### DIFF
--- a/lexer_test.go
+++ b/lexer_test.go
@@ -39,6 +39,15 @@ func TestValidKeyGroup(t *testing.T) {
 	})
 }
 
+func TestNestedQuotedUnicodeKeyGroup(t *testing.T) {
+	testFlow(t, `[ j . "ʞ" . l ]`, []token{
+		token{Position{1, 1}, tokenLeftBracket, "["},
+		token{Position{1, 2}, tokenKeyGroup, ` j . "ʞ" . l `},
+		token{Position{1, 15}, tokenRightBracket, "]"},
+		token{Position{1, 16}, tokenEOF, ""},
+	})
+}
+
 func TestUnclosedKeyGroup(t *testing.T) {
 	testFlow(t, "[hello world", []token{
 		token{Position{1, 1}, tokenLeftBracket, "["},

--- a/parser_test.go
+++ b/parser_test.go
@@ -157,6 +157,41 @@ func TestNestedKeys(t *testing.T) {
 	})
 }
 
+func TestNestedQuotedUnicodeKeys(t *testing.T) {
+	tree, err := Load("[ j . \"ʞ\" . l ]\nd = 42")
+	assertTree(t, tree, err, map[string]interface{}{
+		"j": map[string]interface{}{
+			"ʞ": map[string]interface{}{
+				"l": map[string]interface{}{
+					"d": int64(42),
+				},
+			},
+		},
+	})
+
+	tree, err = Load("[ g . h . i ]\nd = 42")
+	assertTree(t, tree, err, map[string]interface{}{
+		"g": map[string]interface{}{
+			"h": map[string]interface{}{
+				"i": map[string]interface{}{
+					"d": int64(42),
+				},
+			},
+		},
+	})
+
+	tree, err = Load("[ d.e.f ]\nk = 42")
+	assertTree(t, tree, err, map[string]interface{}{
+		"d": map[string]interface{}{
+			"e": map[string]interface{}{
+				"f": map[string]interface{}{
+					"k": int64(42),
+				},
+			},
+		},
+	})
+}
+
 func TestArrayOne(t *testing.T) {
 	tree, err := Load("a = [1]")
 	assertTree(t, tree, err, map[string]interface{}{


### PR DESCRIPTION
Whitespace around dot-separated parts is ignored, however, best practice is to not use any extraneous whitespace.

```toml
[a.b.c]          # this is best practice
[ d.e.f ]        # same as [d.e.f]
[ g .  h  . i ]  # same as [g.h.i]
[ j . "ʞ" . l ]  # same as [j."ʞ".l]
```

I may have lost the track during the implementation of this one, there may be a simpler solution.

@eanderton 