### PR TITLE
Add support for index lookups using GetPath with Groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can run both of them using `./test.sh`.
 
 ## License
 
-Copyright (c) 2013 - 2015 Thomas Pelletier, Eric Anderton
+Copyright (c) 2013 - 2015 Thomas Pelletier, Eric Anderton, Garrett D'Amore
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/parser.go
+++ b/parser.go
@@ -107,8 +107,8 @@ func (p *tomlParser) parseGroupArray() tomlParserStateFn {
 	var array []*TomlTree
 	if destTree == nil {
 		array = make([]*TomlTree, 0)
-	} else if destTree.([]*TomlTree) != nil {
-		array = destTree.([]*TomlTree)
+	} else if oldarray, ok := destTree.([]*TomlTree); ok && oldarray != nil {
+		array = oldarray
 	} else {
 		p.raiseError(key, "key %s is already assigned and not of type group array", key)
 	}

--- a/toml.go
+++ b/toml.go
@@ -79,7 +79,12 @@ func (t *TomlTree) GetPath(keys []string) interface{} {
 		return t
 	}
 	subtree := t
-	for _, intermediateKey := range keys[:len(keys)-1] {
+	skip := false
+	for keyNum, intermediateKey := range keys[:len(keys)-1] {
+		if skip {
+			skip = false
+			continue
+		}
 		value, exists := subtree.values[intermediateKey]
 		if !exists {
 			return nil
@@ -88,11 +93,15 @@ func (t *TomlTree) GetPath(keys []string) interface{} {
 		case *TomlTree:
 			subtree = node
 		case []*TomlTree:
-			// go to most recent element
 			if len(node) == 0 {
 				return nil
 			}
-			subtree = node[len(node)-1]
+			if index, e := strconv.Atoi(keys[keyNum+1]); e != nil {
+				return nil
+			} else if index >= 0 && index < len(node) {
+				subtree = node[index]
+				skip = true
+			}
 		default:
 			return nil // cannot naigate through other node types
 		}

--- a/toml_test.go
+++ b/toml_test.go
@@ -48,6 +48,43 @@ func TestTomlGetPath(t *testing.T) {
 	}
 }
 
+func TestTomlGetGroup(t *testing.T) {
+	tree, err := Load("[[foo]]\nbar=1\n[[foo]]\nbar=2")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	bar := tree.Get("foo.0.bar")
+	if bar == nil {
+		t.Error("Expected index 0 to be non-nil")
+		return
+	}
+	if bar, ok := bar.(int64); !ok {
+		t.Error("Expected index 0 to be int64, but wasn't")
+		return
+	} else if bar != 1 {
+		t.Errorf("Expected index 0 to be 1, but got %d", bar)
+		return
+	}
+	bar = tree.Get("foo.1.bar")
+	if bar == nil {
+		t.Error("Expected index 1 to be non-nil")
+		return
+	}
+	if bar, ok := bar.(int64); !ok {
+		t.Error("Expected index 1 to be int64, but wasn't")
+		return
+	} else if bar != 2 {
+		t.Errorf("Expected index 1 to be 2, but got %d", bar)
+		return
+	}
+	bar = tree.Get("foo.2.bar")
+	if bar != nil {
+		t.Error("Expected index 1 to be nil, but wasn't")
+		return
+	}
+}
+
 func TestTomlQuery(t *testing.T) {
 	tree, err := Load("[foo.bar]\na=1\nb=2\n[baz.foo]\na=3\nb=4\n[gorf.foo]\na=5\nb=6")
 	if err != nil {


### PR DESCRIPTION
This PR addresses two issues.

First, when using a [[group]], the library panics if there is already a different element with the same name, such as [group].  This is a configuration file error, and should not panic.  The fix for that is in parser.go.

The second problem, is really more of an enhancement.  This lets me use Get() (or GetPath()) with such groups by including an index.  That is, I can do Get("group.0.name") to get the item at index 0 (and you can use different indices.)  The old limitation of only choosing the last item in the group is removed, although at some level this change breaks that old limited behavior.

I've included a test case for this new functionality as well.  I've added my name to the copyright list, so and I contribute my changes under the same terms as the original.

I hope others find this helpful.  Let me know if there is anything else needed here.