### PR TITLE
Implement inline tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: go
 script: "./test.sh"
 sudo: false
 go:
-    - 1.1
     - 1.2
     - 1.3
     - 1.4.1
+    - 1.5
     - tip
 before_install:
   - go get github.com/axw/gocov/gocov

--- a/lexer.go
+++ b/lexer.go
@@ -158,13 +158,17 @@ func (l *tomlLexer) lexRvalue() tomlLexStateFn {
 		case '.':
 			return l.errorf("cannot start float with a dot")
 		case '=':
-			return l.errorf("cannot have multiple equals for the same key")
+			return l.lexEqual
 		case '[':
 			l.depth++
 			return l.lexLeftBracket
 		case ']':
 			l.depth--
 			return l.lexRightBracket
+		case '{':
+			return l.lexLeftCurlyBrace
+		case '}':
+			return l.lexRightCurlyBrace
 		case '#':
 			return l.lexComment
 		case '"':
@@ -216,6 +220,20 @@ func (l *tomlLexer) lexRvalue() tomlLexStateFn {
 
 	l.emit(tokenEOF)
 	return nil
+}
+
+func (l *tomlLexer) lexLeftCurlyBrace() tomlLexStateFn {
+	l.ignore()
+	l.pos++
+	l.emit(tokenLeftCurlyBrace)
+	return l.lexRvalue
+}
+
+func (l *tomlLexer) lexRightCurlyBrace() tomlLexStateFn {
+	l.ignore()
+	l.pos++
+	l.emit(tokenRightCurlyBrace)
+	return l.lexRvalue
 }
 
 func (l *tomlLexer) lexDate() tomlLexStateFn {

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -8,11 +8,12 @@ func testFlow(t *testing.T, input string, expectedFlow []token) {
 		token := <-ch
 		if token != expected {
 			t.Log("While testing: ", input)
+			t.Log("compared (got)", token, "to (expected)", expected)
+			t.Log("\tvalue:", token.val, "<->", expected.val)
+			t.Log("\ttype:", token.typ.String(), "<->", expected.typ.String())
+			t.Log("\tline:", token.Line, "<->", expected.Line)
+			t.Log("\tcolumn:", token.Col, "<->", expected.Col)
 			t.Log("compared", token, "to", expected)
-			t.Log(token.val, "<->", expected.val)
-			t.Log(token.typ, "<->", expected.typ)
-			t.Log(token.Line, "<->", expected.Line)
-			t.Log(token.Col, "<->", expected.Col)
 			t.FailNow()
 		}
 	}
@@ -368,14 +369,6 @@ func TestFloatWithExponent5(t *testing.T) {
 		token{Position{1, 3}, tokenEqual, "="},
 		token{Position{1, 5}, tokenFloat, "6.626e-34"},
 		token{Position{1, 14}, tokenEOF, ""},
-	})
-}
-
-func TestDoubleEqualKey(t *testing.T) {
-	testFlow(t, "foo= = 2", []token{
-		token{Position{1, 1}, tokenKey, "foo"},
-		token{Position{1, 4}, tokenEqual, "="},
-		token{Position{1, 5}, tokenError, "cannot have multiple equals for the same key"},
 	})
 }
 

--- a/parser.go
+++ b/parser.go
@@ -171,6 +171,7 @@ func (p *tomlParser) parseGroup() tomlParserStateFn {
 func (p *tomlParser) parseAssign() tomlParserStateFn {
 	key := p.getToken()
 	p.assume(tokenEqual)
+
 	value := p.parseRvalue()
 	var groupKey []string
 	if len(p.currentGroup) > 0 {
@@ -246,6 +247,8 @@ func (p *tomlParser) parseRvalue() interface{} {
 		return p.parseArray()
 	case tokenLeftCurlyBrace:
 		return p.parseInlineTable()
+	case tokenEqual:
+		p.raiseError(tok, "cannot have multiple equals for the same key")
 	case tokenError:
 		p.raiseError(tok, "%s", tok)
 	}

--- a/parser.go
+++ b/parser.go
@@ -312,6 +312,10 @@ func (p *tomlParser) parseArray() interface{} {
 		}
 		if follow.typ == tokenRightBracket {
 			p.getToken()
+			// An array of TomlTrees is actually an array of inline
+			// tables, which is a shorthand for a table array. If the
+			// array was not converted from []interface{} to []*TomlTree,
+			// the two notations would not be equivalent.
 			if arrayType == reflect.TypeOf(newTomlTree()) {
 				tomlArray := make([]*TomlTree, len(array))
 				for i, v := range array {

--- a/parser_test.go
+++ b/parser_test.go
@@ -571,3 +571,10 @@ func TestInvalidGroupArray(t *testing.T) {
 		t.Error("Should error")
 	}
 }
+
+func TestDoubleEqual(t *testing.T) {
+	_, err := Load("foo= = 2")
+	if err.Error() != "(1, 6): cannot have multiple equals for the same key" {
+		t.Error("Bad error message:", err.Error())
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -376,6 +376,34 @@ func TestExampleInlineGroupInArray(t *testing.T) {
 	})
 }
 
+func TestInlineTableUnterminated(t *testing.T) {
+	_, err := Load("foo = {")
+	if err.Error() != "(1, 8): unterminated inline table" {
+		t.Error("Bad error message:", err.Error())
+	}
+}
+
+func TestInlineTableCommaExpected(t *testing.T) {
+	_, err := Load("foo = {hello = 53 test = foo}")
+	if err.Error() != "(1, 19): comma expected between fields in inline table" {
+		t.Error("Bad error message:", err.Error())
+	}
+}
+
+func TestInlineTableCommaStart(t *testing.T) {
+	_, err := Load("foo = {, hello = 53}")
+	if err.Error() != "(1, 8): inline table cannot start with a comma" {
+		t.Error("Bad error message:", err.Error())
+	}
+}
+
+func TestInlineTableDoubleComma(t *testing.T) {
+	_, err := Load("foo = {hello = 53,, foo = 17}")
+	if err.Error() != "(1, 19): need field between two commas in inline table" {
+		t.Error("Bad error message:", err.Error())
+	}
+}
+
 func TestDuplicateGroups(t *testing.T) {
 	_, err := Load("[foo]\na=2\n[foo]b=3")
 	if err.Error() != "(3, 2): duplicated tables" {

--- a/parser_test.go
+++ b/parser_test.go
@@ -310,6 +310,52 @@ func TestArrayWithExtraCommaComment(t *testing.T) {
 	})
 }
 
+func TestSimpleInlineGroup(t *testing.T) {
+	tree, err := Load("key = {a = 42}")
+	assertTree(t, tree, err, map[string]interface{}{
+		"key": map[string]interface{}{
+			"a": int64(42),
+		},
+	})
+}
+
+func TestDoubleInlineGroup(t *testing.T) {
+	tree, err := Load("key = {a = 42, b = \"foo\"}")
+	assertTree(t, tree, err, map[string]interface{}{
+		"key": map[string]interface{}{
+			"a": int64(42),
+			"b": "foo",
+		},
+	})
+}
+
+func TestExampleInlineGroup(t *testing.T) {
+	tree, err := Load(`name = { first = "Tom", last = "Preston-Werner" }
+point = { x = 1, y = 2 }`)
+	assertTree(t, tree, err, map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Tom",
+			"last":  "Preston-Werner",
+		},
+		"point": map[string]interface{}{
+			"x": int64(1),
+			"y": int64(2),
+		},
+	})
+}
+
+func TestExampleInlineGroupInArray(t *testing.T) {
+	tree, err := Load(`points = [{ x = 1, y = 2 }]`)
+	assertTree(t, tree, err, map[string]interface{}{
+		"points": []map[string]interface{}{
+			map[string]interface{}{
+				"x": int64(1),
+				"y": int64(2),
+			},
+		},
+	})
+}
+
 func TestDuplicateGroups(t *testing.T) {
 	_, err := Load("[foo]\na=2\n[foo]b=3")
 	if err.Error() != "(3, 2): duplicated tables" {

--- a/token.go
+++ b/token.go
@@ -26,6 +26,8 @@ const (
 	tokenEqual
 	tokenLeftBracket
 	tokenRightBracket
+	tokenLeftCurlyBrace
+	tokenRightCurlyBrace
 	tokenLeftParen
 	tokenRightParen
 	tokenDoubleLeftBracket
@@ -44,6 +46,7 @@ const (
 )
 
 var tokenTypeNames = []string{
+	"Error",
 	"EOF",
 	"Comment",
 	"Key",
@@ -54,7 +57,9 @@ var tokenTypeNames = []string{
 	"Float",
 	"=",
 	"[",
-	"[",
+	"]",
+	"{",
+	"}",
 	"(",
 	")",
 	"]]",


### PR DESCRIPTION
@eanderton This PR should add the support for inline tables (https://github.com/pelletier/go-toml/issues/41) and therefore give us full support of TOML v0.4.0.

What do you think?