### PR TITLE
Fix multiline strings

### DIFF
--- a/lexer_test.go
+++ b/lexer_test.go
@@ -600,6 +600,20 @@ func TestMultilineString(t *testing.T) {
 		token{Position{1, 11}, tokenString, "The quick brown fox jumps over the lazy dog."},
 		token{Position{5, 11}, tokenEOF, ""},
 	})
+
+	testFlow(t, `key2 = "Roses are red\nViolets are blue"`, []token{
+		token{Position{1, 1}, tokenKey, "key2"},
+		token{Position{1, 6}, tokenEqual, "="},
+		token{Position{1, 9}, tokenString, "Roses are red\nViolets are blue"},
+		token{Position{1, 41}, tokenEOF, ""},
+	})
+
+	testFlow(t, "key2 = \"\"\"\nRoses are red\nViolets are blue\"\"\"", []token{
+		token{Position{1, 1}, tokenKey, "key2"},
+		token{Position{1, 6}, tokenEqual, "="},
+		token{Position{2, 1}, tokenString, "Roses are red\nViolets are blue"},
+		token{Position{3, 20}, tokenEOF, ""},
+	})
 }
 
 func TestUnicodeString(t *testing.T) {

--- a/token.go
+++ b/token.go
@@ -107,9 +107,6 @@ func (t token) String() string {
 		return t.val
 	}
 
-	if len(t.val) > 10 {
-		return fmt.Sprintf("%.10q...", t.val)
-	}
 	return fmt.Sprintf("%q", t.val)
 }
 

--- a/token_test.go
+++ b/token_test.go
@@ -55,7 +55,7 @@ func TestTokenString(t *testing.T) {
 		{token{Position{1, 1}, tokenEOF, ""}, "EOF"},
 		{token{Position{1, 1}, tokenError, "Δt"}, "Δt"},
 		{token{Position{1, 1}, tokenString, "bar"}, `"bar"`},
-		{token{Position{1, 1}, tokenString, "123456789012345"}, `"1234567890"...`},
+		{token{Position{1, 1}, tokenString, "123456789012345"}, `"123456789012345"`},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
I noticed that we didn't properly parse simple multiline strings such as:

```toml
key1 = """
Roses are red
Violets are blue"""
```

That patch fixes that issue. It also contains some refactoring to help further development on literal keys when https://github.com/pelletier/go-toml/issues/61 gets into a tagged TOML version.