### PR TITLE
Fix inline tables parsing

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -208,7 +208,15 @@ func (p *tomlParser) parseAssign() tomlParserStateFn {
 		p.raiseError(key, "The following key was defined twice: %s",
 			strings.Join(finalKey, "."))
 	}
-	targetNode.values[keyVal] = &tomlValue{value, key.Position}
+	var toInsert interface{}
+
+	switch value.(type) {
+	case *TomlTree:
+		toInsert = value
+	default:
+		toInsert = &tomlValue{value, key.Position}
+	}
+	targetNode.values[keyVal] = toInsert
 	return p.parseStart
 }
 

--- a/tomltree_conversions_test.go
+++ b/tomltree_conversions_test.go
@@ -6,6 +6,28 @@ import (
 	"time"
 )
 
+func TestTomlTreeConversionToString(t *testing.T) {
+	toml, err := Load(`name = { first = "Tom", last = "Preston-Werner" }
+points = { x = 1, y = 2 }`)
+
+	if err != nil {
+		t.Fatal("Unexpected error:", err)
+	}
+
+	reparsedTree, err := Load(toml.ToString())
+
+	assertTree(t, reparsedTree, err, map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Tom",
+			"last":  "Preston-Werner",
+		},
+		"points": map[string]interface{}{
+			"x": int64(1),
+			"y": int64(2),
+		},
+	})
+}
+
 func testMaps(t *testing.T, actual, expected map[string]interface{}) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatal("trees aren't equal.\n", "Expected:\n", expected, "\nActual:\n", actual)


### PR DESCRIPTION
Inline tables were wrapped inside a TomlValue, although they should
just be part of the tree.