### PR TITLE
Fix for Array of Tables

### DIFF
--- a/tomltree_conversions.go
+++ b/tomltree_conversions.go
@@ -128,7 +128,12 @@ func (t *TomlTree) ToMap() map[string]interface{} {
 		case []*TomlTree:
 			result[k] = make([]interface{}, 0)
 			for _, item := range node {
-				result[k] = item.ToMap()
+				if _, ok := result[k]; ok {
+					slice := result[k].([]interface{})
+					result[k] = append(slice, item.ToMap())
+				} else {
+					result[k] = item.ToMap()
+				}
 			}
 		case *TomlTree:
 			result[k] = node.ToMap()


### PR DESCRIPTION
The code in this PR addresses the bug documented in #83. It fixes the issue where the code is not returning a properly constructed slice when the array of tables items have the same key names.