### PR TITLE
Fix []*Toml.Tree being wrapped in *Toml.Value

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -211,7 +211,7 @@ func (p *tomlParser) parseAssign() tomlParserStateFn {
 	var toInsert interface{}
 
 	switch value.(type) {
-	case *TomlTree:
+	case *TomlTree, []*TomlTree:
 		toInsert = value
 	default:
 		toInsert = &tomlValue{value, key.Position}

--- a/tomltree_conversions_test.go
+++ b/tomltree_conversions_test.go
@@ -101,3 +101,35 @@ func TestTomlTreeConversionToMapWithTablesInMultipleChunks(t *testing.T) {
 
 	testMaps(t, treeMap, expected)
 }
+
+func TestTomlTreeConversionToMapWithArrayOfInlineTables(t *testing.T) {
+	tree, _ := Load(`
+    	[params]
+	language_tabs = [
+    		{ key = "shell", name = "Shell" },
+    		{ key = "ruby", name = "Ruby" },
+    		{ key = "python", name = "Python" }
+	]`)
+
+	expected := map[string]interface{}{
+		"params": map[string]interface{}{
+			"language_tabs": []interface{}{
+				map[string]interface{}{
+					"key": "shell",
+					"name": "Shell",
+				},
+				map[string]interface{}{
+					"key": "ruby",
+					"name": "Ruby",
+				},
+				map[string]interface{}{
+					"key": "python",
+					"name": "Python",
+				},
+			},
+		},
+	}
+
+	treeMap := tree.ToMap()
+	testMaps(t, treeMap, expected)
+}


### PR DESCRIPTION
Nodes can be either `*Toml.Tree`, `[]*Toml.Tree`, or `*Toml.Value`. Arrays of trees were incorrectly wrapped in a `*Toml.Value`, making the conversion functions think they were leaf nodes.