### PR TITLE
Make values come before tables in ToString output

### DIFF
--- a/tomltree_conversions_test.go
+++ b/tomltree_conversions_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 	"time"
+	"strings"
 )
 
 func TestTomlTreeConversionToString(t *testing.T) {
@@ -26,6 +27,41 @@ points = { x = 1, y = 2 }`)
 			"y": int64(2),
 		},
 	})
+}
+
+func TestTomlTreeConversionToStringKeysOrders(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		tree, _ := Load(`
+		foobar = true
+		bar = "baz"
+		foo = 1
+		[qux]
+		  foo = 1
+		  bar = "baz2"`)
+
+		stringRepr := tree.ToString()
+
+		t.Log("Intermediate string representation:")
+		t.Log(stringRepr)
+
+		r := strings.NewReader(stringRepr)
+		toml, err := LoadReader(r)
+
+
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
+		}
+
+		assertTree(t, toml, err, map[string]interface{}{
+			"foobar": true,
+			"bar": "baz",
+			"foo": 1,
+			"qux": map[string]interface{}{
+				"foo": 1,
+				"bar": "baz2",
+			},
+		})
+	}
 }
 
 func testMaps(t *testing.T, actual, expected map[string]interface{}) {


### PR DESCRIPTION
If no order on the key is enforced in ToString, the following tree:

```toml
foo = 1
bar = "baz"
foobar = true
[qux]
  foo = 1
  bar = "baz"
```

may come out as:

```toml
bar = "baz"
foobar = true
[qux]
  foo = 1
  bar = "baz"
foo = 1
```

which is incorrect, since putting that back to the parser would panic because of a duplicated key (`qux.foo`). Those changes make sure that leaf values come before tables in the ToString output.