### PR TITLE
fix typo in README.md installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Go-toml provides two handy command line tools:
 * `tomljson`: Reads a TOML file and outputs its JSON representation.
 
     ```
-    go install github.com/pelletier/go-toml/cmd/tomjson
+    go install github.com/pelletier/go-toml/cmd/tomljson
     tomljson --help
     ```
 


### PR DESCRIPTION
I tried copying and pasting the installation instructions and got the following error:

```
~$ go install github.com/pelletier/go-toml/cmd/tomjson
can't load package: package github.com/pelletier/go-toml/cmd/tomjson: cannot find package "github.com/pelletier/go-toml/cmd/tomjson" in any of:
        /usr/local/Cellar/go/1.7.4_1/libexec/src/github.com/pelletier/go-toml/cmd/tomjson (from $GOROOT)
        /Users/jordan/projects/gocode/src/github.com/pelletier/go-toml/cmd/tomjson (from $GOPATH)
```