### PR TITLE
[WIP]Fix TreeFromMap for Array of Tables

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -674,6 +674,27 @@ func TestToStringMapStringString(t *testing.T) {
 	}
 }
 
+func TestToRoundTripArrayOfTables(t *testing.T) {
+	orig := "\n[[stuff]]\n  name = \"foo\"\n"
+	tree, err := Load(orig)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	m := tree.ToMap()
+	tree, err = TreeFromMap(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	want := orig
+	got := tree.String()
+
+	if got != want {
+		t.Errorf("want:\n%q\ngot:\n%q", want, got)
+	}
+}
+
 func assertPosition(t *testing.T, text string, ref map[string]Position) {
 	tree, err := Load(text)
 	if err != nil {

--- a/tomltree_create.go
+++ b/tomltree_create.go
@@ -63,7 +63,7 @@ func sliceToTree(object interface{}) (interface{}, error) {
 	value := reflect.ValueOf(object)
 	insideType := value.Type().Elem()
 	length := value.Len()
-	if insideType.Kind() == reflect.Map {
+	if insideType.Kind() == reflect.Map || insideType.Kind() == reflect.Interface {
 		// this is considered as an array of tables
 		tablesArray := make([]*TomlTree, 0, length)
 		for i := 0; i < length; i++ {

--- a/tomltree_create_test.go
+++ b/tomltree_create_test.go
@@ -49,11 +49,12 @@ func TestTomlTreeCreateToTree(t *testing.T) {
 		"nested": map[string]interface{}{
 			"foo": "bar",
 		},
-		"array":       []string{"a", "b", "c"},
-		"array_uint":  []uint{uint(1), uint(2)},
-		"array_table": []map[string]interface{}{map[string]interface{}{"sub_map": 52}},
-		"array_times": []time.Time{time.Now(), time.Now()},
-		"map_times":   map[string]time.Time{"now": time.Now()},
+		"array":        []string{"a", "b", "c"},
+		"array_uint":   []uint{uint(1), uint(2)},
+		"nested_table": []map[string]interface{}{{"sub_map": 52}},
+		"array_table":  []interface{}{map[string]interface{}{"foo": "bar"}},
+		"array_times":  []time.Time{time.Now(), time.Now()},
+		"map_times":    map[string]time.Time{"now": time.Now()},
 	}
 	tree, err := TreeFromMap(data)
 	if err != nil {


### PR DESCRIPTION
This fixes `TreeFromMap` for an [array of tables](https://github.com/toml-lang/toml#array-of-tables), (#143), e.g.

```
[[things]]
name = "stuff"
```