### PR TITLE
Reflect actual slice type in TreeFromMap

### DIFF
--- a/tomltree_create.go
+++ b/tomltree_create.go
@@ -65,6 +65,9 @@ func sliceToTree(object interface{}) (interface{}, error) {
 	value := reflect.ValueOf(object)
 	insideType := value.Type().Elem()
 	length := value.Len()
+	if length > 0 {
+		insideType = reflect.ValueOf(value.Index(0).Interface()).Type()
+	}
 	if insideType.Kind() == reflect.Map {
 		// this is considered as an array of tables
 		tablesArray := make([]*TomlTree, 0, length)

--- a/tomltree_create_test.go
+++ b/tomltree_create_test.go
@@ -3,6 +3,7 @@ package toml
 import (
 	"testing"
 	"time"
+	"strconv"
 )
 
 type customString string
@@ -21,20 +22,19 @@ func validate(t *testing.T, path string, object interface{}) {
 		}
 	case []*TomlTree:
 		for index, tree := range o {
-			validate(t, path+"."+string(index), tree)
+			validate(t, path+"."+strconv.Itoa(index), tree)
 		}
 	case *tomlValue:
 		switch o.value.(type) {
 		case int64, uint64, bool, string, float64, time.Time,
 			[]int64, []uint64, []bool, []string, []float64, []time.Time:
-			return // ok
 		default:
 			t.Fatalf("tomlValue at key %s containing incorrect type %T", path, o.value)
 		}
 	default:
 		t.Fatalf("value at key %s is of incorrect type %T", path, object)
 	}
-	t.Log("validation ok", path)
+	t.Logf("validation ok %s as %T", path, object)
 }
 
 func validateTree(t *testing.T, tree *TomlTree) {

--- a/tomltree_create_test.go
+++ b/tomltree_create_test.go
@@ -105,7 +105,7 @@ func TestTomlTreeCreateToTreeInvalidTableGroupType(t *testing.T) {
 }
 
 func TestRoundTripArrayOfTables(t *testing.T) {
-	orig := "\n[[stuff]]\n  name = \"foo\"\n"
+	orig := "\n[[stuff]]\n  name = \"foo\"\n  things = [\"a\",\"b\"]\n"
 	tree, err := Load(orig)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -117,11 +117,10 @@ func TestRoundTripArrayOfTables(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
-
 	want := orig
 	got := tree.String()
 
 	if got != want {
-		t.Errorf("want:\n%q\ngot:\n%q", want, got)
+		t.Errorf("want:\n%s\ngot:\n%s", want, got)
 	}
 }

--- a/tomltree_create_test.go
+++ b/tomltree_create_test.go
@@ -103,3 +103,25 @@ func TestTomlTreeCreateToTreeInvalidTableGroupType(t *testing.T) {
 		t.Fatalf("expected error %s, got %s", expected, err.Error())
 	}
 }
+
+func TestRoundTripArrayOfTables(t *testing.T) {
+	orig := "\n[[stuff]]\n  name = \"foo\"\n"
+	tree, err := Load(orig)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	m := tree.ToMap()
+
+	tree, err = TreeFromMap(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	want := orig
+	got := tree.String()
+
+	if got != want {
+		t.Errorf("want:\n%q\ngot:\n%q", want, got)
+	}
+}

--- a/tomltree_write_test.go
+++ b/tomltree_write_test.go
@@ -119,19 +119,6 @@ func testMaps(t *testing.T, actual, expected map[string]interface{}) {
 	}
 }
 
-func TestToTomlStringTypeConversionError(t *testing.T) {
-	tree := TomlTree{
-		values: map[string]interface{}{
-			"thing": &tomlValue{[]string{"unsupported"}, Position{}},
-		},
-	}
-	_, err := tree.ToTomlString()
-	expected := errors.New("unsupported value type []string: [unsupported]")
-	if err.Error() != expected.Error() {
-		t.Errorf("expecting error %s, but got %s instead", expected, err)
-	}
-}
-
 func TestTomlTreeWriteToMapSimple(t *testing.T) {
 	tree, _ := Load("a = 42\nb = 17")
 


### PR DESCRIPTION
Retrieve the actual type of a slice's elements when possible.

Fixes #143 
