### PR TITLE
Use MarshalTOML() if struct has defined a custom marshaler

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -51,7 +51,7 @@ func isPrimitive(mtype reflect.Type) bool {
 	case reflect.String:
 		return true
 	case reflect.Struct:
-		return mtype == timeType
+		return mtype == timeType || isCustomMarshaler(mtype)
 	default:
 		return false
 	}

--- a/marshal.go
+++ b/marshal.go
@@ -33,6 +33,7 @@ type tomlOpts struct {
 }
 
 var timeType = reflect.TypeOf(time.Time{})
+var marshalerType = reflect.TypeOf(new(Marshaler)).Elem()
 
 // Check if the given marshall type maps to a TomlTree primitive
 func isPrimitive(mtype reflect.Type) bool {
@@ -90,6 +91,20 @@ func isTree(mtype reflect.Type) bool {
 	}
 }
 
+func isCustomMarshaler(mtype reflect.Type) bool {
+	return mtype.Implements(marshalerType)
+}
+
+func callCustomMarshaler(mval reflect.Value) ([]byte, error) {
+	return mval.Interface().(Marshaler).MarshalTOML()
+}
+
+// Marshaler is the interface implemented by types that
+// can marshal themselves into valid TOML.
+type Marshaler interface {
+	MarshalTOML() ([]byte, error)
+}
+
 /*
 Marshal returns the TOML encoding of v.  Behavior is similar to the Go json
 encoder, except that there is no concept of a Marshaler interface or MarshalTOML
@@ -106,6 +121,9 @@ func Marshal(v interface{}) ([]byte, error) {
 		return []byte{}, errors.New("Only a struct can be marshaled to TOML")
 	}
 	sval := reflect.ValueOf(v)
+	if isCustomMarshaler(mtype) {
+		return callCustomMarshaler(sval)
+	}
 	t, err := valueToTree(mtype, sval)
 	if err != nil {
 		return []byte{}, err
@@ -178,6 +196,8 @@ func valueToToml(mtype reflect.Type, mval reflect.Value) (interface{}, error) {
 		return valueToToml(mtype.Elem(), mval.Elem())
 	}
 	switch {
+	case isCustomMarshaler(mtype):
+		return callCustomMarshaler(mval)
 	case isTree(mtype):
 		return valueToTree(mtype, mval)
 	case isTreeSlice(mtype):

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -536,7 +536,8 @@ func TestNestedUnmarshal(t *testing.T) {
 }
 
 type customMarshalerParent struct {
-	Person customMarshaler `toml:"name"`
+	Self    customMarshaler   `toml:"me"`
+	Friends []customMarshaler `toml:"friends"`
 }
 
 type customMarshaler struct {
@@ -551,8 +552,12 @@ func (c customMarshaler) MarshalTOML() ([]byte, error) {
 
 var customMarshalerData = customMarshaler{FirsName: "Sally", LastName: "Fields"}
 var customMarshalerToml = []byte(`Sally Fields`)
-var nestedCustomMarshalerData = customMarshalerParent{Person: customMarshalerData}
-var nestedCustomMarshalerToml = []byte(`name = "Sally Fields"
+var nestedCustomMarshalerData = customMarshalerParent{
+	Self:    customMarshaler{FirsName: "Maiku", LastName: "Suteda"},
+	Friends: []customMarshaler{customMarshalerData},
+}
+var nestedCustomMarshalerToml = []byte(`friends = ["Sally Fields"]
+me = "Maiku Suteda"
 `)
 
 func TestCustomMarshaler(t *testing.T) {
@@ -562,7 +567,7 @@ func TestCustomMarshaler(t *testing.T) {
 	}
 	expected := customMarshalerToml
 	if !bytes.Equal(result, expected) {
-		t.Errorf("Bad custom marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+		t.Errorf("Bad custom marshaler: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
 	}
 }
 
@@ -573,6 +578,6 @@ func TestNestedCustomMarshaler(t *testing.T) {
 	}
 	expected := nestedCustomMarshalerToml
 	if !bytes.Equal(result, expected) {
-		t.Errorf("Bad nested custom marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+		t.Errorf("Bad nested custom marshaler: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
 	}
 }

--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -52,6 +52,9 @@ func tomlValueStringRepresentation(v interface{}) (string, error) {
 		return strconv.FormatFloat(value, 'f', -1, 32), nil
 	case string:
 		return "\"" + encodeTomlString(value) + "\"", nil
+	case []byte:
+		b, _ := v.([]byte)
+		return tomlValueStringRepresentation(string(b))
 	case bool:
 		if value {
 			return "true", nil


### PR DESCRIPTION
I based `tom.Marshaler` on the implementation for `json.Marshaler`.