### PR TITLE
Initialize keys array to final length

### DIFF
--- a/toml.go
+++ b/toml.go
@@ -52,9 +52,11 @@ func (t *TomlTree) HasPath(keys []string) bool {
 // Keys returns the keys of the toplevel tree.
 // Warning: this is a costly operation.
 func (t *TomlTree) Keys() []string {
-	var keys []string
+	keys := make([]string, len(t.values))
+	i := 0
 	for k := range t.values {
-		keys = append(keys, k)
+		keys[i] = k
+		i++
 	}
 	return keys
 }


### PR DESCRIPTION
Previously we'd create an empty array and need to continuously resize
it as we appended more entries. This way we immediately create the
correct size array, and then add entries to it.