### PR TITLE
Experiment using []byte

### DIFF
--- a/benchmark.json
+++ b/benchmark.json
@@ -1,0 +1,164 @@
+{
+    "array": {
+        "key1": [
+            1,
+            2,
+            3
+        ],
+        "key2": [
+            "red",
+            "yellow",
+            "green"
+        ],
+        "key3": [
+            [
+                1,
+                2
+            ],
+            [
+                3,
+                4,
+                5
+            ]
+        ],
+        "key4": [
+            [
+                1,
+                2
+            ],
+            [
+                "a",
+                "b",
+                "c"
+            ]
+        ],
+        "key5": [
+            1,
+            2,
+            3
+        ],
+        "key6": [
+            1,
+            2
+        ]
+    },
+    "boolean": {
+        "False": false,
+        "True": true
+    },
+    "datetime": {
+        "key1": "1979-05-27T07:32:00Z",
+        "key2": "1979-05-27T00:32:00-07:00",
+        "key3": "1979-05-27T00:32:00.999999-07:00"
+    },
+    "float": {
+        "both": {
+            "key": 6.626e-34
+        },
+        "exponent": {
+            "key1": 5e+22,
+            "key2": 1000000,
+            "key3": -0.02
+        },
+        "fractional": {
+            "key1": 1,
+            "key2": 3.1415,
+            "key3": -0.01
+        },
+        "underscores": {
+            "key1": 9224617.445991227,
+            "key2": 1e+100
+        }
+    },
+    "fruit": [{
+            "name": "apple",
+            "physical": {
+                "color": "red",
+                "shape": "round"
+            },
+            "variety": [{
+                    "name": "red delicious"
+                },
+                {
+                    "name": "granny smith"
+                }
+            ]
+        },
+        {
+            "name": "banana",
+            "variety": [{
+                "name": "plantain"
+            }]
+        }
+    ],
+    "integer": {
+        "key1": 99,
+        "key2": 42,
+        "key3": 0,
+        "key4": -17,
+        "underscores": {
+            "key1": 1000,
+            "key2": 5349221,
+            "key3": 12345
+        }
+    },
+    "products": [{
+            "name": "Hammer",
+            "sku": 738594937
+        },
+        {},
+        {
+            "color": "gray",
+            "name": "Nail",
+            "sku": 284758393
+        }
+    ],
+    "string": {
+        "basic": {
+            "basic": "I'm a string. \"You can quote me\". Name\tJosé\nLocation\tSF."
+        },
+        "literal": {
+            "multiline": {
+                "lines": "The first newline is\ntrimmed in raw strings.\n   All other whitespace\n   is preserved.\n",
+                "regex2": "I [dw]on't need \\d{2} apples"
+            },
+            "quoted": "Tom \"Dubs\" Preston-Werner",
+            "regex": "\u003c\\i\\c*\\s*\u003e",
+            "winpath": "C:\\Users\\nodejs\\templates",
+            "winpath2": "\\\\ServerX\\admin$\\system32\\"
+        },
+        "multiline": {
+            "continued": {
+                "key1": "The quick brown fox jumps over the lazy dog.",
+                "key2": "The quick brown fox jumps over the lazy dog.",
+                "key3": "The quick brown fox jumps over the lazy dog."
+            },
+            "key1": "One\nTwo",
+            "key2": "One\nTwo",
+            "key3": "One\nTwo"
+        }
+    },
+    "table": {
+        "inline": {
+            "name": {
+                "first": "Tom",
+                "last": "Preston-Werner"
+            },
+            "point": {
+                "x": 1,
+                "y": 2
+            }
+        },
+        "key": "value",
+        "subtable": {
+            "key": "another value"
+        }
+    },
+    "x": {
+        "y": {
+            "z": {
+                "w": {}
+            }
+        }
+    }
+}

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -13,7 +13,7 @@ fi
 
 tempdir=`mktemp -d /tmp/go-toml-benchmark-XXXXXX`
 ref_tempdir="${tempdir}/ref"
-ref_benchmark="${ref_tempdir}/benchmark-${reference_ref}.txt"
+ref_benchmark="${ref_tempdir}/benchmark-`echo -n ${reference_ref}|tr -s '/' '-'`.txt"
 local_benchmark="`pwd`/benchmark-local.txt"
 
 echo "=== ${reference_ref} (${ref_tempdir})"
@@ -25,7 +25,7 @@ popd >/dev/null
 
 echo ""
 echo "=== local"
-go test -bench=. -benchmem | tee ${local_benchmark}
+go test -bench=. -benchmem  | tee ${local_benchmark}
 
 echo ""
 echo "=== diff"

--- a/benchmark.toml
+++ b/benchmark.toml
@@ -1,0 +1,244 @@
+################################################################################
+## Comment
+
+# Speak your mind with the hash symbol. They go from the symbol to the end of
+# the line.
+
+
+################################################################################
+## Table
+
+# Tables (also known as hash tables or dictionaries) are collections of
+# key/value pairs. They appear in square brackets on a line by themselves.
+
+[table]
+
+key = "value" # Yeah, you can do this.
+
+# Nested tables are denoted by table names with dots in them. Name your tables
+# whatever crap you please, just don't use #, ., [ or ].
+
+[table.subtable]
+
+key = "another value"
+
+# You don't need to specify all the super-tables if you don't want to. TOML
+# knows how to do it for you.
+
+# [x] you
+# [x.y] don't
+# [x.y.z] need these
+[x.y.z.w] # for this to work
+
+
+################################################################################
+## Inline Table
+
+# Inline tables provide a more compact syntax for expressing tables. They are
+# especially useful for grouped data that can otherwise quickly become verbose.
+# Inline tables are enclosed in curly braces `{` and `}`. No newlines are
+# allowed between the curly braces unless they are valid within a value.
+
+[table.inline]
+
+name = { first = "Tom", last = "Preston-Werner" }
+point = { x = 1, y = 2 }
+
+
+################################################################################
+## String
+
+# There are four ways to express strings: basic, multi-line basic, literal, and
+# multi-line literal. All strings must contain only valid UTF-8 characters.
+
+[string.basic]
+
+basic = "I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF."
+
+[string.multiline]
+
+# The following strings are byte-for-byte equivalent:
+key1 = "One\nTwo"
+key2 = """One\nTwo"""
+key3 = """
+One
+Two"""
+
+[string.multiline.continued]
+
+# The following strings are byte-for-byte equivalent:
+key1 = "The quick brown fox jumps over the lazy dog."
+
+key2 = """
+The quick brown \
+
+
+  fox jumps over \
+    the lazy dog."""
+
+key3 = """\
+       The quick brown \
+       fox jumps over \
+       the lazy dog.\
+       """
+
+[string.literal]
+
+# What you see is what you get.
+winpath  = 'C:\Users\nodejs\templates'
+winpath2 = '\\ServerX\admin$\system32\'
+quoted   = 'Tom "Dubs" Preston-Werner'
+regex    = '<\i\c*\s*>'
+
+
+[string.literal.multiline]
+
+regex2 = '''I [dw]on't need \d{2} apples'''
+lines  = '''
+The first newline is
+trimmed in raw strings.
+   All other whitespace
+   is preserved.
+'''
+
+
+################################################################################
+## Integer
+
+# Integers are whole numbers. Positive numbers may be prefixed with a plus sign.
+# Negative numbers are prefixed with a minus sign.
+
+[integer]
+
+key1 = +99
+key2 = 42
+key3 = 0
+key4 = -17
+
+[integer.underscores]
+
+# For large numbers, you may use underscores to enhance readability. Each
+# underscore must be surrounded by at least one digit.
+key1 = 1_000
+key2 = 5_349_221
+key3 = 1_2_3_4_5     # valid but inadvisable
+
+
+################################################################################
+## Float
+
+# A float consists of an integer part (which may be prefixed with a plus or
+# minus sign) followed by a fractional part and/or an exponent part.
+
+[float.fractional]
+
+key1 = +1.0
+key2 = 3.1415
+key3 = -0.01
+
+[float.exponent]
+
+key1 = 5e+22
+key2 = 1e6
+key3 = -2E-2
+
+[float.both]
+
+key = 6.626e-34
+
+[float.underscores]
+
+key1 = 9_224_617.445_991_228_313
+key2 = 1e1_00
+
+
+################################################################################
+## Boolean
+
+# Booleans are just the tokens you're used to. Always lowercase.
+
+[boolean]
+
+True = true
+False = false
+
+
+################################################################################
+## Datetime
+
+# Datetimes are RFC 3339 dates.
+
+[datetime]
+
+key1 = 1979-05-27T07:32:00Z
+key2 = 1979-05-27T00:32:00-07:00
+key3 = 1979-05-27T00:32:00.999999-07:00
+
+
+################################################################################
+## Array
+
+# Arrays are square brackets with other primitives inside. Whitespace is
+# ignored. Elements are separated by commas. Data types may not be mixed.
+
+[array]
+
+key1 = [ 1, 2, 3 ]
+key2 = [ "red", "yellow", "green" ]
+key3 = [ [ 1, 2 ], [3, 4, 5] ]
+#key4 = [ [ 1, 2 ], ["a", "b", "c"] ] # this is ok
+
+# Arrays can also be multiline. So in addition to ignoring whitespace, arrays
+# also ignore newlines between the brackets.  Terminating commas are ok before
+# the closing bracket.
+
+key5 = [
+  1, 2, 3
+]
+key6 = [
+  1,
+  2, # this is ok
+]
+
+
+################################################################################
+## Array of Tables
+
+# These can be expressed by using a table name in double brackets. Each table
+# with the same double bracketed name will be an element in the array. The
+# tables are inserted in the order encountered.
+
+[[products]]
+
+name = "Hammer"
+sku = 738594937
+
+[[products]]
+
+[[products]]
+
+name = "Nail"
+sku = 284758393
+color = "gray"
+
+
+# You can create nested arrays of tables as well.
+
+[[fruit]]
+  name = "apple"
+
+  [fruit.physical]
+    color = "red"
+    shape = "round"
+
+  [[fruit.variety]]
+    name = "red delicious"
+
+  [[fruit.variety]]
+    name = "granny smith"
+
+[[fruit]]
+  name = "banana"
+
+  [[fruit.variety]]
+    name = "plantain"

--- a/benchmark.yml
+++ b/benchmark.yml
@@ -1,0 +1,121 @@
+---
+array:
+  key1:
+  - 1
+  - 2
+  - 3
+  key2:
+  - red
+  - yellow
+  - green
+  key3:
+  - - 1
+    - 2
+  - - 3
+    - 4
+    - 5
+  key4:
+  - - 1
+    - 2
+  - - a
+    - b
+    - c
+  key5:
+  - 1
+  - 2
+  - 3
+  key6:
+  - 1
+  - 2
+boolean:
+  'False': false
+  'True': true
+datetime:
+  key1: '1979-05-27T07:32:00Z'
+  key2: '1979-05-27T00:32:00-07:00'
+  key3: '1979-05-27T00:32:00.999999-07:00'
+float:
+  both:
+    key: 6.626e-34
+  exponent:
+    key1: 5.0e+22
+    key2: 1000000
+    key3: -0.02
+  fractional:
+    key1: 1
+    key2: 3.1415
+    key3: -0.01
+  underscores:
+    key1: 9224617.445991227
+    key2: 1.0e+100
+fruit:
+- name: apple
+  physical:
+    color: red
+    shape: round
+  variety:
+  - name: red delicious
+  - name: granny smith
+- name: banana
+  variety:
+  - name: plantain
+integer:
+  key1: 99
+  key2: 42
+  key3: 0
+  key4: -17
+  underscores:
+    key1: 1000
+    key2: 5349221
+    key3: 12345
+products:
+- name: Hammer
+  sku: 738594937
+- {}
+- color: gray
+  name: Nail
+  sku: 284758393
+string:
+  basic:
+    basic: "I'm a string. \"You can quote me\". Name\tJosé\nLocation\tSF."
+  literal:
+    multiline:
+      lines: |
+        The first newline is
+        trimmed in raw strings.
+           All other whitespace
+           is preserved.
+      regex2: I [dw]on't need \d{2} apples
+    quoted: Tom "Dubs" Preston-Werner
+    regex: "<\\i\\c*\\s*>"
+    winpath: C:\Users\nodejs\templates
+    winpath2: "\\\\ServerX\\admin$\\system32\\"
+  multiline:
+    continued:
+      key1: The quick brown fox jumps over the lazy dog.
+      key2: The quick brown fox jumps over the lazy dog.
+      key3: The quick brown fox jumps over the lazy dog.
+    key1: |-
+      One
+      Two
+    key2: |-
+      One
+      Two
+    key3: |-
+      One
+      Two
+table:
+  inline:
+    name:
+      first: Tom
+      last: Preston-Werner
+    point:
+      x: 1
+      y: 2
+  key: value
+  subtable:
+    key: another value
+x:
+  y:
+    z:
+      w: {}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,176 @@
+package toml
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+type benchmarkDoc struct {
+	Table struct {
+		Key      string
+		Subtable struct {
+			Key string
+		}
+		Inline struct {
+			Name struct {
+				First string
+				Last  string
+			}
+			Point struct {
+				X int64
+				U int64
+			}
+		}
+	}
+	String struct {
+		Basic struct {
+			Basic string
+		}
+		Multiline struct {
+			Key1      string
+			Key2      string
+			Key3      string
+			Continued struct {
+				Key1 string
+				Key2 string
+				Key3 string
+			}
+		}
+		Literal struct {
+			Winpath   string
+			Winpath2  string
+			Quoted    string
+			Regex     string
+			Multiline struct {
+				Regex2 string
+				Lines  string
+			}
+		}
+	}
+	Integer struct {
+		Key1        int64
+		Key2        int64
+		Key3        int64
+		Key4        int64
+		Underscores struct {
+			Key1 int64
+			Key2 int64
+			Key3 int64
+		}
+	}
+	Float struct {
+		Fractional struct {
+			Key1 float64
+			Key2 float64
+			Key3 float64
+		}
+		Exponent struct {
+			Key1 float64
+			Key2 float64
+			Key3 float64
+		}
+		Both struct {
+			Key float64
+		}
+		Underscores struct {
+			Key1 float64
+			Key2 float64
+		}
+	}
+	Boolean struct {
+		True  bool
+		False bool
+	}
+	Datetime struct {
+		Key1 time.Time
+		Key2 time.Time
+		Key3 time.Time
+	}
+	Array struct {
+		Key1 []int64
+		Key2 []string
+		Key3 [][]int64
+		// TODO: Key4
+		Key5 []int64
+		Key6 []int64
+	}
+	Products []struct {
+		Name  string
+		Sku   int64
+		Color string
+	}
+	Fruit []struct {
+		Name     string
+		Physical struct {
+			Color   string
+			Shape   string
+			Variety []struct {
+				Name string
+			}
+		}
+	}
+}
+
+func BenchmarkParseToml(b *testing.B) {
+	fileBytes, err := ioutil.ReadFile("benchmark.toml")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := LoadReader(bytes.NewReader(fileBytes))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalToml(b *testing.B) {
+	bytes, err := ioutil.ReadFile("benchmark.toml")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		target := benchmarkDoc{}
+		err := Unmarshal(bytes, &target)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalJson(b *testing.B) {
+	bytes, err := ioutil.ReadFile("benchmark.json")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		target := benchmarkDoc{}
+		err := json.Unmarshal(bytes, &target)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalYaml(b *testing.B) {
+	bytes, err := ioutil.ReadFile("benchmark.yml")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		target := benchmarkDoc{}
+		err := yaml.Unmarshal(bytes, &target)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	burntsushi "github.com/BurntSushi/toml"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -95,7 +96,7 @@ type benchmarkDoc struct {
 		Key1 []int64
 		Key2 []string
 		Key3 [][]int64
-		// TODO: Key4
+		// TODO: Key4 not supported by go-toml's Unmarshal
 		Key5 []int64
 		Key6 []int64
 	}
@@ -139,6 +140,21 @@ func BenchmarkUnmarshalToml(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		target := benchmarkDoc{}
 		err := Unmarshal(bytes, &target)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkUnmarshalBurntSushiToml(b *testing.B) {
+	bytes, err := ioutil.ReadFile("benchmark.toml")
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		target := benchmarkDoc{}
+		err := burntsushi.Unmarshal(bytes, &target)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/lexer.go
+++ b/lexer.go
@@ -9,12 +9,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/pelletier/go-buffruneio"
 )
 
 var dateRegexp *regexp.Regexp
@@ -24,29 +21,29 @@ type tomlLexStateFn func() tomlLexStateFn
 
 // Define lexer
 type tomlLexer struct {
-	input         *buffruneio.Reader // Textual source
-	buffer        bytes.Buffer       // Runes composing the current token
-	tokens        []token
-	depth         int
-	line          int
-	col           int
-	endbufferLine int
-	endbufferCol  int
+	inputIdx          int
+	input             []rune // Textual source
+	currentTokenStart int
+	currentTokenStop  int
+	tokens            []token
+	depth             int
+	line              int
+	col               int
+	endbufferLine     int
+	endbufferCol      int
 }
 
 // Basic read operations on input
 
 func (l *tomlLexer) read() rune {
-	r, _, err := l.input.ReadRune()
-	if err != nil {
-		panic(err)
-	}
+	r := l.peek()
 	if r == '\n' {
 		l.endbufferLine++
 		l.endbufferCol = 1
 	} else {
 		l.endbufferCol++
 	}
+	l.inputIdx++
 	return r
 }
 
@@ -54,13 +51,13 @@ func (l *tomlLexer) next() rune {
 	r := l.read()
 
 	if r != eof {
-		l.buffer.WriteRune(r)
+		l.currentTokenStop++
 	}
 	return r
 }
 
 func (l *tomlLexer) ignore() {
-	l.buffer.Reset()
+	l.currentTokenStart = l.currentTokenStop
 	l.line = l.endbufferLine
 	l.col = l.endbufferCol
 }
@@ -86,30 +83,27 @@ func (l *tomlLexer) emitWithValue(t tokenType, value string) {
 }
 
 func (l *tomlLexer) emit(t tokenType) {
-	l.emitWithValue(t, l.buffer.String())
+	l.emitWithValue(t, string(l.input[l.currentTokenStart:l.currentTokenStop]))
 }
 
 func (l *tomlLexer) peek() rune {
-	r, _, err := l.input.ReadRune()
-	if err != nil {
-		panic(err)
+	if l.inputIdx >= len(l.input) {
+		return eof
 	}
-	l.input.UnreadRune()
-	return r
+	return l.input[l.inputIdx]
+}
+
+func (l *tomlLexer) peekString(size int) string {
+	maxIdx := len(l.input)
+	upperIdx := l.inputIdx + size // FIXME: potential overflow
+	if upperIdx > maxIdx {
+		upperIdx = maxIdx
+	}
+	return string(l.input[l.inputIdx:upperIdx])
 }
 
 func (l *tomlLexer) follow(next string) bool {
-	for _, expectedRune := range next {
-		r, _, err := l.input.ReadRune()
-		defer l.input.UnreadRune()
-		if err != nil {
-			panic(err)
-		}
-		if expectedRune != r {
-			return false
-		}
-	}
-	return true
+	return next == l.peekString(len(next))
 }
 
 // Error management
@@ -220,7 +214,7 @@ func (l *tomlLexer) lexRvalue() tomlLexStateFn {
 			break
 		}
 
-		possibleDate := string(l.input.PeekRunes(35))
+		possibleDate := l.peekString(35)
 		dateMatch := dateRegexp.FindString(possibleDate)
 		if dateMatch != "" {
 			l.fastForward(len(dateMatch))
@@ -537,7 +531,7 @@ func (l *tomlLexer) lexInsideTableArrayKey() tomlLexStateFn {
 	for r := l.peek(); r != eof; r = l.peek() {
 		switch r {
 		case ']':
-			if l.buffer.Len() > 0 {
+			if l.currentTokenStop > l.currentTokenStart {
 				l.emit(tokenKeyGroupArray)
 			}
 			l.next()
@@ -560,7 +554,7 @@ func (l *tomlLexer) lexInsideTableKey() tomlLexStateFn {
 	for r := l.peek(); r != eof; r = l.peek() {
 		switch r {
 		case ']':
-			if l.buffer.Len() > 0 {
+			if l.currentTokenStop > l.currentTokenStart {
 				l.emit(tokenKeyGroup)
 			}
 			l.next()
@@ -642,10 +636,10 @@ func init() {
 }
 
 // Entry point
-func lexToml(input io.Reader) []token {
-	bufferedInput := buffruneio.NewReader(input)
+func lexToml(inputBytes []byte) []token {
+	runes := bytes.Runes(inputBytes)
 	l := &tomlLexer{
-		input:         bufferedInput,
+		input:         runes,
 		tokens:        make([]token, 0, 256),
 		line:          1,
 		col:           1,

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -1,14 +1,12 @@
 package toml
 
 import (
-	"os"
 	"reflect"
-	"strings"
 	"testing"
 )
 
 func testFlow(t *testing.T, input string, expectedFlow []token) {
-	tokens := lexToml(strings.NewReader(input))
+	tokens := lexToml([]byte(input))
 	if !reflect.DeepEqual(tokens, expectedFlow) {
 		t.Fatal("Different flows. Expected\n", expectedFlow, "\nGot:\n", tokens)
 	}
@@ -745,13 +743,8 @@ pluralizeListTitles = false
 	url = "https://github.com/spf13/hugo/releases"
 	weight = -200
 `
-	rd := strings.NewReader(sample)
-
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		rd.Seek(0, os.SEEK_SET)
-		ch := lexToml(rd)
-		for _ = range ch {
-		}
+		lexToml([]byte(sample))
 	}
 }

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -2,37 +2,15 @@ package toml
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
 
 func testFlow(t *testing.T, input string, expectedFlow []token) {
-	ch := lexToml(strings.NewReader(input))
-	for _, expected := range expectedFlow {
-		token := <-ch
-		if token != expected {
-			t.Log("While testing: ", input)
-			t.Log("compared (got)", token, "to (expected)", expected)
-			t.Log("\tvalue:", token.val, "<->", expected.val)
-			t.Log("\tvalue as bytes:", []byte(token.val), "<->", []byte(expected.val))
-			t.Log("\ttype:", token.typ.String(), "<->", expected.typ.String())
-			t.Log("\tline:", token.Line, "<->", expected.Line)
-			t.Log("\tcolumn:", token.Col, "<->", expected.Col)
-			t.Log("compared", token, "to", expected)
-			t.FailNow()
-		}
-	}
-
-	tok, ok := <-ch
-	if ok {
-		t.Log("channel is not closed!")
-		t.Log(len(ch)+1, "tokens remaining:")
-
-		t.Log("token ->", tok)
-		for token := range ch {
-			t.Log("token ->", token)
-		}
-		t.FailNow()
+	tokens := lexToml(strings.NewReader(input))
+	if !reflect.DeepEqual(tokens, expectedFlow) {
+		t.Fatal("Different flows. Expected\n", expectedFlow, "\nGot:\n", tokens)
 	}
 }
 

--- a/marshal.go
+++ b/marshal.go
@@ -268,15 +268,20 @@ func valueFromTree(mtype reflect.Type, tval *Tree) (reflect.Value, error) {
 			mtypef := mtype.Field(i)
 			opts := tomlOptions(mtypef)
 			if opts.include {
-				key := opts.name
-				exists := tval.Has(key)
-				if exists {
+				baseKey := opts.name
+				keysToTry := []string{baseKey, strings.ToLower(baseKey), strings.ToTitle(baseKey)}
+				for _, key := range keysToTry {
+					exists := tval.Has(key)
+					if !exists {
+						continue
+					}
 					val := tval.Get(key)
 					mvalf, err := valueFromToml(mtypef.Type, val)
 					if err != nil {
 						return mval, formatError(err, tval.GetPosition(key))
 					}
 					mval.Field(i).Set(mvalf)
+					break
 				}
 			}
 		}

--- a/parser.go
+++ b/parser.go
@@ -13,9 +13,9 @@ import (
 )
 
 type tomlParser struct {
-	flow          chan token
+	flowIdx       int
+	flow          []token
 	tree          *Tree
-	tokensBuffer  []token
 	currentTable  []string
 	seenTableKeys []string
 }
@@ -34,16 +34,10 @@ func (p *tomlParser) run() {
 }
 
 func (p *tomlParser) peek() *token {
-	if len(p.tokensBuffer) != 0 {
-		return &(p.tokensBuffer[0])
-	}
-
-	tok, ok := <-p.flow
-	if !ok {
+	if p.flowIdx >= len(p.flow) {
 		return nil
 	}
-	p.tokensBuffer = append(p.tokensBuffer, tok)
-	return &tok
+	return &p.flow[p.flowIdx]
 }
 
 func (p *tomlParser) assume(typ tokenType) {
@@ -57,16 +51,12 @@ func (p *tomlParser) assume(typ tokenType) {
 }
 
 func (p *tomlParser) getToken() *token {
-	if len(p.tokensBuffer) != 0 {
-		tok := p.tokensBuffer[0]
-		p.tokensBuffer = p.tokensBuffer[1:]
-		return &tok
-	}
-	tok, ok := <-p.flow
-	if !ok {
+	tok := p.peek()
+	if tok == nil {
 		return nil
 	}
-	return &tok
+	p.flowIdx++
+	return tok
 }
 
 func (p *tomlParser) parseStart() tomlParserStateFn {
@@ -374,13 +364,13 @@ func (p *tomlParser) parseArray() interface{} {
 	return array
 }
 
-func parseToml(flow chan token) *Tree {
+func parseToml(flow []token) *Tree {
 	result := newTree()
 	result.position = Position{1, 1}
 	parser := &tomlParser{
+		flowIdx:       0,
 		flow:          flow,
 		tree:          result,
-		tokensBuffer:  make([]token, 0),
 		currentTable:  make([]string, 0),
 		seenTableKeys: make([]string, 0),
 	}

--- a/test.sh
+++ b/test.sh
@@ -28,6 +28,7 @@ go vet ./...
 go get github.com/pelletier/go-buffruneio
 go get github.com/davecgh/go-spew/spew
 go get gopkg.in/yaml.v2
+go get github.com/BurntSushi/toml
 
 # get code for BurntSushi TOML validation
 # pinning all to 'HEAD' for version 0.3.x work (TODO: pin to commit hash when tests stabilize)

--- a/test.sh
+++ b/test.sh
@@ -27,6 +27,7 @@ go vet ./...
 
 go get github.com/pelletier/go-buffruneio
 go get github.com/davecgh/go-spew/spew
+go get gopkg.in/yaml.v2
 
 # get code for BurntSushi TOML validation
 # pinning all to 'HEAD' for version 0.3.x work (TODO: pin to commit hash when tests stabilize)

--- a/toml.go
+++ b/toml.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -251,8 +252,8 @@ func (t *Tree) createSubTree(keys []string, pos Position) error {
 	return nil
 }
 
-// LoadReader creates a Tree from any io.Reader.
-func LoadReader(reader io.Reader) (tree *Tree, err error) {
+// LoadBytes creates a Tree from a []byte.
+func LoadBytes(b []byte) (tree *Tree, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if _, ok := r.(runtime.Error); ok {
@@ -261,13 +262,23 @@ func LoadReader(reader io.Reader) (tree *Tree, err error) {
 			err = errors.New(r.(string))
 		}
 	}()
-	tree = parseToml(lexToml(reader))
+	tree = parseToml(lexToml(b))
+	return
+}
+
+// LoadReader creates a Tree from any io.Reader.
+func LoadReader(reader io.Reader) (tree *Tree, err error) {
+	inputBytes, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return
+	}
+	tree, err = LoadBytes(inputBytes)
 	return
 }
 
 // Load creates a Tree from a string.
 func Load(content string) (tree *Tree, err error) {
-	return LoadReader(strings.NewReader(content))
+	return LoadBytes([]byte(content))
 }
 
 // LoadFile creates a Tree from a file.


### PR DESCRIPTION
Just for the kicks I tried out to:

1. get rid of the `chan` communication between parser and lexer
2. and lex on a `[]byte` instead of a `io.Reader`

Results are rather impressive:

```
name                       old time/op    new time/op    delta
ParseToml-8                  1.24ms ± 0%    0.30ms ± 0%  -76.09%
UnmarshalToml-8              1.36ms ± 0%    0.40ms ± 0%  -70.99%
UnmarshalBurntSushiToml-8     398µs ± 0%     374µs ± 0%   -5.89%
UnmarshalJson-8              63.2µs ± 0%    61.3µs ± 0%   -2.98%
UnmarshalYaml-8               179µs ± 0%     187µs ± 0%   +4.41%

name                       old alloc/op   new alloc/op   delta
ParseToml-8                   429kB ± 0%     135kB ± 0%  -68.53%
UnmarshalToml-8               451kB ± 0%     157kB ± 0%  -65.23%
UnmarshalBurntSushiToml-8    82.9kB ± 0%    82.9kB ± 0%   -0.00%
UnmarshalJson-8              3.54kB ± 0%    3.54kB ± 0%    0.00%
UnmarshalYaml-8              44.9kB ± 0%    44.9kB ± 0%    0.00%

name                       old allocs/op  new allocs/op  delta
ParseToml-8                   14.1k ± 0%      3.2k ± 0%  -77.20%
UnmarshalToml-8               15.1k ± 0%      4.2k ± 0%  -72.00%
UnmarshalBurntSushiToml-8     1.76k ± 0%     1.76k ± 0%    0.00%
UnmarshalJson-8                 101 ± 0%       101 ± 0%    0.00%
UnmarshalYaml-8               1.06k ± 0%     1.06k ± 0%    0.00%
```

That was a quick hack so there are probably other stuff to try out.

@bep @moorereason @kevinburke 

Ref https://github.com/pelletier/go-toml/issues/167