### PR TITLE
String concat allocation reduction

### DIFF
--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -118,8 +118,7 @@ func (t *Tree) writeTo(w io.Writer, indent, keyspace string, bytesCount int64) (
 			return bytesCount, err
 		}
 
-		kvRepr := indent + k + " = " + repr + "\n"
-		writtenBytesCount, err := w.Write([]byte(kvRepr))
+		writtenBytesCount, err := writeStrings(w, indent, k, " = ", repr, "\n")
 		bytesCount += int64(writtenBytesCount)
 		if err != nil {
 			return bytesCount, err
@@ -137,8 +136,7 @@ func (t *Tree) writeTo(w io.Writer, indent, keyspace string, bytesCount int64) (
 		switch node := v.(type) {
 		// node has to be of those two types given how keys are sorted above
 		case *Tree:
-			tableName := "\n" + indent + "[" + combinedKey + "]\n"
-			writtenBytesCount, err := w.Write([]byte(tableName))
+			writtenBytesCount, err := writeStrings(w, "\n", indent, "[", combinedKey, "]\n")
 			bytesCount += int64(writtenBytesCount)
 			if err != nil {
 				return bytesCount, err
@@ -149,8 +147,7 @@ func (t *Tree) writeTo(w io.Writer, indent, keyspace string, bytesCount int64) (
 			}
 		case []*Tree:
 			for _, subTree := range node {
-				tableArrayName := "\n" + indent + "[[" + combinedKey + "]]\n"
-				writtenBytesCount, err := w.Write([]byte(tableArrayName))
+				writtenBytesCount, err := writeStrings(w, "\n", indent, "[[", combinedKey, "]]\n")
 				bytesCount += int64(writtenBytesCount)
 				if err != nil {
 					return bytesCount, err
@@ -165,6 +162,18 @@ func (t *Tree) writeTo(w io.Writer, indent, keyspace string, bytesCount int64) (
 	}
 
 	return bytesCount, nil
+}
+
+func writeStrings(w io.Writer, s ...string) (int, error) {
+	var n int
+	for i := range s {
+		b, err := io.WriteString(w, s[i])
+		n += b
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
 }
 
 // WriteTo encode the Tree as Toml and writes it to the writer w.


### PR DESCRIPTION
This proposed change offers a ~19% reduction in `TreeToTomlString` allocations by tweaking some string concatenation and writes, and also fixes some exposed problems with the test Writer, `failingWriter`.

```
=== master (/tmp/go-toml-benchmark-cAnF2E/ref)
BenchmarkParseToml-4                 	    1000	   1244751 ns/op	  429140 B/op	   14057 allocs/op
BenchmarkUnmarshalToml-4             	    1000	   1441443 ns/op	  450912 B/op	   15072 allocs/op
BenchmarkUnmarshalBurntSushiToml-4   	    3000	    420625 ns/op	   83486 B/op	    1774 allocs/op
BenchmarkUnmarshalJson-4             	   20000	     66958 ns/op	    3824 B/op	     107 allocs/op
BenchmarkUnmarshalYaml-4             	    5000	    207442 ns/op	   45160 B/op	    1064 allocs/op
BenchmarkLexer-4                     	   10000	    179860 ns/op	   50832 B/op	    1839 allocs/op
BenchmarkTreeToTomlString-4          	  200000	      8640 ns/op	    4960 B/op	      78 allocs/op
PASS
ok  	_/tmp/go-toml-benchmark-cAnF2E/ref	11.966s

=== local
BenchmarkParseToml-4                 	    1000	   1254238 ns/op	  429131 B/op	   14057 allocs/op
BenchmarkUnmarshalToml-4             	    1000	   1403903 ns/op	  450921 B/op	   15072 allocs/op
BenchmarkUnmarshalBurntSushiToml-4   	    3000	    426985 ns/op	   83487 B/op	    1774 allocs/op
BenchmarkUnmarshalJson-4             	   20000	     67378 ns/op	    3824 B/op	     107 allocs/op
BenchmarkUnmarshalYaml-4             	    5000	    208335 ns/op	   45160 B/op	    1064 allocs/op
BenchmarkLexer-4                     	   10000	    176975 ns/op	   50832 B/op	    1839 allocs/op
BenchmarkTreeToTomlString-4          	  200000	      8852 ns/op	    3984 B/op	      63 allocs/op
PASS
ok  	github.com/pelletier/go-toml	12.898s

=== diff
name                       old time/op    new time/op    delta
ParseToml-4                  1.24ms ± 0%    1.25ms ± 0%   +0.76%
UnmarshalToml-4              1.44ms ± 0%    1.40ms ± 0%   -2.60%
UnmarshalBurntSushiToml-4     421µs ± 0%     427µs ± 0%   +1.51%
UnmarshalJson-4              67.0µs ± 0%    67.4µs ± 0%   +0.63%
UnmarshalYaml-4               207µs ± 0%     208µs ± 0%   +0.43%
Lexer-4                       180µs ± 0%     177µs ± 0%   -1.60%
TreeToTomlString-4           8.64µs ± 0%    8.85µs ± 0%   +2.45%

name                       old alloc/op   new alloc/op   delta
ParseToml-4                   429kB ± 0%     429kB ± 0%   -0.00%
UnmarshalToml-4               451kB ± 0%     451kB ± 0%   +0.00%
UnmarshalBurntSushiToml-4    83.5kB ± 0%    83.5kB ± 0%   +0.00%
UnmarshalJson-4              3.82kB ± 0%    3.82kB ± 0%    0.00%
UnmarshalYaml-4              45.2kB ± 0%    45.2kB ± 0%    0.00%
Lexer-4                      50.8kB ± 0%    50.8kB ± 0%    0.00%
TreeToTomlString-4           4.96kB ± 0%    3.98kB ± 0%  -19.68%

name                       old allocs/op  new allocs/op  delta
ParseToml-4                   14.1k ± 0%     14.1k ± 0%    0.00%
UnmarshalToml-4               15.1k ± 0%     15.1k ± 0%    0.00%
UnmarshalBurntSushiToml-4     1.77k ± 0%     1.77k ± 0%    0.00%
UnmarshalJson-4                 107 ± 0%       107 ± 0%    0.00%
UnmarshalYaml-4               1.06k ± 0%     1.06k ± 0%    0.00%
Lexer-4                       1.84k ± 0%     1.84k ± 0%    0.00%
TreeToTomlString-4             78.0 ± 0%      63.0 ± 0%  -19.23%
```

Related #167