### PR TITLE
Marshal map[string]interface{} with quoted keys

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -167,7 +167,11 @@ func valueToTree(mtype reflect.Type, mval reflect.Value) (*Tree, error) {
 			if err != nil {
 				return nil, err
 			}
-			tval.Set(key.String(), "", false, val)
+			keyStr, err := tomlValueStringRepresentation(key.String())
+			if err != nil {
+				return nil, err
+			}
+			tval.SetPath([]string{keyStr}, "", false, val)
 		}
 	}
 	return tval, nil
@@ -302,7 +306,7 @@ func valueFromTree(mtype reflect.Type, tval *Tree) (reflect.Value, error) {
 	case reflect.Map:
 		mval = reflect.MakeMap(mtype)
 		for _, key := range tval.Keys() {
-			val := tval.Get(key)
+			val := tval.GetPath([]string{key})
 			mvalf, err := valueFromToml(mtype.Elem(), val)
 			if err != nil {
 				return mval, formatError(err, tval.GetPosition(key))

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -479,10 +479,10 @@ ListPtr = ["Hello"]
 Str = "Hello"
 
 [Map]
-  response = "Goodbye"
+  "response" = "Goodbye"
 
 [MapPtr]
-  alternate = "Hello"
+  "alternate" = "Hello"
 `)
 
 func TestPointerMarshal(t *testing.T) {
@@ -549,6 +549,60 @@ func TestNestedUnmarshal(t *testing.T) {
 	}
 	if !reflect.DeepEqual(result, expected) {
 		t.Errorf("Bad nested unmarshal: expected %v, got %v", expected, result)
+	}
+}
+
+type mapsTestStruct struct {
+	Simple map[string]string
+	Paths  map[string]string
+	Other  map[string]float64
+}
+
+var mapsTestData = mapsTestStruct{
+	Simple: map[string]string{
+		"one plus one": "two",
+		"next":         "three",
+	},
+	Paths: map[string]string{
+		"/this/is/a/path": "/this/is/also/a/path",
+		"/heloo.txt":      "/tmp/lololo.txt",
+	},
+	Other: map[string]float64{
+		"testing": 3.9999,
+	},
+}
+var mapsTestToml = []byte(`
+[Other]
+  "testing" = 3.9999
+
+[Paths]
+  "/heloo.txt" = "/tmp/lololo.txt"
+  "/this/is/a/path" = "/this/is/also/a/path"
+
+[Simple]
+  "next" = "three"
+  "one plus one" = "two"
+`)
+
+func TestMapsMarshal(t *testing.T) {
+	result, err := Marshal(mapsTestData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := mapsTestToml
+	if !bytes.Equal(result, expected) {
+		t.Errorf("Bad maps marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	}
+}
+func TestMapsUnmarshal(t *testing.T) {
+	result := mapsTestStruct{}
+	err := Unmarshal(mapsTestToml, &result)
+	expected := mapsTestData
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Bad maps unmarshal: expected %v, got %v", expected, result)
 	}
 }
 

--- a/marshal_test.toml
+++ b/marshal_test.toml
@@ -17,8 +17,8 @@ title = "TOML Marshal Testing"
   uints = [5002,5003]
 
 [basic_map]
-  one = "one"
-  two = "two"
+  "one" = "one"
+  "two" = "two"
 
 [subdoc]
 


### PR DESCRIPTION
The TOML spec supports using UTF-8 strings as keys.
https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md#table

This PR changes the Marshal function to output quoted strings if it
encounters a map[string]interface{}

Usage example:
Currently the following example can not be unmarshaled -> manipulated -> marshaled
```go
type Config struct {
  Pathmap map[string]string
}
```
```toml
[pathmap]
  "/path/to/somewhere" = "/path/to/somewhere/else"
```