### PR TITLE
Support single quoted keys (#61)

### DIFF
--- a/keysparsing_test.go
+++ b/keysparsing_test.go
@@ -47,6 +47,12 @@ func TestBaseKeyPound(t *testing.T) {
 func TestQuotedKeys(t *testing.T) {
 	testResult(t, `hello."foo".bar`, []string{"hello", "foo", "bar"})
 	testResult(t, `"hello!"`, []string{"hello!"})
+	testResult(t, `"hello\tworld"`, []string{"hello\tworld"})
+	testResult(t, `"\U0001F914"`, []string{"\U0001F914"})
+
+	testResult(t, `hello.'foo'.bar`, []string{"hello", "foo", "bar"})
+	testResult(t, `'hello!'`, []string{"hello!"})
+	testResult(t, `'hello\tworld'`, []string{`hello\tworld`})
 }
 
 func TestEmptyKey(t *testing.T) {


### PR DESCRIPTION
This change supports single quoted keys _as like_ quoted keys. However both don't support escape sequences correctly.

According to the spec;

> Quoted keys follow the exact same rules as either basic strings or literal strings and allow you to use a much broader set of key names.

Should we fix both of them in this PR?