### PR TITLE
Fix typos

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -17,7 +17,7 @@
 // JSONPath-like queries
 //
 // The package github.com/pelletier/go-toml/query implements a system
-// similar to JSONPath to quickly retrive elements of a TOML document using a
+// similar to JSONPath to quickly retrieve elements of a TOML document using a
 // single expression. See the package documentation for more information.
 //
 package toml

--- a/marshal.go
+++ b/marshal.go
@@ -105,7 +105,7 @@ The following struct annotations are supported:
   commented:"true"  Emits the value as commented.
 
 Note that pointers are automatically assigned the "omitempty" option, as TOML
-explicity does not handle null values (saying instead the label should be
+explicitly does not handle null values (saying instead the label should be
 dropped).
 
 Tree structural types and corresponding marshal types:

--- a/query/doc.go
+++ b/query/doc.go
@@ -139,7 +139,7 @@
 // Compiled Queries
 //
 // Queries may be executed directly on a Tree object, or compiled ahead
-// of time and executed discretely.  The former is more convienent, but has the
+// of time and executed discretely.  The former is more convenient, but has the
 // penalty of having to recompile the query expression each time.
 //
 //   // basic query

--- a/tomltree_write_test.go
+++ b/tomltree_write_test.go
@@ -30,7 +30,7 @@ func (f *failingWriter) Write(p []byte) (n int, err error) {
 
 	f.buffer.Write(p[:toWrite])
 	f.written = f.failAt
-	return toWrite, fmt.Errorf("failingWriter failed after writting %d bytes", f.written)
+	return toWrite, fmt.Errorf("failingWriter failed after writing %d bytes", f.written)
 }
 
 func assertErrorString(t *testing.T, expected string, err error) {
@@ -176,7 +176,7 @@ func TestTreeWriteToFailingWriterInSimpleValue(t *testing.T) {
 	toml, _ := Load(`a = 2`)
 	writer := failingWriter{failAt: 0, written: 0}
 	_, err := toml.WriteTo(&writer)
-	assertErrorString(t, "failingWriter failed after writting 0 bytes", err)
+	assertErrorString(t, "failingWriter failed after writing 0 bytes", err)
 }
 
 func TestTreeWriteToFailingWriterInTable(t *testing.T) {
@@ -185,11 +185,11 @@ func TestTreeWriteToFailingWriterInTable(t *testing.T) {
 a = 2`)
 	writer := failingWriter{failAt: 2, written: 0}
 	_, err := toml.WriteTo(&writer)
-	assertErrorString(t, "failingWriter failed after writting 2 bytes", err)
+	assertErrorString(t, "failingWriter failed after writing 2 bytes", err)
 
 	writer = failingWriter{failAt: 13, written: 0}
 	_, err = toml.WriteTo(&writer)
-	assertErrorString(t, "failingWriter failed after writting 13 bytes", err)
+	assertErrorString(t, "failingWriter failed after writing 13 bytes", err)
 }
 
 func TestTreeWriteToFailingWriterInArray(t *testing.T) {
@@ -198,11 +198,11 @@ func TestTreeWriteToFailingWriterInArray(t *testing.T) {
 a = 2`)
 	writer := failingWriter{failAt: 2, written: 0}
 	_, err := toml.WriteTo(&writer)
-	assertErrorString(t, "failingWriter failed after writting 2 bytes", err)
+	assertErrorString(t, "failingWriter failed after writing 2 bytes", err)
 
 	writer = failingWriter{failAt: 15, written: 0}
 	_, err = toml.WriteTo(&writer)
-	assertErrorString(t, "failingWriter failed after writting 15 bytes", err)
+	assertErrorString(t, "failingWriter failed after writing 15 bytes", err)
 }
 
 func TestTreeWriteToMapExampleFile(t *testing.T) {


### PR DESCRIPTION
Most of them are caught by Go Report Card.
https://goreportcard.com/report/github.com/pelletier/go-toml