### PR TITLE
Actually show the error message from an Error token

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -350,7 +350,7 @@ Loop:
 			}
 			p.getToken()
 		default:
-			p.raiseError(follow, "unexpected token type in inline table: %s", follow.typ.String())
+			p.raiseError(follow, "unexpected token type in inline table: %s", follow.String())
 		}
 		previous = follow
 	}


### PR DESCRIPTION
Before the error output is like this:

```
(37, 13): unexpected token type in inline table: Error
```

With this change it's like this:

```
(37, 13): unexpected token type in inline table: keys cannot contain } character
```