### PR TITLE
Fix false positive when running test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # fail out of the script if anything here fails
 set -e
+set -o pipefail
 
 # set the path to the present working directory
 export GOPATH=`pwd`


### PR DESCRIPTION
Patch #193 introduced a regression in the toml-tests examples, but it was
never caught because test.sh was exiting with a zero status code, even
though the tests failed. This is because of the `|tee` operation when
invoking toml-test, without setting the pipefail option, reporting the
status code of `tee` instead of `toml-test`.