### PR TITLE
Fix backward incompatibility for Set* methods

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -230,7 +230,7 @@ func (e *Encoder) valueToTree(mtype reflect.Type, mval reflect.Value) (*Tree, er
 				if err != nil {
 					return nil, err
 				}
-				tval.Set(opts.name, opts.comment, opts.commented, val)
+				tval.SetWithComment(opts.name, opts.comment, opts.commented, val)
 			}
 		}
 	case reflect.Map:
@@ -245,9 +245,9 @@ func (e *Encoder) valueToTree(mtype reflect.Type, mval reflect.Value) (*Tree, er
 				if err != nil {
 					return nil, err
 				}
-				tval.SetPath([]string{keyStr}, "", false, val)
+				tval.SetPath([]string{keyStr}, val)
 			} else {
-				tval.Set(key.String(), "", false, val)
+				tval.Set(key.String(), val)
 			}
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -111,7 +111,7 @@ func (p *tomlParser) parseGroupArray() tomlParserStateFn {
 	newTree := newTree()
 	newTree.position = startToken.Position
 	array = append(array, newTree)
-	p.tree.SetPath(p.currentTable, "", false, array)
+	p.tree.SetPath(p.currentTable, array)
 
 	// remove all keys that were children of this table array
 	prefix := key.val + "."
@@ -345,7 +345,7 @@ Loop:
 			key := p.getToken()
 			p.assume(tokenEqual)
 			value := p.parseRvalue()
-			tree.Set(key.val, "", false, value)
+			tree.Set(key.val, value)
 		case tokenComma:
 			if previous == nil {
 				p.raiseError(follow, "inline table cannot start with a comma")

--- a/parser_test.go
+++ b/parser_test.go
@@ -47,7 +47,7 @@ func assertTree(t *testing.T, tree *Tree, err error, ref map[string]interface{})
 func TestCreateSubTree(t *testing.T) {
 	tree := newTree()
 	tree.createSubTree([]string{"a", "b", "c"}, Position{})
-	tree.Set("a.b.c", "", false, 42)
+	tree.Set("a.b.c", 42)
 	if tree.Get("a.b.c") != 42 {
 		t.Fail()
 	}

--- a/toml.go
+++ b/toml.go
@@ -178,14 +178,26 @@ func (t *Tree) GetDefault(key string, def interface{}) interface{} {
 // Set an element in the tree.
 // Key is a dot-separated path (e.g. a.b.c).
 // Creates all necessary intermediate trees, if needed.
-func (t *Tree) Set(key string, comment string, commented bool, value interface{}) {
-	t.SetPath(strings.Split(key, "."), comment, commented, value)
+func (t *Tree) Set(key string, value interface{}) {
+	t.SetWithComment(key, "", false, value)
+}
+
+// SetWithComment is the same as Set, but allows you to provide comment
+// information to the key, that will be reused by Marshal().
+func (t *Tree) SetWithComment(key string, comment string, commented bool, value interface{}) {
+	t.SetPathWithComment(strings.Split(key, "."), comment, commented, value)
 }
 
 // SetPath sets an element in the tree.
 // Keys is an array of path elements (e.g. {"a","b","c"}).
 // Creates all necessary intermediate trees, if needed.
-func (t *Tree) SetPath(keys []string, comment string, commented bool, value interface{}) {
+func (t *Tree) SetPath(keys []string, value interface{}) {
+	t.SetPathWithComment(keys, "", false, value)
+}
+
+// SetPathWithComment is the same as SetPath, but allows you to provide comment
+// information to the key, that will be reused by Marshal().
+func (t *Tree) SetPathWithComment(keys []string, comment string, commented bool, value interface{}) {
 	subtree := t
 	for _, intermediateKey := range keys[:len(keys)-1] {
 		nextTree, exists := subtree.values[intermediateKey]


### PR DESCRIPTION
Patch #185 introduced a backward incompatibility by changing the arguments
of the `Set*` methods on `Tree`.

This change restores the arguments to what they previous were, and
introduces `SetWithComment` and `SetPathWithComment` to perform the same
action.