### PR TITLE
Make multi-line arrays always use trailing commas

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -187,7 +187,7 @@ func (e *Encoder) QuoteMapKeys(v bool) *Encoder {
 //   A = [
 //     1,
 //     2,
-//     3
+//     3,
 //   ]
 func (e *Encoder) ArraysWithOneElementPerLine(v bool) *Encoder {
 	e.arraysOneElementPerLine = v

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -775,7 +775,7 @@ func TestMarshalArrayOnePerLine(t *testing.T) {
   B = [
     1,
     2,
-    3
+    3,
   ]
   C = [1]
 `)

--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -91,12 +91,10 @@ func tomlValueStringRepresentation(v interface{}, indent string, arraysOneElemen
 
 			stringBuffer.WriteString("[\n")
 
-			for i, value := range values {
+			for _, value := range values {
 				stringBuffer.WriteString(valueIndent)
 				stringBuffer.WriteString(value)
-				if i != len(values)-1 {
-					stringBuffer.WriteString(`,`)
-				}
+				stringBuffer.WriteString(`,`)
 				stringBuffer.WriteString("\n")
 			}
 


### PR DESCRIPTION
This makes the Encoder option `ArraysWithOneElementPerLine` output arrays with commas after every element.

```
A = [1,2,3]
```

Now becomes:

```
A = [
  1,
  2,
  3,
]
```

Originally proposed here: golang/dep#1595