### PR TITLE
Fix Go 1.10 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: go
 go:
-  - 1.8.5
-  - 1.9.2
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
   - tip
 matrix:
   allow_failures:

--- a/cmd/tomljson/main.go
+++ b/cmd/tomljson/main.go
@@ -17,13 +17,12 @@ import (
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, `tomljson can be used in two ways:
-Writing to STDIN and reading from STDOUT:
-  cat file.toml | tomljson > file.json
-
-Reading from a file name:
-  tomljson file.toml
-`)
+		fmt.Fprintln(os.Stderr, "tomljson can be used in two ways:")
+		fmt.Fprintln(os.Stderr, "Writing to STDIN and reading from STDOUT:")
+		fmt.Fprintln(os.Stderr, "  cat file.toml | tomljson > file.json")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Reading from a file name:")
+		fmt.Fprintln(os.Stderr, "  tomljson file.toml")
 	}
 	flag.Parse()
 	os.Exit(processMain(flag.Args(), os.Stdin, os.Stdout, os.Stderr))

--- a/cmd/tomll/main.go
+++ b/cmd/tomll/main.go
@@ -17,15 +17,14 @@ import (
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, `tomll can be used in two ways:
-Writing to STDIN and reading from STDOUT:
-  cat file.toml | tomll > file.toml
-
-Reading and updating a list of files:
-  tomll a.toml b.toml c.toml
-
-When given a list of files, tomll will modify all files in place without asking.
-`)
+		fmt.Fprintln(os.Stderr, "tomll can be used in two ways:")
+		fmt.Fprintln(os.Stderr, "Writing to STDIN and reading from STDOUT:")
+		fmt.Fprintln(os.Stderr, "  cat file.toml | tomll > file.toml")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Reading and updating a list of files:")
+		fmt.Fprintln(os.Stderr, "  tomll a.toml b.toml c.toml")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "When given a list of files, tomll will modify all files in place without asking.")
 	}
 	flag.Parse()
 	// read from stdin and print to stdout

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -2,12 +2,13 @@ package query
 
 import (
 	"fmt"
-	"github.com/pelletier/go-toml"
 	"io/ioutil"
 	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/pelletier/go-toml"
 )
 
 type queryTestNode struct {
@@ -406,8 +407,7 @@ func TestQueryFilterFn(t *testing.T) {
 
 	assertQueryPositions(t, string(buff),
 		"$..[?(float)]",
-		[]interface{}{
-		// no float values in document
+		[]interface{}{ // no float values in document
 		})
 
 	tv, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")

--- a/test.sh
+++ b/test.sh
@@ -23,9 +23,6 @@ function git_clone() {
 # Remove potential previous runs
 rm -rf src test_program_bin toml-test
 
-# Run go vet
-go vet ./...
-
 go get github.com/pelletier/go-buffruneio
 go get github.com/davecgh/go-spew/spew
 go get gopkg.in/yaml.v2


### PR DESCRIPTION
This PR updates Travis CI to use the latest Go releases and fixes a couple issues introduced by changes in Go 1.10.  See commit messages for more details.