### PR TITLE
Fix the Windows support in file/path not found message.

### DIFF
--- a/cmd/tomljson/main_test.go
+++ b/cmd/tomljson/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"runtime"
 )
 
 func expectBufferEquality(t *testing.T, name string, buffer *bytes.Buffer, expected string) {
@@ -76,7 +77,14 @@ func TestProcessMainReadFromFile(t *testing.T) {
 }
 
 func TestProcessMainReadFromMissingFile(t *testing.T) {
-	expectedError := `open /this/file/does/not/exist: no such file or directory
+	var expectedError string
+	if runtime.GOOS == "windows" {
+		expectedError = `open /this/file/does/not/exist: The system cannot find the path specified.
 `
+	} else {
+		expectedError = `open /this/file/does/not/exist: no such file or directory
+`
+	}
+
 	expectProcessMainResults(t, ``, []string{"/this/file/does/not/exist"}, -1, ``, expectedError)
 }


### PR DESCRIPTION
The original path not found message is only for Linux: ``open /this/file/does/not/exist: no such file or directory``. But on Windows the message is: ``open /this/file/does/not/exist: The system cannot find the path specified.`` So the test will fail on Windows.

https://github.com/pelletier/go-toml/blob/31055c2ff0bb0c7f9095aec0d220aed21108121e/cmd/tomljson/main_test.go#L78-L82