### PR TITLE
fix inlineTable parse when key is integer or string

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -338,7 +338,7 @@ Loop:
 		case tokenRightCurlyBrace:
 			p.getToken()
 			break Loop
-		case tokenKey:
+		case tokenKey,tokenInteger,tokenString:
 			if !tokenIsComma(previous) && previous != nil {
 				p.raiseError(follow, "comma expected between fields in inline table")
 			}

--- a/parser.go
+++ b/parser.go
@@ -338,7 +338,7 @@ Loop:
 		case tokenRightCurlyBrace:
 			p.getToken()
 			break Loop
-		case tokenKey,tokenInteger,tokenString:
+		case tokenKey, tokenInteger, tokenString:
 			if !tokenIsComma(previous) && previous != nil {
 				p.raiseError(follow, "comma expected between fields in inline table")
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -897,3 +897,14 @@ func TestInvalidFloatParsing(t *testing.T) {
 		t.Error("Bad error message:", err.Error())
 	}
 }
+
+func TestMapKeyIsNum(t *testing.T) {
+	_, err := Load("table={2018=1,2019=2}")
+	if err != nil {
+		t.Error("should be passed")
+	}
+	_, err = Load(`table={"2018"=1,"2019"=2}`)
+	if err != nil {
+		t.Error("should be passed")
+	}
+}


### PR DESCRIPTION
#224 

Explanation of what this pull request does.

i test 

```
table =  {2018=1,2019=2}
table = {"2018"=1,"2019"=1}
```

could parse successfully to map[string]int