### PR TITLE
check for golang 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.8.x
   - 1.9.x
   - 1.10.x
+  - 1.11.x
   - tip
 matrix:
   allow_failures:


### PR DESCRIPTION
ensure compatibility for golang 1.11

golang 1.11 has been released recently. Add it to travis to ensure future compatibility as well. 


