### PR TITLE
Feature/255 keep fields ordered marshal struct

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -64,7 +64,7 @@ const (
 var timeType = reflect.TypeOf(time.Time{})
 var marshalerType = reflect.TypeOf(new(Marshaler)).Elem()
 
-// Check if the given marshall type maps to a Tree primitive
+// Check if the given marshal type maps to a Tree primitive
 func isPrimitive(mtype reflect.Type) bool {
 	switch mtype.Kind() {
 	case reflect.Ptr:
@@ -86,7 +86,7 @@ func isPrimitive(mtype reflect.Type) bool {
 	}
 }
 
-// Check if the given marshall type maps to a Tree slice
+// Check if the given marshal type maps to a Tree slice
 func isTreeSlice(mtype reflect.Type) bool {
 	switch mtype.Kind() {
 	case reflect.Slice:
@@ -96,7 +96,7 @@ func isTreeSlice(mtype reflect.Type) bool {
 	}
 }
 
-// Check if the given marshall type maps to a non-Tree slice
+// Check if the given marshal type maps to a non-Tree slice
 func isOtherSlice(mtype reflect.Type) bool {
 	switch mtype.Kind() {
 	case reflect.Ptr:
@@ -108,7 +108,7 @@ func isOtherSlice(mtype reflect.Type) bool {
 	}
 }
 
-// Check if the given marshall type maps to a Tree
+// Check if the given marshal type maps to a Tree
 func isTree(mtype reflect.Type) bool {
 	switch mtype.Kind() {
 	case reflect.Map:
@@ -168,14 +168,7 @@ Tree primitive types and corresponding marshal types:
   time.Time  time.Time{}, pointers to same
 */
 func Marshal(v interface{}) ([]byte, error) {
-	return MarshalOrdered(v, OrderAlphabetical)
-}
-
-// MarshalOrdered is same as Marshal with enforced order.
-func MarshalOrdered(v interface{}, ord marshalOrder) ([]byte, error) {
-	ne := NewEncoder(nil)
-	ne.order = ord
-	return ne.marshal(v)
+	return NewEncoder(nil).marshal(v)
 }
 
 // Encoder writes TOML values to an output stream.
@@ -239,6 +232,12 @@ func (e *Encoder) QuoteMapKeys(v bool) *Encoder {
 //   ]
 func (e *Encoder) ArraysWithOneElementPerLine(v bool) *Encoder {
 	e.arraysOneElementPerLine = v
+	return e
+}
+
+// SetOrder allows changing default tag "toml"
+func (e *Encoder) SetOrder(ord marshalOrder) *Encoder {
+	e.order = ord
 	return e
 }
 

--- a/marshal.go
+++ b/marshal.go
@@ -56,8 +56,12 @@ var annotationDefault = annotation{
 
 type marshalOrder int
 
+// Orders the Encoder can write the fields to the output stream.
 const (
+	// Sort fields alphabetically.
 	OrderAlphabetical marshalOrder = iota + 1
+	// Preserve the order the fields are encountered. For example, the order of fields in
+	// a struct.
 	OrderPreserve
 )
 
@@ -166,6 +170,8 @@ Tree primitive types and corresponding marshal types:
   string     string, pointers to same
   bool       bool, pointers to same
   time.Time  time.Time{}, pointers to same
+
+For additional flexibility, use the Encoder API.
 */
 func Marshal(v interface{}) ([]byte, error) {
 	return NewEncoder(nil).marshal(v)
@@ -235,8 +241,8 @@ func (e *Encoder) ArraysWithOneElementPerLine(v bool) *Encoder {
 	return e
 }
 
-// SetOrder allows changing default tag "toml"
-func (e *Encoder) SetOrder(ord marshalOrder) *Encoder {
+// Order allows to change in which order fields will be written to the output stream.
+func (e *Encoder) Order(ord marshalOrder) *Encoder {
 	e.order = ord
 	return e
 }

--- a/marshal.go
+++ b/marshal.go
@@ -296,7 +296,6 @@ func (e *Encoder) marshal(v interface{}) ([]byte, error) {
 
 // Create next tree with a position based on Encoder.line
 func (e *Encoder) nextTree() *Tree {
-	e.line++
 	return newTreeWithPosition(Position{Line: e.line, Col: 1})
 }
 
@@ -373,6 +372,7 @@ func (e *Encoder) valueToOtherSlice(mtype reflect.Type, mval reflect.Value) (int
 
 // Convert given marshal value to toml value
 func (e *Encoder) valueToToml(mtype reflect.Type, mval reflect.Value) (interface{}, error) {
+	e.line++
 	if mtype.Kind() == reflect.Ptr {
 		return e.valueToToml(mtype.Elem(), mval.Elem())
 	}

--- a/marshal_OrderPreserve_test.toml
+++ b/marshal_OrderPreserve_test.toml
@@ -1,0 +1,38 @@
+title = "TOML Marshal Testing"
+
+[basic_lists]
+  floats = [12.3,45.6,78.9]
+  bools = [true,false,true]
+  dates = [1979-05-27T07:32:00Z,1980-05-27T07:32:00Z]
+  ints = [8001,8001,8002]
+  uints = [5002,5003]
+  strings = ["One","Two","Three"]
+
+[[subdocptrs]]
+  name = "Second"
+
+[basic_map]
+  one = "one"
+  two = "two"
+
+[subdoc]
+
+  [subdoc.second]
+    name = "Second"
+
+  [subdoc.first]
+    name = "First"
+
+[basic]
+  uint = 5001
+  bool = true
+  float = 123.4
+  int = 5000
+  string = "Bite me"
+  date = 1979-05-27T07:32:00Z
+
+[[subdoclist]]
+  name = "List.First"
+
+[[subdoclist]]
+  name = "List.Second"

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -67,13 +67,14 @@ func TestBasicMarshal(t *testing.T) {
 }
 
 func TestBasicMarshalOrdered(t *testing.T) {
-	result, err := MarshalOrdered(basicTestData, OrderPreserve)
+	var result bytes.Buffer
+	err := NewEncoder(&result).SetOrder(OrderPreserve).Encode(basicTestData)
 	if err != nil {
 		t.Fatal(err)
 	}
 	expected := basicTestTomlOrdered
-	if !bytes.Equal(result, expected) {
-		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	if !bytes.Equal(result.Bytes(), expected) {
+		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result.Bytes())
 	}
 }
 
@@ -89,13 +90,14 @@ func TestBasicMarshalWithPointer(t *testing.T) {
 }
 
 func TestBasicMarshalOrderedWithPointer(t *testing.T) {
-	result, err := MarshalOrdered(&basicTestData, OrderPreserve)
+	var result bytes.Buffer
+	err := NewEncoder(&result).SetOrder(OrderPreserve).Encode(&basicTestData)
 	if err != nil {
 		t.Fatal(err)
 	}
 	expected := basicTestTomlOrdered
-	if !bytes.Equal(result, expected) {
-		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	if !bytes.Equal(result.Bytes(), expected) {
+		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result.Bytes())
 	}
 }
 
@@ -210,13 +212,14 @@ func TestDocMarshal(t *testing.T) {
 }
 
 func TestDocMarshalOrdered(t *testing.T) {
-	result, err := MarshalOrdered(docData, OrderPreserve)
+	var result bytes.Buffer
+	err := NewEncoder(&result).SetOrder(OrderPreserve).Encode(docData)
 	if err != nil {
 		t.Fatal(err)
 	}
 	expected, _ := ioutil.ReadFile("marshal_OrderPreserve_test.toml")
-	if !bytes.Equal(result, expected) {
-		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+	if !bytes.Equal(result.Bytes(), expected) {
+		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result.Bytes())
 	}
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -163,6 +163,15 @@ var docData = testDoc{
 	Title:       "TOML Marshal Testing",
 	unexported:  0,
 	Unexported2: 0,
+	Basics: testDocBasics{
+		Bool:       true,
+		Date:       time.Date(1979, 5, 27, 7, 32, 0, 0, time.UTC),
+		Float:      123.4,
+		Int:        5000,
+		Uint:       5001,
+		String:     &biteMe,
+		unexported: 0,
+	},
 	BasicLists: testDocBasicLists{
 		Bools: []bool{true, false, true},
 		Dates: []time.Time{
@@ -177,15 +186,6 @@ var docData = testDoc{
 	BasicMap: map[string]string{
 		"one": "one",
 		"two": "two",
-	},
-	Basics: testDocBasics{
-		Bool:       true,
-		Date:       time.Date(1979, 5, 27, 7, 32, 0, 0, time.UTC),
-		Float:      123.4,
-		Int:        5000,
-		Uint:       5001,
-		String:     &biteMe,
-		unexported: 0,
 	},
 	Subdocs: testDocSubs{
 		First:  testSubDoc{"First", 0},
@@ -246,7 +246,7 @@ func TestDocUnmarshal(t *testing.T) {
 	}
 }
 
-/* func TestDocPartialUnmarshal(t *testing.T) {
+func TestDocPartialUnmarshal(t *testing.T) {
 	result := testDocSubs{}
 
 	tree, _ := LoadFile("marshal_test.toml")
@@ -262,7 +262,7 @@ func TestDocUnmarshal(t *testing.T) {
 		t.Errorf("Bad partial unmartial: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expStr, resStr)
 	}
 }
-*/
+
 type tomlTypeCheckTest struct {
 	name string
 	item interface{}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -68,7 +68,7 @@ func TestBasicMarshal(t *testing.T) {
 
 func TestBasicMarshalOrdered(t *testing.T) {
 	var result bytes.Buffer
-	err := NewEncoder(&result).SetOrder(OrderPreserve).Encode(basicTestData)
+	err := NewEncoder(&result).Order(OrderPreserve).Encode(basicTestData)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +91,7 @@ func TestBasicMarshalWithPointer(t *testing.T) {
 
 func TestBasicMarshalOrderedWithPointer(t *testing.T) {
 	var result bytes.Buffer
-	err := NewEncoder(&result).SetOrder(OrderPreserve).Encode(&basicTestData)
+	err := NewEncoder(&result).Order(OrderPreserve).Encode(&basicTestData)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -213,7 +213,7 @@ func TestDocMarshal(t *testing.T) {
 
 func TestDocMarshalOrdered(t *testing.T) {
 	var result bytes.Buffer
-	err := NewEncoder(&result).SetOrder(OrderPreserve).Encode(docData)
+	err := NewEncoder(&result).Order(OrderPreserve).Encode(docData)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -22,7 +22,6 @@ const (
 type sortNode struct {
 	key        string
 	complexity valueComplexity
-	sortOrder  int
 }
 
 // Encodes a string to a TOML-compliant multi-line string value
@@ -193,14 +192,14 @@ func sortByLines(t *Tree) (vals []sortNode) {
 		case *Tree:
 			tv = v.(*Tree)
 			line = tv.position.Line
-			node = sortNode{key: k, sortOrder: line, complexity: valueComplex}
+			node = sortNode{key: k, complexity: valueComplex}
 		case []*Tree:
 			line = getTreeArrayLine(v.([]*Tree))
-			node = sortNode{key: k, sortOrder: line, complexity: valueComplex}
+			node = sortNode{key: k, complexity: valueComplex}
 		default:
 			tom = v.(*tomlValue)
 			line = tom.position.Line
-			node = sortNode{key: k, sortOrder: line, complexity: valueSimple}
+			node = sortNode{key: k, complexity: valueSimple}
 		}
 		lines = append(lines, line)
 		vals = append(vals, node)


### PR DESCRIPTION
Here is a fix for #255

Tracking the order of members as they are marshaled so they can be written in order of the structure.  Default behavior stays the same.

New func MarshalOrdered() allows a marshalOrder to be passed in.  Current options are OrderAlphabetical (default) and OrderPreserve
