### PR TITLE
Add basic Dockerfile for building binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+cmd/tomll/tomll
+cmd/tomljson/tomljson

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 test_program/test_program_bin
 fuzz/
+cmd/tomll/tomll
+cmd/tomljson/tomljson
+cmd/tomltestgen/tomltestgen

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.12-alpine3.9 as builder
+WORKDIR /go/src/github.com/pelletier/go-toml
+COPY . .
+RUN go build && \
+      cd cmd/tomll && \
+      go build && \
+      cd ../tomljson && \
+      go build
+
+FROM alpine:3.9
+COPY --from=builder /go/src/github.com/pelletier/go-toml/cmd/tomll/tomll /usr/bin/tomll
+COPY --from=builder /go/src/github.com/pelletier/go-toml/cmd/tomljson/tomljson /usr/bin/tomljson
+RUN chmod +x /usr/bin/tomll /usr/bin/tomljson


### PR DESCRIPTION
This PR adds in a basic Dockerfile to provide an easy of use the `tomll` and `tomljson` binaries.
You could probably set up an automated build for this in docker hub as well.

Please let me know if this isn't what you had in mind/there's any changes you'd like to see 😃 

For example
```
docker build -t go-toml .
docker run -v $PWD:/workdir go-toml "tomljson" "/workdir/example.toml" | jq
```