### PR TITLE
Allow unmarshaling to top level maps

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -515,7 +515,7 @@ func (d *Decoder) SetTagName(v string) *Decoder {
 func (d *Decoder) unmarshal(v interface{}) error {
 	mtype := reflect.TypeOf(v)
 	if mtype.Kind() != reflect.Ptr {
-		return errors.New("Only a pointer to struct or map can be unmarshaled from TOML")
+		return errors.New("only a pointer to struct or map can be unmarshaled from TOML")
 	}
 
 	elem := mtype.Elem()
@@ -523,7 +523,7 @@ func (d *Decoder) unmarshal(v interface{}) error {
 	switch elem.Kind() {
 	case reflect.Struct, reflect.Map:
 	default:
-		return errors.New("Only a pointer to struct or map can be unmarshaled from TOML")
+		return errors.New("only a pointer to struct or map can be unmarshaled from TOML")
 	}
 
 	sval, err := d.valueFromTree(elem, d.tval)

--- a/marshal.go
+++ b/marshal.go
@@ -514,11 +514,19 @@ func (d *Decoder) SetTagName(v string) *Decoder {
 
 func (d *Decoder) unmarshal(v interface{}) error {
 	mtype := reflect.TypeOf(v)
-	if mtype.Kind() != reflect.Ptr || mtype.Elem().Kind() != reflect.Struct {
-		return errors.New("Only a pointer to struct can be unmarshaled from TOML")
+	if mtype.Kind() != reflect.Ptr {
+		return errors.New("Only a pointer to struct or map can be unmarshaled from TOML")
 	}
 
-	sval, err := d.valueFromTree(mtype.Elem(), d.tval)
+	elem := mtype.Elem()
+
+	switch elem.Kind() {
+	case reflect.Struct, reflect.Map:
+	default:
+		return errors.New("Only a pointer to struct or map can be unmarshaled from TOML")
+	}
+
+	sval, err := d.valueFromTree(elem, d.tval)
 	if err != nil {
 		return err
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1134,7 +1134,6 @@ func TestUnmarshalNonPointer(t *testing.T) {
 	}
 }
 
-
 func TestUnmarshalInvalidPointerKind(t *testing.T) {
 	a := 1
 	err := Unmarshal([]byte{}, &a)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1103,12 +1103,26 @@ func TestUnmarshalCustomTag(t *testing.T) {
 }
 
 func TestUnmarshalMap(t *testing.T) {
-	m := make(map[string]int)
-	m["a"] = 1
+	testToml := []byte(`
+		a = 1
+		b = 2
+		c = 3
+		`)
+	var result map[string]int
+	err := Unmarshal(testToml, &result)
+	if err != nil {
+		t.Errorf("Received unexpected error: %s", err)
+		return
+	}
 
-	err := Unmarshal(basicTestToml, m)
-	if err.Error() != "Only a pointer to struct can be unmarshaled from TOML" {
-		t.Fail()
+	expected := map[string]int{
+		"a": 1,
+		"b": 2,
+		"c": 3,
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Bad unmarshal: expected %v, got %v", expected, result)
 	}
 }
 

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1126,6 +1126,23 @@ func TestUnmarshalMap(t *testing.T) {
 	}
 }
 
+func TestUnmarshalNonPointer(t *testing.T) {
+	a := 1
+	err := Unmarshal([]byte{}, a)
+	if err == nil {
+		t.Fatal("unmarshal should err when given a non pointer")
+	}
+}
+
+
+func TestUnmarshalInvalidPointerKind(t *testing.T) {
+	a := 1
+	err := Unmarshal([]byte{}, &a)
+	if err == nil {
+		t.Fatal("unmarshal should err when given an invalid pointer type")
+	}
+}
+
 func TestMarshalSlice(t *testing.T) {
 	m := make([]int, 1)
 	m[0] = 1


### PR DESCRIPTION
**Issue:** add link to pelletier/go-toml issue here

This is related to #150, but that seems to be for map[string]interface{}, which this PR does not attempt to address.

**Explanation of what this pull request does.**

This allows unmarshaling to a top-level map in addition to a struct.

**More detailed description of the decisions being made and the reasons why (if the patch is non-trivial).**

We were porting code over from the BurntSushi TOML parser and ran into this limitation. The implementation is trivial. I am happy to make changes.
