### PR TITLE
Handle other key types when unmarshaling to map

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -615,7 +615,7 @@ func (d *Decoder) valueFromTree(mtype reflect.Type, tval *Tree) (reflect.Value, 
 			if err != nil {
 				return mval, formatError(err, tval.GetPosition(key))
 			}
-			mval.SetMapIndex(reflect.ValueOf(key), mvalf)
+			mval.SetMapIndex(reflect.ValueOf(key).Convert(mtype.Key()), mvalf)
 		}
 	}
 	return mval, nil

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1126,6 +1126,32 @@ func TestUnmarshalMap(t *testing.T) {
 	}
 }
 
+func TestUnmarshalMapWithTypedKey(t *testing.T) {
+	testToml := []byte(`
+		a = 1
+		b = 2
+		c = 3
+		`)
+
+	type letter string
+	var result map[letter]int
+	err := Unmarshal(testToml, &result)
+	if err != nil {
+		t.Errorf("Received unexpected error: %s", err)
+		return
+	}
+
+	expected := map[letter]int{
+		"a": 1,
+		"b": 2,
+		"c": 3,
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("Bad unmarshal: expected %v, got %v", expected, result)
+	}
+}
+
 func TestUnmarshalNonPointer(t *testing.T) {
 	a := 1
 	err := Unmarshal([]byte{}, a)


### PR DESCRIPTION
Previously, this would fail with:

```
panic: reflect.Value.SetMapIndex: value of type string is not assignable to type toml.letter [recovered]
	panic: reflect.Value.SetMapIndex: value of type string is not assignable to type toml.letter
```