### PR TITLE
Merge struct fields in Unmarshal

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1460,3 +1460,45 @@ func TestUnmarshalNestedAnonymousStructs_Controversial(t *testing.T) {
 		t.Fatal("should error")
 	}
 }
+
+type unexportedFieldPreservationTest struct {
+	Exported   string `toml:"exported"`
+	unexported string
+}
+
+func TestUnmarshalPreservesUnexportedFields(t *testing.T) {
+	toml := `
+	exported = "visible"
+	unexported = "ignored"
+	`
+
+	t.Run("unexported field should not be set from toml", func(t *testing.T) {
+		var actual unexportedFieldPreservationTest
+		err := Unmarshal([]byte(toml), &actual)
+
+		if err != nil {
+			t.Fatal("did not expect an error")
+		}
+
+		expect := unexportedFieldPreservationTest{"visible", ""}
+
+		if !reflect.DeepEqual(actual, expect) {
+			t.Fatalf("%+v did not equal %+v", actual, expect)
+		}
+	})
+
+	t.Run("unexported field should be preserved", func(t *testing.T) {
+		actual := unexportedFieldPreservationTest{"foo", "bar"}
+		err := Unmarshal([]byte(toml), &actual)
+
+		if err != nil {
+			t.Fatal("did not expect an error")
+		}
+
+		expect := unexportedFieldPreservationTest{"visible", "bar"}
+
+		if !reflect.DeepEqual(actual, expect) {
+			t.Fatalf("%+v did not equal %+v", actual, expect)
+		}
+	})
+}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1466,6 +1466,7 @@ type unexportedFieldPreservationTest struct {
 	unexported string
 	Nested1    unexportedFieldPreservationTestNested    `toml:"nested1"`
 	Nested2    *unexportedFieldPreservationTestNested   `toml:"nested2"`
+	Nested3    *unexportedFieldPreservationTestNested   `toml:"nested3"`
 	Slice1     []unexportedFieldPreservationTestNested  `toml:"slice1"`
 	Slice2     []*unexportedFieldPreservationTestNested `toml:"slice2"`
 }
@@ -1487,6 +1488,10 @@ func TestUnmarshalPreservesUnexportedFields(t *testing.T) {
 	[nested2]
 	exported1 = "visible2"
 	unexported1 = "ignored2"
+
+	[nested3]
+	exported1 = "visible3"
+	unexported1 = "ignored3"
 
 	[[slice1]]
 	exported1 = "visible3"
@@ -1511,6 +1516,7 @@ func TestUnmarshalPreservesUnexportedFields(t *testing.T) {
 			unexported: "",
 			Nested1:    unexportedFieldPreservationTestNested{"visible1", ""},
 			Nested2:    &unexportedFieldPreservationTestNested{"visible2", ""},
+			Nested3:    &unexportedFieldPreservationTestNested{"visible3", ""},
 			Slice1: []unexportedFieldPreservationTestNested{
 				{Exported1: "visible3"},
 				{Exported1: "visible4"},
@@ -1530,6 +1536,8 @@ func TestUnmarshalPreservesUnexportedFields(t *testing.T) {
 			Exported:   "foo",
 			unexported: "bar",
 			Nested1:    unexportedFieldPreservationTestNested{"baz", "bax"},
+			Nested2:    nil,
+			Nested3:    &unexportedFieldPreservationTestNested{"baz", "bax"},
 		}
 		err := Unmarshal([]byte(toml), &actual)
 
@@ -1542,6 +1550,7 @@ func TestUnmarshalPreservesUnexportedFields(t *testing.T) {
 			unexported: "bar",
 			Nested1:    unexportedFieldPreservationTestNested{"visible1", "bax"},
 			Nested2:    &unexportedFieldPreservationTestNested{"visible2", ""},
+			Nested3:    &unexportedFieldPreservationTestNested{"visible3", "bax"},
 			Slice1: []unexportedFieldPreservationTestNested{
 				{Exported1: "visible3"},
 				{Exported1: "visible4"},


### PR DESCRIPTION
- Addresses https://github.com/pelletier/go-toml/issues/283.
- Partially addresses https://github.com/pelletier/go-toml/issues/252.

When unmarshalling (nested) structs, pass the original reflect.Value down to `valueFromTree()` and `valueFromToml()`. When that struct already exists (i.e. it's a value, or a non-nil pointer), set its fields directly instead of overwriting the struct with a blank copy.

The main effect of this change is that the library will no longer re-initialise the fields that were not available in the original TOML tree (including un-exported fields).

Setting this up as a draft request at first, as the changes have so far worked for what I needed them for, but it feels like the code has been bolted on, and may have introduced breakage somewhere. I'm open to guidance in making it merge-worthy.