### PR TITLE
Add continuous fuzzing integration via Fuzzit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
-sudo: false
+dist: bionic
 language: go
-go:
-  - 1.11.x
-  - 1.12.x
-  - tip
+services:
+  - docker
+
 matrix:
   allow_failures:
     - go: tip
   fast_finish: true
+  include:
+    - go: 1.11.x
+    - go: 1.12.x
+      env: WITH_FUZZ=true
+    - go: tip
 env:
   - GO111MODULE=on
+  - secure: "hhoCl77LhP25e+dLzmKphjdj+ep6jRfqON1JoxdvRXYjQqmhtxWSTJFqPyMLz2fNGSN8HUcyZZKTrOG6HkrapiIR5kjrnvm6Fzjp+IfClPoPu8xQUIbKd8E3BrDwvvF1JkkLImozxZbrbJhksJqN+QgG/Lv2vs6wkAfQjvGcRTQ="
 script:
   - if [ -n "$(go fmt ./...)" ]; then exit 1; fi
   - go test github.com/pelletier/go-toml -race -coverprofile=coverage.txt -covermode=atomic
@@ -17,6 +22,7 @@ script:
   - go test github.com/pelletier/go-toml/cmd/tomll
   - go test github.com/pelletier/go-toml/query
   - ./benchmark.sh $TRAVIS_BRANCH https://github.com/$TRAVIS_REPO_SLUG.git
+  - ./fuzzit.sh
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -xe
+
+# fuzz only in one configuration
+# there's no benefit to fuzzing with different go versions
+if [ -z ${WITH_FUZZ} ]; then
+    exit 0
+fi
+
+# go-fuzz doesn't support modules yet, so ensure we do everything
+# in the old style GOPATH way
+export GO111MODULE="off"
+
+# install go-fuzz
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+
+# target name can only contain lower-case letters (a-z), digits (0-9) and a dash (-)
+# to add another target, make sure to create it with `fuzzit create target`
+# before using `fuzzit create job`
+TARGET=toml-fuzzer
+
+go-fuzz-build -libfuzzer -o ${TARGET}.a github.com/pelletier/go-toml
+clang -fsanitize=fuzzer ${TARGET}.a -o ${TARGET}
+
+# install fuzzit for talking to fuzzit.dev service
+# or latest version:
+# https://github.com/fuzzitdev/fuzzit/releases/latest/download/fuzzit_Linux_x86_64
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.23/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+# upload fuzz target for long fuzz testing on fuzzit.dev server
+# or run locally for regression, depending on --type
+if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+	TYPE=fuzzing
+else
+	TYPE=local-regression
+fi
+
+# TODO: change kkowalczyk to go-toml and create toml-fuzzer target there
+./fuzzit create job --type $TYPE go-toml/${TARGET} ${TARGET}


### PR DESCRIPTION
Hi @pelletier This is the PR as discussed in https://github.com/pelletier/go-toml/issues/287


It adds the following:

* Runs fuzzing continuously on master
* Runs regression with the generated corpus from the above step on every PR.

Cheers,
Yevgeny