### PR TITLE
Quote keys during encoding when the key isn't bare

### DIFF
--- a/tomltree_write_test.go
+++ b/tomltree_write_test.go
@@ -327,6 +327,30 @@ c = nan`
 	}
 }
 
+func TestIssue290(t *testing.T) {
+	tomlString :=
+		`[table]
+"127.0.0.1" = "value"
+"127.0.0.1:8028" = "value"
+"character encoding" = "value"
+"ʎǝʞ" = "value"`
+
+	t1, err := Load(tomlString)
+	if err != nil {
+		t.Fatal("load err:", err)
+	}
+
+	s, err := t1.ToTomlString()
+	if err != nil {
+		t.Fatal("ToTomlString err:", err)
+	}
+
+	_, err = Load(s)
+	if err != nil {
+		t.Fatal("reload err:", err)
+	}
+}
+
 func BenchmarkTreeToTomlString(b *testing.B) {
 	toml, err := Load(sampleHard)
 	if err != nil {


### PR DESCRIPTION
In case the key contains non-bare characters (out of `A-Za-z0-9_-`), the
key needs to be quoted during encoding to be valid TOML.

Fixes https://github.com/pelletier/go-toml/issues/290