### PR TITLE
Fixed #289: Float64 trucating

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -55,6 +55,9 @@ Ystrlist = ["Howdy","Hey There"]
   String2 = "Three"
 `)
 
+var testMarshalFloat64 = []byte(`Value = 1.24675324675
+`)
+
 func TestBasicMarshal(t *testing.T) {
 	result, err := Marshal(basicTestData)
 	if err != nil {
@@ -98,6 +101,22 @@ func TestBasicMarshalOrderedWithPointer(t *testing.T) {
 	expected := basicTestTomlOrdered
 	if !bytes.Equal(result.Bytes(), expected) {
 		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result.Bytes())
+	}
+}
+
+func TestMarshalFloat64(t *testing.T) {
+	foo := struct {
+		Value float64
+	}{
+		Value: 1.24675324675,
+	}
+	b, err := Marshal(&foo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := testMarshalFloat64
+	if !bytes.Equal(b, expected) {
+		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, b)
 	}
 }
 
@@ -1495,7 +1514,7 @@ func TestUnmarshalPreservesUnexportedFields(t *testing.T) {
 
 	[[slice1]]
 	exported1 = "visible3"
-	
+
 	[[slice1]]
 	exported1 = "visible4"
 

--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -109,9 +109,9 @@ func tomlValueStringRepresentation(v interface{}, indent string, arraysOneElemen
 		// Ensure a round float does contain a decimal point. Otherwise feeding
 		// the output back to the parser would convert to an integer.
 		if math.Trunc(value) == value {
-			return strings.ToLower(strconv.FormatFloat(value, 'f', 1, 32)), nil
+			return strings.ToLower(strconv.FormatFloat(value, 'f', 1, 64)), nil
 		}
-		return strings.ToLower(strconv.FormatFloat(value, 'f', -1, 32)), nil
+		return strings.ToLower(strconv.FormatFloat(value, 'f', -1, 64)), nil
 	case string:
 		if tv.multiline {
 			return "\"\"\"\n" + encodeMultilineTomlString(value) + "\"\"\"", nil


### PR DESCRIPTION
Fixed #289

This PR change the bitSize of FormatFloat to string of 32 to 64.  Maybe should be useful add a case statement to FormatFloat of float32 to string, but I don't implement because I was in doubt.