### PR TITLE
Fix float64 truncation error

### DIFF
--- a/marshal_OrderPreserve_test.toml
+++ b/marshal_OrderPreserve_test.toml
@@ -27,6 +27,7 @@ title = "TOML Marshal Testing"
   uint = 5001
   bool = true
   float = 123.4
+  float64 = 123.456782132399
   int = 5000
   string = "Bite me"
   date = 1979-05-27T07:32:00Z

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -135,7 +135,8 @@ type testMapDoc struct {
 type testDocBasics struct {
 	Uint       uint      `toml:"uint"`
 	Bool       bool      `toml:"bool"`
-	Float      float32   `toml:"float"`
+	Float32    float32   `toml:"float"`
+	Float64    float64   `toml:"float64"`
 	Int        int       `toml:"int"`
 	String     *string   `toml:"string"`
 	Date       time.Time `toml:"date"`
@@ -174,7 +175,8 @@ var docData = testDoc{
 	Basics: testDocBasics{
 		Bool:       true,
 		Date:       time.Date(1979, 5, 27, 7, 32, 0, 0, time.UTC),
-		Float:      123.4,
+		Float32:    123.4,
+		Float64:    123.456782132399,
 		Int:        5000,
 		Uint:       5001,
 		String:     &biteMe,

--- a/marshal_test.toml
+++ b/marshal_test.toml
@@ -4,6 +4,7 @@ title = "TOML Marshal Testing"
   bool = true
   date = 1979-05-27T07:32:00Z
   float = 123.4
+  float64 = 123.456782132399
   int = 5000
   string = "Bite me"
   uint = 5001


### PR DESCRIPTION
**Issue:** https://github.com/pelletier/go-toml/issues/289

Fixed it, non-breaking.  Updated tests to add the new 64bit float test cases.