### PR TITLE
Allow space to separate date and time

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -733,7 +733,7 @@ func (l *tomlLexer) run() {
 }
 
 func init() {
-	dateRegexp = regexp.MustCompile(`^\d{1,4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})`)
+	dateRegexp = regexp.MustCompile(`^\d{1,4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})`)
 }
 
 // Entry point

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -299,6 +299,9 @@ func TestDateRegexp(t *testing.T) {
 	if dateRegexp.FindString("1979-05-27T00:32:00.999999-07:00") == "" {
 		t.Error("nano precision lexing")
 	}
+	if dateRegexp.FindString("1979-05-27 07:32:00Z") == "" {
+		t.Error("space delimiter lexing")
+	}
 }
 
 func TestKeyEqualDate(t *testing.T) {
@@ -319,6 +322,12 @@ func TestKeyEqualDate(t *testing.T) {
 		{Position{1, 5}, tokenEqual, "="},
 		{Position{1, 7}, tokenDate, "1979-05-27T00:32:00.999999-07:00"},
 		{Position{1, 39}, tokenEOF, ""},
+	})
+	testFlow(t, "foo = 1979-05-27 07:32:00Z", []token{
+		{Position{1, 1}, tokenKey, "foo"},
+		{Position{1, 5}, tokenEqual, "="},
+		{Position{1, 7}, tokenDate, "1979-05-27 07:32:00Z"},
+		{Position{1, 27}, tokenEOF, ""},
 	})
 }
 

--- a/parser.go
+++ b/parser.go
@@ -313,7 +313,11 @@ func (p *tomlParser) parseRvalue() interface{} {
 		}
 		return val
 	case tokenDate:
-		val, err := time.ParseInLocation(time.RFC3339Nano, tok.val, time.UTC)
+		layout := time.RFC3339Nano
+		if !strings.Contains(tok.val, "T") {
+			layout = strings.Replace(layout, "T", " ", 1)
+		}
+		val, err := time.ParseInLocation(layout, tok.val, time.UTC)
 		if err != nil {
 			p.raiseError(tok, "%s", err)
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -225,6 +225,13 @@ func TestDateNano(t *testing.T) {
 	})
 }
 
+func TestDateSpaceDelimiter(t *testing.T) {
+	tree, err := Load("odt4 = 1979-05-27 07:32:00Z")
+	assertTree(t, tree, err, map[string]interface{}{
+		"odt4": time.Date(1979, time.May, 27, 7, 32, 0, 0, time.UTC),
+	})
+}
+
 func TestSimpleString(t *testing.T) {
 	tree, err := Load("a = \"hello world\"")
 	assertTree(t, tree, err, map[string]interface{}{


### PR DESCRIPTION
**Issue:** #231

This implementation enables using a space as a delimiter between date and time.