### PR TITLE
Tree.Marshal returns the TOML encoding of Tree

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -445,8 +445,11 @@ func (t *Tree) Unmarshal(v interface{}) error {
 // See Marshal() documentation for types mapping table.
 func (t *Tree) Marshal() ([]byte, error) {
 	var buf bytes.Buffer
-	err := NewEncoder(&buf).Encode(t)
-	return buf.Bytes(), err
+	_, err := t.WriteTo(&buf)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // Unmarshal parses the TOML-encoded data and stores the result in the value

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1675,3 +1675,27 @@ func TestUnmarshalPreservesUnexportedFields(t *testing.T) {
 		}
 	})
 }
+
+func TestTreeMarshal(t *testing.T) {
+	cases := [][]byte{
+		basicTestToml,
+		marshalTestToml,
+		emptyTestToml,
+		pointerTestToml,
+	}
+	for _, expected := range cases {
+		t.Run("", func(t *testing.T) {
+			tree, err := LoadBytes(expected)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := tree.Marshal()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(result, expected) {
+				t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expected, result)
+			}
+		})
+	}
+}

--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -423,12 +423,11 @@ func (t *Tree) WriteTo(w io.Writer) (int64, error) {
 // Output spans multiple lines, and is suitable for ingest by a TOML parser.
 // If the conversion cannot be performed, ToString returns a non-nil error.
 func (t *Tree) ToTomlString() (string, error) {
-	var buf bytes.Buffer
-	_, err := t.WriteTo(&buf)
+	b, err := t.Marshal()
 	if err != nil {
 		return "", err
 	}
-	return buf.String(), nil
+	return string(b), nil
 }
 
 // String generates a human-readable representation of the current tree.


### PR DESCRIPTION
**Issue:** #295

The `Tree.Marshal` method tried to marshal the `Tree` struct itself rather than the nodes being part of the tree. The `Tree` struct doesn't export any fields so the result was empty. Regardless, the output would not represent the TOML structure inside the tree.