### PR TITLE
TOML 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Go library for the [TOML](https://github.com/mojombo/toml) format.
 
 This library supports TOML version
-[v0.4.0](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md)
+[v0.5.0](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.5.0.md)
 
 [![GoDoc](https://godoc.org/github.com/pelletier/go-toml?status.svg)](http://godoc.org/github.com/pelletier/go-toml)
 [![license](https://img.shields.io/github/license/pelletier/go-toml.svg)](https://github.com/pelletier/go-toml/blob/master/LICENSE)

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,7 @@
 // Package toml is a TOML parser and manipulation library.
 //
 // This version supports the specification as described in
-// https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.4.0.md
+// https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.5.0.md
 //
 // Marshaling
 //


### PR DESCRIPTION
go-toml now officially supports all TOML 0.5.0 features. If anything
does not work according to the spec, please [file a bug](https://github.com/pelletier/go-toml/issues/new?template=bug_report.md)!

* [Milestone](https://github.com/pelletier/go-toml/milestone/4?closed=1)
* [TOML spec](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v0.5.0.md)