### PR TITLE
Support default values for non-anonymous structs

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -624,8 +624,8 @@ func (d *Decoder) valueFromTree(mtype reflect.Type, tval *Tree, mval1 *reflect.V
 					mval.Field(i).Set(reflect.ValueOf(val))
 				}
 
-				// save the old behavior above and try to check anonymous structs
-				if !found && opts.defaultValue == "" && mtypef.Anonymous && mtypef.Type.Kind() == reflect.Struct {
+				// save the old behavior above and try to check structs
+				if !found && opts.defaultValue == "" && mtypef.Type.Kind() == reflect.Struct {
 					v, err := d.valueFromTree(mtypef.Type, tval, nil)
 					if err != nil {
 						return v, err

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1483,12 +1483,20 @@ func TestUnmarshalCamelCaseKey(t *testing.T) {
 }
 
 func TestUnmarshalDefault(t *testing.T) {
+	type EmbeddedStruct struct {
+		StringField string `default:"c"`
+	}
+
 	var doc struct {
 		StringField  string  `default:"a"`
 		BoolField    bool    `default:"true"`
 		IntField     int     `default:"1"`
 		Int64Field   int64   `default:"2"`
 		Float64Field float64 `default:"3.1"`
+		NonEmbeddedStruct  struct {
+			StringField string `default:"b"`
+		}
+		EmbeddedStruct
 	}
 
 	err := Unmarshal([]byte(``), &doc)
@@ -1509,6 +1517,12 @@ func TestUnmarshalDefault(t *testing.T) {
 	}
 	if doc.Float64Field != 3.1 {
 		t.Errorf("Float64Field should be 3.1, not %f", doc.Float64Field)
+	}
+	if doc.NonEmbeddedStruct.StringField != "b" {
+		t.Errorf("StringField should be \"b\", not %s", doc.NonEmbeddedStruct.StringField)
+	}
+	if doc.EmbeddedStruct.StringField != "c" {
+		t.Errorf("StringField should be \"c\", not %s", doc.EmbeddedStruct.StringField)
 	}
 }
 


### PR DESCRIPTION
**Issue:** https://github.com/pelletier/go-toml/issues/274

This adds support for default values on fields of non-anonymous structs. I'm not sure why there was a check for the struct being anonymous prior to calling `valueFromTree`? I don't see a reason to exclude non-anonymous struct.
