### PR TITLE
Fix issue #321

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -256,7 +256,7 @@ func (l *tomlLexer) lexLeftCurlyBrace() tomlLexStateFn {
 func (l *tomlLexer) lexRightCurlyBrace() tomlLexStateFn {
 	l.next()
 	l.emit(tokenRightCurlyBrace)
-	return l.lexVoid
+	return l.lexRvalue
 }
 
 func (l *tomlLexer) lexDate() tomlLexStateFn {

--- a/parser_test.go
+++ b/parser_test.go
@@ -581,6 +581,39 @@ func TestDoubleInlineGroup(t *testing.T) {
 	})
 }
 
+func TestNestedInlineGroup(t *testing.T) {
+	tree, err := Load("out = {block0 = {x = 99, y = 100}, block1 = {p = \"999\", q = \"1000\"}}")
+	assertTree(t, tree, err, map[string]interface{}{
+		"out": map[string]interface{}{
+			"block0": map[string]interface{}{
+				"x": int64(99),
+				"y": int64(100),
+			},
+			"block1": map[string]interface{}{
+				"p": "999",
+				"q": "1000",
+			},
+		},
+	})
+}
+
+func TestArrayInNestedInlineGroup(t *testing.T) {
+	tree, err := Load(`image = {name = "xxx", palette = {id = 100, colors = ["red", "blue", "green"]}}`)
+	assertTree(t, tree, err, map[string]interface{}{
+		"image": map[string]interface{}{
+			"name": "xxx",
+			"palette": map[string]interface{}{
+				"id": int64(100),
+				"colors": []string{
+					"red",
+					"blue",
+					"green",
+				},
+			},
+		},
+	})
+}
+
 func TestExampleInlineGroup(t *testing.T) {
 	tree, err := Load(`name = { first = "Tom", last = "Preston-Werner" }
 point = { x = 1, y = 2 }`)


### PR DESCRIPTION
**Issue:** #321 

This pr fix issue #321. The lexer should not transition its state to `lexVoid` when it meets a right curly brace. Instead, it should transition to `lexRvalue`, which can handle both simple inline table and nested inline table case.
