### PR TITLE
fix issue#216

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -302,7 +302,7 @@ func (e *Encoder) marshal(v interface{}) ([]byte, error) {
 	}
 
 	var buf bytes.Buffer
-	_, err = t.writeToOrdered(&buf, "", "", 0, e.arraysOneElementPerLine, e.order)
+	_, err = t.writeToOrdered(&buf, "", "", 0, e.arraysOneElementPerLine, e.order, false)
 
 	return buf.Bytes(), err
 }
@@ -363,7 +363,7 @@ func (e *Encoder) valueToTree(mtype reflect.Type, mval reflect.Value) (*Tree, er
 				return nil, err
 			}
 			if e.quoteMapKeys {
-				keyStr, err := tomlValueStringRepresentation(key.String(), "", e.arraysOneElementPerLine)
+				keyStr, err := tomlValueStringRepresentation(key.String(), "", "", e.arraysOneElementPerLine)
 				if err != nil {
 					return nil, err
 				}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -913,6 +913,213 @@ func TestMarshalComment(t *testing.T) {
 	}
 }
 
+func TestMarshalMultilineCommented(t *testing.T) {
+	expectedToml := []byte(`# MultilineArray = [
+  # 100,
+  # 200,
+  # 300,
+# ]
+# MultilineNestedArray = [
+  # [
+  # "a",
+  # "b",
+  # "c",
+# ],
+  # [
+  # "d",
+  # "e",
+  # "f",
+# ],
+# ]
+# MultilineString = """
+# I
+# am
+# Allen"""
+NonCommented = "Not commented line"
+`)
+	type StructWithMultiline struct {
+		NonCommented         string
+		MultilineString      string     `commented:"true" multiline:"true"`
+		MultilineArray       []int      `commented:"true"`
+		MultilineNestedArray [][]string `commented:"true"`
+	}
+
+	var buf bytes.Buffer
+	enc := NewEncoder(&buf)
+	if err := enc.ArraysWithOneElementPerLine(true).Encode(StructWithMultiline{
+		NonCommented:    "Not commented line",
+		MultilineString: "I\nam\nAllen",
+		MultilineArray:  []int{100, 200, 300},
+		MultilineNestedArray: [][]string{
+			{"a", "b", "c"},
+			{"d", "e", "f"},
+		},
+	}); err == nil {
+		result := buf.Bytes()
+		if !bytes.Equal(result, expectedToml) {
+			t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expectedToml, result)
+		}
+	} else {
+		t.Fatal(err)
+	}
+}
+
+func TestMarshalNonPrimitiveTypeCommented(t *testing.T) {
+	expectedToml := []byte(`
+# [CommentedMapField]
+
+  # [CommentedMapField.CommentedMapField1]
+    # SingleLineString = "This line should be commented out"
+
+  # [CommentedMapField.CommentedMapField2]
+    # SingleLineString = "This line should be commented out"
+
+# [CommentedStructField]
+
+  # [CommentedStructField.CommentedStructField]
+    # MultilineArray = [
+      # 1,
+      # 2,
+    # ]
+    # MultilineNestedArray = [
+      # [
+      # 10,
+      # 20,
+    # ],
+      # [
+      # 100,
+      # 200,
+    # ],
+    # ]
+    # MultilineString = """
+# This line
+# should be
+# commented out"""
+
+  # [CommentedStructField.NotCommentedStructField]
+    # MultilineArray = [
+      # 1,
+      # 2,
+    # ]
+    # MultilineNestedArray = [
+      # [
+      # 10,
+      # 20,
+    # ],
+      # [
+      # 100,
+      # 200,
+    # ],
+    # ]
+    # MultilineString = """
+# This line
+# should be
+# commented out"""
+
+[NotCommentedStructField]
+
+  # [NotCommentedStructField.CommentedStructField]
+    # MultilineArray = [
+      # 1,
+      # 2,
+    # ]
+    # MultilineNestedArray = [
+      # [
+      # 10,
+      # 20,
+    # ],
+      # [
+      # 100,
+      # 200,
+    # ],
+    # ]
+    # MultilineString = """
+# This line
+# should be
+# commented out"""
+
+  [NotCommentedStructField.NotCommentedStructField]
+    MultilineArray = [
+      3,
+      4,
+    ]
+    MultilineNestedArray = [
+      [
+      30,
+      40,
+    ],
+      [
+      300,
+      400,
+    ],
+    ]
+    MultilineString = """
+This line
+should NOT be
+commented out"""
+`)
+	type InnerStruct struct {
+		MultilineString      string `multiline:"true"`
+		MultilineArray       []int
+		MultilineNestedArray [][]int
+	}
+	type MiddleStruct struct {
+		NotCommentedStructField InnerStruct
+		CommentedStructField    InnerStruct `commented:"true"`
+	}
+	type OuterStruct struct {
+		CommentedStructField    MiddleStruct `commented:"true"`
+		NotCommentedStructField MiddleStruct
+		CommentedMapField       map[string]struct{ SingleLineString string } `commented:"true"`
+	}
+
+	commentedTestStruct := OuterStruct{
+		CommentedStructField: MiddleStruct{
+			NotCommentedStructField: InnerStruct{
+				MultilineString:      "This line\nshould be\ncommented out",
+				MultilineArray:       []int{1, 2},
+				MultilineNestedArray: [][]int{{10, 20}, {100, 200}},
+			},
+			CommentedStructField: InnerStruct{
+				MultilineString:      "This line\nshould be\ncommented out",
+				MultilineArray:       []int{1, 2},
+				MultilineNestedArray: [][]int{{10, 20}, {100, 200}},
+			},
+		},
+		NotCommentedStructField: MiddleStruct{
+			NotCommentedStructField: InnerStruct{
+				MultilineString:      "This line\nshould NOT be\ncommented out",
+				MultilineArray:       []int{3, 4},
+				MultilineNestedArray: [][]int{{30, 40}, {300, 400}},
+			},
+			CommentedStructField: InnerStruct{
+				MultilineString:      "This line\nshould be\ncommented out",
+				MultilineArray:       []int{1, 2},
+				MultilineNestedArray: [][]int{{10, 20}, {100, 200}},
+			},
+		},
+		CommentedMapField: map[string]struct{ SingleLineString string }{
+			"CommentedMapField1": {
+				SingleLineString: "This line should be commented out",
+			},
+			"CommentedMapField2": {
+				SingleLineString: "This line should be commented out",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	enc := NewEncoder(&buf)
+	if err := enc.ArraysWithOneElementPerLine(true).Encode(commentedTestStruct); err == nil {
+		result := buf.Bytes()
+		if !bytes.Equal(result, expectedToml) {
+			t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", expectedToml, result)
+		}
+	} else {
+		t.Fatal(err)
+	}
+}
+
 type mapsTestStruct struct {
 	Simple map[string]string
 	Paths  map[string]string
@@ -1488,12 +1695,12 @@ func TestUnmarshalDefault(t *testing.T) {
 	}
 
 	var doc struct {
-		StringField  string  `default:"a"`
-		BoolField    bool    `default:"true"`
-		IntField     int     `default:"1"`
-		Int64Field   int64   `default:"2"`
-		Float64Field float64 `default:"3.1"`
-		NonEmbeddedStruct  struct {
+		StringField       string  `default:"a"`
+		BoolField         bool    `default:"true"`
+		IntField          int     `default:"1"`
+		Int64Field        int64   `default:"2"`
+		Float64Field      float64 `default:"3.1"`
+		NonEmbeddedStruct struct {
 			StringField string `default:"b"`
 		}
 		EmbeddedStruct

--- a/parser_test.go
+++ b/parser_test.go
@@ -897,7 +897,7 @@ func TestTomlValueStringRepresentation(t *testing.T) {
 			"[\"gamma\",\"delta\"]"},
 		{nil, ""},
 	} {
-		result, err := tomlValueStringRepresentation(item.Value, "", false)
+		result, err := tomlValueStringRepresentation(item.Value, "", "", false)
 		if err != nil {
 			t.Errorf("Test %d - unexpected error: %s", idx, err)
 		}

--- a/toml.go
+++ b/toml.go
@@ -222,8 +222,12 @@ func (t *Tree) SetPathWithOptions(keys []string, opts SetOptions, value interfac
 	switch v := value.(type) {
 	case *Tree:
 		v.comment = opts.Comment
+		v.commented = opts.Commented
 		toInsert = value
 	case []*Tree:
+		for i := range v {
+			v[i].commented = opts.Commented
+		}
 		toInsert = value
 	case *tomlValue:
 		v.comment = opts.Comment


### PR DESCRIPTION
**Issue:** #216 
This pr fix #216. If a non-primitive(like struct, map) is commented, all of its sub kv pairs should be commented out too. Besides, I notice that If a multiline string or multiline array is commented, go-toml just commented out the first line. This pr also fix that. 