### PR TITLE
Support default for slice, but only one default value

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -629,6 +629,39 @@ func (d *Decoder) valueFromTree(mtype reflect.Type, tval *Tree, mval1 *reflect.V
 						if err != nil {
 							return mval.Field(i), err
 						}
+					// For slice
+					case reflect.Slice:
+						var tt interface{}
+						switch mvalf.Type().Elem().Kind() {
+						case reflect.Bool:
+							tt, err = strconv.ParseBool(opts.defaultValue)
+							if err != nil {
+								return mval.Field(i), err
+							}
+						case reflect.Int:
+							tt, err = strconv.Atoi(opts.defaultValue)
+							if err != nil {
+								return mval.Field(i), err
+							}
+						case reflect.String:
+							tt = opts.defaultValue
+						case reflect.Int64:
+							tt, err = strconv.ParseInt(opts.defaultValue, 10, 64)
+							if err != nil {
+								return mval.Field(i), err
+							}
+						case reflect.Float64:
+							tt, err = strconv.ParseFloat(opts.defaultValue, 64)
+							if err != nil {
+								return mval.Field(i), err
+							}
+						default:
+							return mval.Field(i), fmt.Errorf("unsuported field type for default option")
+						}
+						val := reflect.MakeSlice(mtypef.Type, 1, 1)
+						val.Index(0).Set(reflect.ValueOf(tt))
+						mval.Field(i).Set(val)
+						continue
 					default:
 						return mval.Field(i), fmt.Errorf("unsuported field type for default option")
 					}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -177,6 +177,74 @@ Age = 18
   LastName = "jl"
   Age = 100`)
 
+func TestSliceWithDefault(t *testing.T) {
+	type sliceWithDefault struct {
+		Bools  []bool    `toml:"bool" default:"false"`
+		Strs   []string  `toml:"name" default:"test"`
+		Ints   []int     `toml:"int" default:"100"`
+		Int64s []int64   `toml:"int64" default:"10000"`
+		Floats []float64 `toml:"float" default:"100.111"`
+	}
+
+	var test sliceWithDefault
+	err := Unmarshal([]byte(``), &test)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := sliceWithDefault{
+		Bools:  []bool{false},
+		Strs:   []string{"test"},
+		Ints:   []int{100},
+		Int64s: []int64{10000},
+		Floats: []float64{100.111},
+	}
+	if !reflect.DeepEqual(test, expected) {
+		t.Errorf("Bad unmarshal: expected %v, got %v", expected, test)
+	}
+}
+
+func TestSliceWithDefaultError(t *testing.T) {
+	var testBool struct{
+		Bools []bool `default:"error"`
+	}
+	err := Unmarshal([]byte(``), &testBool)
+	if err == nil {
+		t.Fatal("should error")
+	}
+
+	var testInt struct{
+		Ints []int `default:"error"`
+	}
+	err = Unmarshal([]byte(``), &testInt)
+	if err == nil {
+		t.Fatal("should error")
+	}
+
+	var testInt64 struct{
+		Int64s []int64 `default:"error"`
+	}
+	err = Unmarshal([]byte(``), &testInt64)
+	if err == nil {
+		t.Fatal("should error")
+	}
+
+	var testFloat64 struct{
+		Float64s []float64 `default:"error"`
+	}
+	err = Unmarshal([]byte(``), &testFloat64)
+	if err == nil {
+		t.Fatal("should error")
+	}
+
+	var unsupportSliceWithDefault struct{
+		Ints []struct{} `default:"error"`
+	}
+	err = Unmarshal([]byte(``), &unsupportSliceWithDefault)
+	if err == nil {
+		t.Fatal("should error")
+	}
+}
+
 func TestInterface(t *testing.T) {
 	var config Conf
 	config.Inter = &NestedStruct{}


### PR DESCRIPTION
e.g.

```
type sliceWithDefault struct {
	Bools  []bool    `toml:"bool" default:"false"`
	Strs   []string  `toml:"name" default:"test"`
	Ints   []int     `toml:"int" default:"100"`
	Int64s []int64   `toml:"int64" default:"10000"`
	Floats []float64 `toml:"float" default:"100.111"`
}

var test sliceWithDefault
err := Unmarshal([]byte(``), &test)

// {[false] [test] [100] [10000] [100.111]}
log.Println(test)
```