### PR TITLE
Add float to test case to check leading zeroes in exponent parts

### DIFF
--- a/example-crlf.toml
+++ b/example-crlf.toml
@@ -27,3 +27,4 @@ enabled = true
 
 [clients]
 data = [ ["gamma", "delta"], [1, 2] ] # just an update to make sure parsers support it
+score = 4e-08 # to make sure leading zeroes in exponent parts of floats are supported

--- a/example.toml
+++ b/example.toml
@@ -27,3 +27,4 @@ enabled = true
 
 [clients]
 data = [ ["gamma", "delta"], [1, 2] ] # just an update to make sure parsers support it
+score = 4e-08 # to make sure leading zeroes in exponent parts of floats are supported

--- a/parser_test.go
+++ b/parser_test.go
@@ -783,6 +783,7 @@ func TestParseFile(t *testing.T) {
 				[]string{"gamma", "delta"},
 				[]int64{1, 2},
 			},
+			"score": 4e-08,
 		},
 	})
 }
@@ -819,6 +820,7 @@ func TestParseFileCRLF(t *testing.T) {
 				[]string{"gamma", "delta"},
 				[]int64{1, 2},
 			},
+			"score": 4e-08,
 		},
 	})
 }

--- a/query/parser_test.go
+++ b/query/parser_test.go
@@ -407,7 +407,10 @@ func TestQueryFilterFn(t *testing.T) {
 
 	assertQueryPositions(t, string(buff),
 		"$..[?(float)]",
-		[]interface{}{ // no float values in document
+		[]interface{}{ 
+			queryTestNode{
+				4e-08, toml.Position{30, 1},
+			},
 		})
 
 	tv, _ := time.Parse(time.RFC3339, "1979-05-27T07:32:00Z")
@@ -460,6 +463,7 @@ func TestQueryFilterFn(t *testing.T) {
 						[]interface{}{"gamma", "delta"},
 						[]interface{}{int64(1), int64(2)},
 					},
+					"score": 4e-08,
 				}, toml.Position{28, 1},
 			},
 		})

--- a/tomltree_write_test.go
+++ b/tomltree_write_test.go
@@ -236,6 +236,7 @@ func TestTreeWriteToMapExampleFile(t *testing.T) {
 				[]interface{}{"gamma", "delta"},
 				[]interface{}{int64(1), int64(2)},
 			},
+			"score": 4e-08,
 		},
 	}
 	testMaps(t, tree.ToMap(), expected)


### PR DESCRIPTION
**Issue:** add link to pelletier/go-toml issue here #360

Explanation of what this pull request does.
Add float to example.toml and example-crlf.toml files so that we have test case to check leading zeroes in exponent parts are supported
More detailed description of the decisions being made and the reasons why (if the patch is non-trivial).
