### PR TITLE
add support for tab in basic string value and quoted key

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -313,7 +313,7 @@ func (l *tomlLexer) lexKey() tomlLexStateFn {
 	for r := l.peek(); isKeyChar(r) || r == '\n' || r == '\r'; r = l.peek() {
 		if r == '"' {
 			l.next()
-			str, err := l.lexStringAsString(`"`, false, true, false)
+			str, err := l.lexStringAsString(`"`, false, true)
 			if err != nil {
 				return l.errorf(err.Error())
 			}
@@ -419,7 +419,7 @@ func (l *tomlLexer) lexLiteralString() tomlLexStateFn {
 // Lex a string and return the results as a string.
 // Terminator is the substring indicating the end of the token.
 // The resulting string does not include the terminator.
-func (l *tomlLexer) lexStringAsString(terminator string, discardLeadingNewLine, acceptNewLines bool, acceptTab bool) (string, error) {
+func (l *tomlLexer) lexStringAsString(terminator string, discardLeadingNewLine, acceptNewLines bool) (string, error) {
 	growingString := ""
 
 	if discardLeadingNewLine {
@@ -512,8 +512,7 @@ func (l *tomlLexer) lexStringAsString(terminator string, discardLeadingNewLine, 
 		} else {
 			r := l.peek()
 
-			if 0x00 <= r && r <= 0x1F && !(acceptNewLines && (r == '\n' || r == '\r')) &&
-				!(acceptTab && r == '\t') {
+			if 0x00 <= r && r <= 0x1F && r != '\t' && !(acceptNewLines && (r == '\n' || r == '\r')) {
 				return "", fmt.Errorf("unescaped control character %U", r)
 			}
 			l.next()
@@ -535,17 +534,15 @@ func (l *tomlLexer) lexString() tomlLexStateFn {
 	terminator := `"`
 	discardLeadingNewLine := false
 	acceptNewLines := false
-	acceptTab := false
 	if l.follow(`""`) {
 		l.skip()
 		l.skip()
 		terminator = `"""`
 		discardLeadingNewLine = true
 		acceptNewLines = true
-		acceptTab = true
 	}
 
-	str, err := l.lexStringAsString(terminator, discardLeadingNewLine, acceptNewLines, acceptTab)
+	str, err := l.lexStringAsString(terminator, discardLeadingNewLine, acceptNewLines)
 
 	if err != nil {
 		return l.errorf(err.Error())

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -707,6 +707,15 @@ func TestEscapeInString(t *testing.T) {
 	})
 }
 
+func TestTabInString(t *testing.T) {
+	testFlow(t, `foo = "hello	world"`, []token{
+		{Position{1, 1}, tokenKey, "foo"},
+		{Position{1, 5}, tokenEqual, "="},
+		{Position{1, 8}, tokenString, "hello\tworld"},
+		{Position{1, 20}, tokenEOF, ""},
+	})
+}
+
 func TestKeyGroupArray(t *testing.T) {
 	testFlow(t, "[[foo]]", []token{
 		{Position{1, 1}, tokenDoubleLeftBracket, "[["},
@@ -722,6 +731,15 @@ func TestQuotedKey(t *testing.T) {
 		{Position{1, 7}, tokenEqual, "="},
 		{Position{1, 9}, tokenInteger, "42"},
 		{Position{1, 11}, tokenEOF, ""},
+	})
+}
+
+func TestQuotedKeyTab(t *testing.T) {
+	testFlow(t, "\"num\tber\" = 123", []token{
+		{Position{1, 1}, tokenKey, "\"num\tber\""},
+		{Position{1, 11}, tokenEqual, "="},
+		{Position{1, 13}, tokenInteger, "123"},
+		{Position{1, 16}, tokenEOF, ""},
 	})
 }
 


### PR DESCRIPTION
**Issue:** #358 

From [TOML v1.0.0-rc1](https://github.com/toml-lang/toml/blob/master/versions/en/toml-v1.0.0-rc.1.md):

> Basic strings are surrounded by quotation marks. Any Unicode character may be used except those that must be escaped: quotation mark, backslash, and the control characters other than **tab** (U+0000 to U+0008, U+000A to U+001F, U+007F).

> Quoted keys follow the exact **same rules as** either **basic strings** or literal strings and allow you to use a much broader set of key names.

So the raw tab character should be allowed in quoted key, basic string as well as multiline string.