### PR TITLE
marshal: do not encode embedded structs as sub-table

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -5,6 +5,7 @@ package toml_test
 import (
 	"fmt"
 	"log"
+	"os"
 
 	toml "github.com/pelletier/go-toml"
 )
@@ -103,4 +104,67 @@ func ExampleUnmarshal() {
 	fmt.Println("user=", config.Postgres.User)
 	// Output:
 	// user= pelletier
+}
+
+func ExampleEncoder_anonymous() {
+	type Credentials struct {
+		User     string `toml:"user"`
+		Password string `toml:"password"`
+	}
+
+	type Protocol struct {
+		Name string `toml:"name"`
+	}
+
+	type Config struct {
+		Version int `toml:"version"`
+		Credentials
+		Protocol `toml:"Protocol"`
+	}
+	config := Config{
+		Version: 2,
+		Credentials: Credentials{
+			User:     "pelletier",
+			Password: "mypassword",
+		},
+		Protocol: Protocol{
+			Name: "tcp",
+		},
+	}
+	fmt.Println("Default:")
+	fmt.Println("---------------")
+
+	def := toml.NewEncoder(os.Stdout)
+	if err := def.Encode(config); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("---------------")
+	fmt.Println("With promotion:")
+	fmt.Println("---------------")
+
+	prom := toml.NewEncoder(os.Stdout).PromoteAnonymous(true)
+	if err := prom.Encode(config); err != nil {
+		log.Fatal(err)
+	}
+	// Output:
+	// Default:
+	// ---------------
+	// password = "mypassword"
+	// user = "pelletier"
+	// version = 2
+	//
+	// [Protocol]
+	//   name = "tcp"
+	// ---------------
+	// With promotion:
+	// ---------------
+	// version = 2
+	//
+	// [Credentials]
+	//   password = "mypassword"
+	//   user = "pelletier"
+	//
+	// [Protocol]
+	//   name = "tcp"
 }

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2016,6 +2016,23 @@ func TestMarshalNestedAnonymousStructs(t *testing.T) {
 
 }
 
+func TestMarshalNestedAnonymousStructs_DuplicateField(t *testing.T) {
+	type Embedded struct {
+		Value string `toml:"value"`
+		Top   struct {
+			Value string `toml:"value"`
+		} `toml:"top"`
+	}
+
+	var doc struct {
+		Value int `toml:"value"`
+		Embedded
+	}
+	if rest, err := Marshal(doc); err == nil {
+		t.Fatal("should error", string(rest))
+	}
+}
+
 func TestUnmarshalNestedAnonymousStructs(t *testing.T) {
 	type Nested struct {
 		Value string `toml:"nested_field"`

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1974,6 +1974,48 @@ func TestUnmarshalDefaultFailureUnsupported(t *testing.T) {
 	}
 }
 
+func TestMarshalNestedAnonymousStructs(t *testing.T) {
+	type Embedded struct {
+		Value string `toml:"value"`
+		Top   struct {
+			Value string `toml:"value"`
+		} `toml:"top"`
+	}
+
+	type Named struct {
+		Value string `toml:"value"`
+	}
+
+	var doc struct {
+		Embedded
+		Named     `toml:"named"`
+		Anonymous struct {
+			Value string `toml:"value"`
+		} `toml:"anonymous"`
+	}
+
+	expected := `value = ""
+
+[anonymous]
+  value = ""
+
+[named]
+  value = ""
+
+[top]
+  value = ""
+`
+
+	result, err := Marshal(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+	if !bytes.Equal(result, []byte(expected)) {
+		t.Errorf("Bad marshal: expected\n-----\n%s\n-----\ngot\n-----\n%s\n-----\n", string(expected), string(result))
+	}
+
+}
+
 func TestUnmarshalNestedAnonymousStructs(t *testing.T) {
 	type Nested struct {
 		Value string `toml:"nested_field"`


### PR DESCRIPTION
Currently, the marshalling code encodes the embedded structs as sub-tables.
This is a bit unexpected, as it differs from what encoding/json does in
that case: https://play.golang.org/p/KDPaGtrijV1

This PR adapts the encoder to behave like encoding/json.
Fields in an embedded struct are promoted to the top level table.
In case the embedded struct is named in the tag, it will still
encode as a sub-table.

