### PR TITLE
unmarshal: add strict mode

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2959,3 +2959,49 @@ func TestUnmarshalSliceFail2(t *testing.T) {
 	}
 
 }
+
+func TestDecoderStrict(t *testing.T) {
+	input := `
+[decoded]
+  key = ""
+
+[undecoded]
+  key = ""
+
+  [undecoded.inner]
+	key = ""
+
+  [[undecoded.array]]
+	key = ""
+
+  [[undecoded.array]]
+	key = ""
+
+`
+	var doc struct {
+		Decoded struct {
+			Key string
+		}
+	}
+
+	t.Log("strict mode")
+	expected := `undecoded keys: ["undecoded.array.0.key" "undecoded.array.1.key" "undecoded.inner.key" "undecoded.key"]`
+
+	err := NewDecoder(bytes.NewReader([]byte(input))).Strict(true).Decode(&doc)
+	if err == nil {
+		t.Error("expected error, got none")
+	} else if err.Error() != expected {
+		t.Errorf("expect err: %s, got: %s", expected, err.Error())
+	}
+
+	t.Log("default")
+	if err := NewDecoder(bytes.NewReader([]byte(input))).Decode(&doc); err != nil {
+		t.Errorf("unexpected err: %s", err)
+	}
+
+	t.Log("map")
+	var m map[string]interface{}
+	if err := NewDecoder(bytes.NewReader([]byte(input))).Decode(&m); err != nil {
+		t.Errorf("unexpected err: %s", err)
+	}
+}


### PR DESCRIPTION
This PR adds strict mode to the Decoder. It can be enabled with the
`Strict` method.

In the strict mode, the decoder fails if any fields that were part
of the input do not have a corresponding field in the struct.

The decoder only modifies the visitor state in case strict mode is enabled.
Thus, not forcing unnecessary allocations, when not needed.