### PR TITLE
add support of mixed-type array

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -395,7 +395,7 @@ func (e *Encoder) valueToTree(mtype reflect.Type, mval reflect.Value) (*Tree, er
 				return nil, err
 			}
 			if e.quoteMapKeys {
-				keyStr, err := tomlValueStringRepresentation(key.String(), "", "", e.arraysOneElementPerLine)
+				keyStr, err := tomlValueStringRepresentation(key.String(), "", "", OrderPreserve, e.arraysOneElementPerLine)
 				if err != nil {
 					return nil, err
 				}
@@ -423,9 +423,6 @@ func (e *Encoder) valueToTreeSlice(mtype reflect.Type, mval reflect.Value) ([]*T
 
 // Convert given marshal slice to slice of toml values
 func (e *Encoder) valueToOtherSlice(mtype reflect.Type, mval reflect.Value) (interface{}, error) {
-	if mtype.Elem().Kind() == reflect.Interface {
-		return nil, fmt.Errorf("marshal can't handle []interface{}")
-	}
 	tval := make([]interface{}, mval.Len(), mval.Len())
 	for i := 0; i < mval.Len(); i++ {
 		val, err := e.valueToToml(mtype.Elem(), mval.Index(i))

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -2695,10 +2695,6 @@ func TestMarshalInterface(t *testing.T) {
 		InterfacePointerField *interface{}
 	}
 
-	type ShouldNotSupportStruct struct {
-		InterfaceArray []interface{}
-	}
-
 	expected := []byte(`ArrayField = [1,2,3]
 InterfacePointerField = "hello world"
 PrimitiveField = "string"
@@ -2748,11 +2744,6 @@ PrimitiveField = "string"
 		}
 	} else {
 		t.Fatal(err)
-	}
-
-	// according to the toml standard, data types of array may not be mixed
-	if _, err := Marshal(ShouldNotSupportStruct{[]interface{}{1, "a", true}}); err == nil {
-		t.Errorf("Should not support []interface{} marshaling")
 	}
 }
 
@@ -3051,4 +3042,75 @@ func TestUnmarshalSliceFail2(t *testing.T) {
 		t.Error("expect err:(1, 1): Can't convert 1(int64) to string but got ", err)
 	}
 
+}
+
+func TestMarshalMixedTypeArray(t *testing.T) {
+	type InnerStruct struct {
+		IntField int
+		StrField string
+	}
+
+	type TestStruct struct {
+		ArrayField []interface{}
+	}
+
+	expected := []byte(`ArrayField = [3.14,100,true,"hello world",{IntField = 100,StrField = "inner1"},[{IntField = 200,StrField = "inner2"},{IntField = 300,StrField = "inner3"}]]
+`)
+
+	if result, err := Marshal(TestStruct{
+		ArrayField:[]interface{}{
+			3.14,
+			100,
+			true,
+			"hello world",
+			InnerStruct{
+				IntField:100,
+				StrField:"inner1",
+			},
+			[]InnerStruct{
+				{IntField:200,StrField:"inner2"},
+				{IntField:300,StrField:"inner3"},
+			},
+		},
+	}); err == nil {
+		if !bytes.Equal(result, expected) {
+			t.Errorf("Bad marshal: expected\n----\n%s\n----\ngot\n----\n%s\n----\n", expected, result)
+		}
+	} else {
+		t.Fatal(err)
+	}
+}
+
+func TestUnmarshalMixedTypeArray(t *testing.T) {
+	type TestStruct struct {
+		ArrayField []interface{}
+	}
+
+	toml := []byte(`ArrayField = [3.14,100,true,"hello world",{Field = "inner1"},[{Field = "inner2"},{Field = "inner3"}]]
+`)
+
+	actual := TestStruct{}
+	expected := TestStruct{
+		ArrayField:[]interface{}{
+			3.14,
+			int64(100),
+			true,
+			"hello world",
+			map[string]interface{}{
+				"Field":"inner1",
+			},
+			[]map[string]interface{}{
+				{"Field":"inner2"},
+				{"Field":"inner3"},
+			},
+		},
+	}
+
+	if err := Unmarshal(toml, &actual); err == nil {
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("Bad unmarshal: expected %#v, got %#v", expected, actual)
+		}
+	} else {
+		t.Fatal(err)
+	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -486,18 +486,6 @@ func TestNestedEmptyArrays(t *testing.T) {
 	})
 }
 
-func TestArrayMixedTypes(t *testing.T) {
-	_, err := Load("a = [42, 16.0]")
-	if err.Error() != "(1, 10): mixed types in array" {
-		t.Error("Bad error message:", err.Error())
-	}
-
-	_, err = Load("a = [42, \"hello\"]")
-	if err.Error() != "(1, 11): mixed types in array" {
-		t.Error("Bad error message:", err.Error())
-	}
-}
-
 func TestArrayNestedStrings(t *testing.T) {
 	tree, err := Load("data = [ [\"gamma\", \"delta\"], [\"Foo\"] ]")
 	assertTree(t, tree, err, map[string]interface{}{
@@ -906,7 +894,7 @@ func TestTomlValueStringRepresentation(t *testing.T) {
 			"[\"gamma\",\"delta\"]"},
 		{nil, ""},
 	} {
-		result, err := tomlValueStringRepresentation(item.Value, "", "", false)
+		result, err := tomlValueStringRepresentation(item.Value, "", "", OrderPreserve, false)
 		if err != nil {
 			t.Errorf("Test %d - unexpected error: %s", idx, err)
 		}

--- a/toml_testgen_test.go
+++ b/toml_testgen_test.go
@@ -5,21 +5,6 @@ import (
 	"testing"
 )
 
-func TestInvalidArrayMixedTypesArraysAndInts(t *testing.T) {
-	input := `arrays-and-ints =  [1, ["Arrays are not integers."]]`
-	testgenInvalid(t, input)
-}
-
-func TestInvalidArrayMixedTypesIntsAndFloats(t *testing.T) {
-	input := `ints-and-floats = [1, 1.1]`
-	testgenInvalid(t, input)
-}
-
-func TestInvalidArrayMixedTypesStringsAndInts(t *testing.T) {
-	input := `strings-and-ints = ["hi", 42]`
-	testgenInvalid(t, input)
-}
-
 func TestInvalidDatetimeMalformedNoLeads(t *testing.T) {
 	input := `no-leads = 1987-7-05T17:45:00Z`
 	testgenInvalid(t, input)


### PR DESCRIPTION
**Issue:** #357 

This pr adds support of mixed-type array as the spec(v1.0.0) describes:

> Values of different types may be mixed.
> ```toml
> # Mixed-type arrays are allowed
> numbers = [ 0.1, 0.2, 0.5, 1, 2, 5 ]
> contributors = [
>  "Foo Bar <foo@example.com>",
>   { name = "Baz Qux", email = "bazqux@example.com", url = "https://example.com/bazqux" }
> ]
>```