### PR TITLE
forbid adding keys to exist inline table

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -703,6 +703,34 @@ func TestInlineTableTrailingComma(t *testing.T) {
 	}
 }
 
+func TestAddKeyToInlineTable(t *testing.T) {
+	_, err := Load("type = { name = \"Nail\" }\ntype.edible = false")
+	if err.Error() != "(2, 1): could not add key or sub-table to exist inline table or its sub-table : type" {
+		t.Error("Bad error message:", err.Error())
+	}
+}
+
+func TestAddSubTableToInlineTable(t *testing.T) {
+	_, err := Load("a = { b = \"c\" }\na.d.e = \"f\"")
+	if err.Error() != "(2, 1): could not add key or sub-table to exist inline table or its sub-table : a.d" {
+		t.Error("Bad error message:", err.Error())
+	}
+}
+
+func TestAddKeyToSubTableOfInlineTable(t *testing.T) {
+	_, err := Load("a = { b = { c = \"d\" } }\na.b.e = \"f\"")
+	if err.Error() != "(2, 1): could not add key or sub-table to exist inline table or its sub-table : a.b" {
+		t.Error("Bad error message:", err.Error())
+	}
+}
+
+func TestReDefineInlineTable(t *testing.T) {
+	_, err := Load("a = { b = \"c\" }\n[a]\n  d = \"e\"")
+	if err.Error() != "(2, 2): could not re-define exist inline table or its sub-table : a" {
+		t.Error("Bad error message:", err.Error())
+	}
+}
+
 func TestDuplicateGroups(t *testing.T) {
 	_, err := Load("[foo]\na=2\n[foo]b=3")
 	if err.Error() != "(3, 2): duplicated tables" {

--- a/toml.go
+++ b/toml.go
@@ -23,6 +23,7 @@ type Tree struct {
 	values    map[string]interface{} // string -> *tomlValue, *Tree, []*Tree
 	comment   string
 	commented bool
+	inline    bool
 	position  Position
 }
 
@@ -311,6 +312,7 @@ func (t *Tree) createSubTree(keys []string, pos Position) error {
 		if !exists {
 			tree := newTreeWithPosition(Position{Line: t.position.Line + i, Col: t.position.Col})
 			tree.position = pos
+			tree.inline = subtree.inline
 			subtree.values[intermediateKey] = tree
 			nextTree = tree
 		}


### PR DESCRIPTION
As the spec describes:

> Inline tables fully define the keys and sub-tables within them. New keys and sub-tables cannot be added to them.

> ```toml
> [product]
> type = { name = "Nail" }
> # type.edible = false  # INVALID
> ```
> Similarly, inline tables can not be used to add keys or sub-tables to an already-defined table.

> ```toml
> [product]
> type.name = "Nail"
> # type = { edible = false }  # INVALID
> ```

The inline table should not be allowed to add new keys.