### PR TITLE
Fix unmarshaler error when a custom marshaler function is defined

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -91,7 +91,7 @@ func isPrimitive(mtype reflect.Type) bool {
 	case reflect.String:
 		return true
 	case reflect.Struct:
-		return isTimeType(mtype) || isCustomMarshaler(mtype) || isTextMarshaler(mtype)
+		return isTimeType(mtype)
 	default:
 		return false
 	}
@@ -108,6 +108,30 @@ func isTreeSequence(mtype reflect.Type) bool {
 		return isTreeSequence(mtype.Elem())
 	case reflect.Slice, reflect.Array:
 		return isTree(mtype.Elem())
+	default:
+		return false
+	}
+}
+
+// Check if the given marshal type maps to a slice or array of a custom marshaler type
+func isCustomMarshalerSequence(mtype reflect.Type) bool {
+	switch mtype.Kind() {
+	case reflect.Ptr:
+		return isCustomMarshalerSequence(mtype.Elem())
+	case reflect.Slice, reflect.Array:
+		return isCustomMarshaler(mtype.Elem()) || isCustomMarshaler(reflect.New(mtype.Elem()).Type())
+	default:
+		return false
+	}
+}
+
+// Check if the given marshal type maps to a slice or array of a text marshaler type
+func isTextMarshalerSequence(mtype reflect.Type) bool {
+	switch mtype.Kind() {
+	case reflect.Ptr:
+		return isTextMarshalerSequence(mtype.Elem())
+	case reflect.Slice, reflect.Array:
+		return isTextMarshaler(mtype.Elem()) || isTextMarshaler(reflect.New(mtype.Elem()).Type())
 	default:
 		return false
 	}
@@ -477,10 +501,10 @@ func (e *Encoder) valueToToml(mtype reflect.Type, mval reflect.Value) (interface
 		return callTextMarshaler(mval)
 	case isTree(mtype):
 		return e.valueToTree(mtype, mval)
+	case isOtherSequence(mtype), isCustomMarshalerSequence(mtype), isTextMarshalerSequence(mtype):
+		return e.valueToOtherSlice(mtype, mval)
 	case isTreeSequence(mtype):
 		return e.valueToTreeSlice(mtype, mval)
-	case isOtherSequence(mtype):
-		return e.valueToOtherSlice(mtype, mval)
 	default:
 		switch mtype.Kind() {
 		case reflect.Bool:

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1037,6 +1037,30 @@ stranger = "hidden"
 	}
 }
 
+func TestPointerCustomMarshalerSequence(t *testing.T) {
+	var customPointerMarshalerSlice *[]*customPointerMarshaler
+	var customPointerMarshalerArray *[2]*customPointerMarshaler
+
+	if !isCustomMarshalerSequence(reflect.TypeOf(customPointerMarshalerSlice)) {
+		t.Errorf("error: should be a sequence of custom marshaler interfaces")
+	}
+	if !isCustomMarshalerSequence(reflect.TypeOf(customPointerMarshalerArray)) {
+		t.Errorf("error: should be a sequence of custom marshaler interfaces")
+	}
+}
+
+func TestPointerTextMarshalerSequence(t *testing.T) {
+	var textPointerMarshalerSlice *[]*textPointerMarshaler
+	var textPointerMarshalerArray *[2]*textPointerMarshaler
+
+	if !isTextMarshalerSequence(reflect.TypeOf(textPointerMarshalerSlice)) {
+		t.Errorf("error: should be a sequence of text marshaler interfaces")
+	}
+	if !isTextMarshalerSequence(reflect.TypeOf(textPointerMarshalerArray)) {
+		t.Errorf("error: should be a sequence of text marshaler interfaces")
+	}
+}
+
 var commentTestToml = []byte(`
 # it's a comment on type
 [postgres]


### PR DESCRIPTION
This PR fixes an unmarshaling error when a custom marshaler function is defined.

Fixes #382.