### PR TITLE
Prevent automatic conversion between int and float when unmarshaling

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -916,7 +916,7 @@ func (d *Decoder) valueFromToml(mtype reflect.Type, tval interface{}, mval1 *ref
 				}
 				return reflect.ValueOf(d), nil
 			}
-			if !val.Type().ConvertibleTo(mtype) {
+			if !val.Type().ConvertibleTo(mtype) || val.Kind() == reflect.Float64 {
 				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to %v", tval, tval, mtype.String())
 			}
 			if reflect.Indirect(reflect.New(mtype)).OverflowInt(val.Convert(mtype).Int()) {
@@ -926,7 +926,7 @@ func (d *Decoder) valueFromToml(mtype reflect.Type, tval interface{}, mval1 *ref
 			return val.Convert(mtype), nil
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 			val := reflect.ValueOf(tval)
-			if !val.Type().ConvertibleTo(mtype) {
+			if !val.Type().ConvertibleTo(mtype) || val.Kind() == reflect.Float64 {
 				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to %v", tval, tval, mtype.String())
 			}
 
@@ -940,7 +940,7 @@ func (d *Decoder) valueFromToml(mtype reflect.Type, tval interface{}, mval1 *ref
 			return val.Convert(mtype), nil
 		case reflect.Float32, reflect.Float64:
 			val := reflect.ValueOf(tval)
-			if !val.Type().ConvertibleTo(mtype) {
+			if !val.Type().ConvertibleTo(mtype) || val.Kind() == reflect.Int64 {
 				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to %v", tval, tval, mtype.String())
 			}
 			if reflect.Indirect(reflect.New(mtype)).OverflowFloat(val.Convert(mtype).Float()) {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -1989,6 +1989,42 @@ func TestUnmarshalCamelCaseKey(t *testing.T) {
 	}
 }
 
+func TestUnmarshalNegativeUint(t *testing.T) {
+	type check struct{ U uint }
+
+	tree, _ := Load("u = -1")
+	err := tree.Unmarshal(&check{})
+	if err.Error() != "(1, 1): -1(int64) is negative so does not fit in uint" {
+		t.Error("expect err:(1, 1): -1(int64) is negative so does not fit in uint but got:", err)
+	}
+}
+
+func TestUnmarshalCheckConversionFloatInt(t *testing.T) {
+	type conversionCheck struct {
+		U uint
+		I int
+		F float64
+	}
+
+	treeU, _ := Load("u = 1e300")
+	treeI, _ := Load("i = 1e300")
+	treeF, _ := Load("f = 9223372036854775806")
+
+	errU := treeU.Unmarshal(&conversionCheck{})
+	errI := treeI.Unmarshal(&conversionCheck{})
+	errF := treeF.Unmarshal(&conversionCheck{})
+
+	if errU.Error() != "(1, 1): Can't convert 1e+300(float64) to uint" {
+		t.Error("expect err:(1, 1): Can't convert 1e+300(float64) to uint but got:", errU)
+	}
+	if errI.Error() != "(1, 1): Can't convert 1e+300(float64) to int" {
+		t.Error("expect err:(1, 1): Can't convert 1e+300(float64) to int but got:", errI)
+	}
+	if errF.Error() != "(1, 1): Can't convert 9223372036854775806(int64) to float64" {
+		t.Error("expect err:(1, 1): Can't convert 9223372036854775806(int64) to float64 but got:", errF)
+	}
+}
+
 func TestUnmarshalDefault(t *testing.T) {
 	type EmbeddedStruct struct {
 		StringField string `default:"c"`
@@ -2258,7 +2294,7 @@ func TestUnmarshalPreservesUnexportedFields(t *testing.T) {
 
 	[[slice1]]
 	exported1 = "visible3"
-	
+
 	[[slice1]]
 	exported1 = "visible4"
 


### PR DESCRIPTION
This PR prevents automatic conversion between int and float when unmarshaling.

Fixes #389.