### PR TITLE
Fix marshaling nested arrays of tables

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -367,7 +367,7 @@ func (e *Encoder) PromoteAnonymous(promote bool) *Encoder {
 func (e *Encoder) marshal(v interface{}) ([]byte, error) {
 	// Check if indentation is valid
 	for _, char := range e.indentation {
-		if !(char == ' ' || char == '\t') {
+		if !isSpace(char) {
 			return []byte{}, fmt.Errorf("invalid indentation: must only contains space or tab characters")
 		}
 	}
@@ -475,7 +475,7 @@ func (e *Encoder) valueToTree(mtype reflect.Type, mval reflect.Value) (*Tree, er
 				return nil, err
 			}
 			if e.quoteMapKeys {
-				keyStr, err := tomlValueStringRepresentation(key.String(), "", "", OrderPreserve, e.arraysOneElementPerLine)
+				keyStr, err := tomlValueStringRepresentation(key.String(), "", "", e.order, e.arraysOneElementPerLine)
 				if err != nil {
 					return nil, err
 				}

--- a/parser_test.go
+++ b/parser_test.go
@@ -919,10 +919,10 @@ func TestTomlValueStringRepresentation(t *testing.T) {
 		{"\b\t\n\f\r\"\\", "\"\\b\\t\\n\\f\\r\\\"\\\\\""},
 		{"\x05", "\"\\u0005\""},
 		{time.Date(1979, time.May, 27, 7, 32, 0, 0, time.UTC), "1979-05-27T07:32:00Z"},
-		{[]interface{}{"gamma", "delta"}, "[\"gamma\",\"delta\"]"},
+		{[]interface{}{"gamma", "delta"}, "[\"gamma\", \"delta\"]"},
 		{nil, ""},
 	} {
-		result, err := tomlValueStringRepresentation(item.Value, "", "", OrderPreserve, false)
+		result, err := tomlValueStringRepresentation(item.Value, "", "", OrderAlphabetical, false)
 		if err != nil {
 			t.Errorf("Test %d - unexpected error: %s", idx, err)
 		}

--- a/tomltree_create_test.go
+++ b/tomltree_create_test.go
@@ -105,7 +105,7 @@ func TestTreeCreateToTreeInvalidTableGroupType(t *testing.T) {
 }
 
 func TestRoundTripArrayOfTables(t *testing.T) {
-	orig := "\n[[stuff]]\n  name = \"foo\"\n  things = [\"a\",\"b\"]\n"
+	orig := "\n[[stuff]]\n  name = \"foo\"\n  things = [\"a\", \"b\"]\n"
 	tree, err := Load(orig)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -105,7 +105,6 @@ func encodeTomlString(value string) string {
 
 func tomlTreeStringRepresentation(t *Tree, ord marshalOrder) (string, error) {
 	var orderedVals []sortNode
-
 	switch ord {
 	case OrderPreserve:
 		orderedVals = sortByLines(t)
@@ -113,29 +112,18 @@ func tomlTreeStringRepresentation(t *Tree, ord marshalOrder) (string, error) {
 		orderedVals = sortAlphabetical(t)
 	}
 
-	stringBuffer := bytes.Buffer{}
-	stringBuffer.WriteString(`{`)
-	first := true
-	for i := range orderedVals {
-		v := t.values[orderedVals[i].key]
-		quotedKey := quoteKeyIfNeeded(orderedVals[i].key)
-		valueStr, err := tomlValueStringRepresentation(v, "", "", ord, false)
+	var values []string
+	for _, node := range orderedVals {
+		k := node.key
+		v := t.values[k]
+
+		repr, err := tomlValueStringRepresentation(v, "", "", ord, false)
 		if err != nil {
 			return "", err
 		}
-		if first {
-			first = false
-		} else {
-			stringBuffer.WriteString(`,`)
-		}
-
-		stringBuffer.WriteString(quotedKey)
-		stringBuffer.WriteString(" = ")
-		stringBuffer.WriteString(valueStr)
+		values = append(values, quoteKeyIfNeeded(k)+" = "+repr)
 	}
-	stringBuffer.WriteString(`}`)
-
-	return stringBuffer.String(), nil
+	return "{ " + strings.Join(values, ", ") + " }", nil
 }
 
 func tomlValueStringRepresentation(v interface{}, commented string, indent string, ord marshalOrder, arraysOneElementPerLine bool) (string, error) {
@@ -224,7 +212,7 @@ func tomlValueStringRepresentation(v interface{}, commented string, indent strin
 
 			return stringBuffer.String(), nil
 		}
-		return "[" + strings.Join(values, ",") + "]", nil
+		return "[" + strings.Join(values, ", ") + "]", nil
 	}
 	return "", fmt.Errorf("unsupported value type %T: %v", v, v)
 }


### PR DESCRIPTION
This PR fixes marshaling for nested arrays of tables by adding support for inline tables.

Fixes #369.

