### PR TITLE
Allow spaces when using dotted keys in assignment

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -330,7 +330,26 @@ func (l *tomlLexer) lexKey() tomlLexStateFn {
 		} else if r == '\n' {
 			return l.errorf("keys cannot contain new lines")
 		} else if isSpace(r) {
-			break
+			str := " "
+			// skip trailing whitespace
+			l.next()
+			for r = l.peek(); isSpace(r); r = l.peek() {
+				str += string(r)
+				l.next()
+			}
+			// break loop if not a dot
+			if r != '.' {
+				break
+			}
+			str += "."
+			// skip trailing whitespace after dot
+			l.next()
+			for r = l.peek(); isSpace(r); r = l.peek() {
+				str += string(r)
+				l.next()
+			}
+			growingString += str
+			continue
 		} else if r == '.' {
 			// skip
 		} else if !isValidBareChar(r) {

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -22,20 +22,20 @@ func TestValidKeyGroup(t *testing.T) {
 }
 
 func TestNestedQuotedUnicodeKeyGroup(t *testing.T) {
-	testFlow(t, `[ j . "ʞ" . 'l' ]`, []token{
+	testFlow(t, `[ j . "ʞ" . l . 'ɯ' ]`, []token{
 		{Position{1, 1}, tokenLeftBracket, "["},
-		{Position{1, 2}, tokenKeyGroup, ` j . "ʞ" . 'l' `},
-		{Position{1, 17}, tokenRightBracket, "]"},
-		{Position{1, 18}, tokenEOF, ""},
+		{Position{1, 2}, tokenKeyGroup, ` j . "ʞ" . l . 'ɯ' `},
+		{Position{1, 21}, tokenRightBracket, "]"},
+		{Position{1, 22}, tokenEOF, ""},
 	})
 }
 
 func TestNestedQuotedUnicodeKeyAssign(t *testing.T) {
-	testFlow(t, ` j . "ʞ" . 'l' = 3`, []token{
-		{Position{1, 2}, tokenKey, `j . "ʞ" . 'l'`},
-		{Position{1, 16}, tokenEqual, "="},
-		{Position{1, 18}, tokenInteger, "3"},
-		{Position{1, 19}, tokenEOF, ""},
+	testFlow(t, ` j . "ʞ" . l . 'ɯ' = 3`, []token{
+		{Position{1, 2}, tokenKey, `j . "ʞ" . l . 'ɯ'`},
+		{Position{1, 20}, tokenEqual, "="},
+		{Position{1, 22}, tokenInteger, "3"},
+		{Position{1, 23}, tokenEOF, ""},
 	})
 }
 

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -8,7 +8,7 @@ import (
 func testFlow(t *testing.T, input string, expectedFlow []token) {
 	tokens := lexToml([]byte(input))
 	if !reflect.DeepEqual(tokens, expectedFlow) {
-		t.Fatal("Different flows. Expected\n", expectedFlow, "\nGot:\n", tokens)
+		t.Fatalf("Different flows.\nExpected:\n%v\nGot:\n%v", expectedFlow, tokens)
 	}
 }
 
@@ -22,11 +22,20 @@ func TestValidKeyGroup(t *testing.T) {
 }
 
 func TestNestedQuotedUnicodeKeyGroup(t *testing.T) {
-	testFlow(t, `[ j . "ʞ" . l ]`, []token{
+	testFlow(t, `[ j . "ʞ" . 'l' ]`, []token{
 		{Position{1, 1}, tokenLeftBracket, "["},
-		{Position{1, 2}, tokenKeyGroup, ` j . "ʞ" . l `},
-		{Position{1, 15}, tokenRightBracket, "]"},
-		{Position{1, 16}, tokenEOF, ""},
+		{Position{1, 2}, tokenKeyGroup, ` j . "ʞ" . 'l' `},
+		{Position{1, 17}, tokenRightBracket, "]"},
+		{Position{1, 18}, tokenEOF, ""},
+	})
+}
+
+func TestNestedQuotedUnicodeKeyAssign(t *testing.T) {
+	testFlow(t, ` j . "ʞ" . 'l' = 3`, []token{
+		{Position{1, 2}, tokenKey, `j . "ʞ" . 'l'`},
+		{Position{1, 16}, tokenEqual, "="},
+		{Position{1, 18}, tokenInteger, "3"},
+		{Position{1, 19}, tokenEOF, ""},
 	})
 }
 


### PR DESCRIPTION
This PR fixes an issue where spaces are not allowed in assignment when using dotted keys.

Fixes #401.