### PR TITLE
Restore test for accidental whitespaces

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1125,9 +1125,9 @@ The quick brown \
     the lazy dog."""
 
 str3 = """\
-       The quick brown \
-       fox jumps over \
-       the lazy dog.\
+       The quick brown \` + "   " + `
+       fox jumps over \` + "   " + `
+       the lazy dog.\` + "   " + `
 	   """`)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
The last PR (#381) modified an important test (#319) for accidental whitespaces after a line ending backslash in multi-line string, due to the automatic trimming of trailing whitespaces feature in my VS Code editor.

I have modified the test by visually adding whitespaces to avoid this in the future. 
