### PR TITLE
Fix TreeFromMap on list of interfaces

### DIFF
--- a/tomltree_create.go
+++ b/tomltree_create.go
@@ -57,6 +57,19 @@ func simpleValueCoercion(object interface{}) (interface{}, error) {
 		return float64(original), nil
 	case fmt.Stringer:
 		return original.String(), nil
+	case []interface{}:
+		value := reflect.ValueOf(original)
+		length := value.Len()
+		arrayValue := reflect.MakeSlice(value.Type(), 0, length)
+		for i := 0; i < length; i++ {
+			val := value.Index(i).Interface()
+			simpleValue, err := simpleValueCoercion(val)
+			if err != nil {
+				return nil, err
+			}
+			arrayValue = reflect.Append(arrayValue, reflect.ValueOf(simpleValue))
+		}
+		return arrayValue.Interface(), nil
 	default:
 		return nil, fmt.Errorf("cannot convert type %T to Tree", object)
 	}


### PR DESCRIPTION
**Issue:** add link to pelletier/go-toml issue here
#415
Explanation of what this pull request does.
Make TreeFromMap work when the value of map contains []interface{}
```

func TestTomlSliceOfSlice(t *testing.T) {
	tree, err := Load(` hosts=[["10.1.0.107:9092","10.1.0.107:9093", "192.168.0.40:9094"] ] `)
	m := tree.ToMap()
	tree, err = TreeFromMap(m)
	if err != nil {
		t.Error("should not error", err)
	}
	type Struct struct {
		Hosts [][]string
	}
	var actual Struct
	tree.Unmarshal(&actual)

	expected := Struct{Hosts: [][]string{[]string{"10.1.0.107:9092", "10.1.0.107:9093", "192.168.0.40:9094"}}}

	if !reflect.DeepEqual(actual, expected) {
		t.Errorf("Bad unmarshal: expected %+v, got %+v", expected, actual)
	}
}
```
 
