### PR TITLE
Fix index exception when setting empty *Tree slice

### DIFF
--- a/toml.go
+++ b/toml.go
@@ -295,7 +295,8 @@ func (t *Tree) SetPathWithOptions(keys []string, opts SetOptions, value interfac
 			// go to most recent element
 			if len(node) == 0 {
 				// create element if it does not exist
-				subtree.values[intermediateKey] = append(node, newTreeWithPosition(Position{Line: t.position.Line + i, Col: t.position.Col}))
+				node = append(node, newTreeWithPosition(Position{Line: t.position.Line + i, Col: t.position.Col}))
+				subtree.values[intermediateKey] = node
 			}
 			subtree = node[len(node)-1]
 		}


### PR DESCRIPTION
When `len(node) == 0`, we can't lookup `node[len(node)-1]` unless `node` includes the newly added tree.

Example: https://play.golang.org/p/voNBW4QfRxy
Note that it works if the first key is populated: https://play.golang.org/p/8Ak-pPXVyPa

I wasn't able to use `*Tree.SetPath` to construct arbitrary TOML that works when `toml.OrderPreserve` is set.
For example: https://play.golang.org/p/Lns42AVkEcT
So I'm not sure if this fix covers a supported use case, or if logic should be removed instead.