### PR TITLE
Add *Tree.SetPositionPath

### DIFF
--- a/toml.go
+++ b/toml.go
@@ -213,6 +213,50 @@ func (t *Tree) GetPosition(key string) Position {
 	return t.GetPositionPath(strings.Split(key, "."))
 }
 
+// SetPositionPath sets the position of element in the tree indicated by 'keys'.
+// If keys is of length zero, the current tree position is set.
+func (t *Tree) SetPositionPath(keys []string, pos Position) {
+	if len(keys) == 0 {
+		t.position = pos
+		return
+	}
+	subtree := t
+	for _, intermediateKey := range keys[:len(keys)-1] {
+		value, exists := subtree.values[intermediateKey]
+		if !exists {
+			return
+		}
+		switch node := value.(type) {
+		case *Tree:
+			subtree = node
+		case []*Tree:
+			// go to most recent element
+			if len(node) == 0 {
+				return
+			}
+			subtree = node[len(node)-1]
+		default:
+			return
+		}
+	}
+	// branch based on final node type
+	switch node := subtree.values[keys[len(keys)-1]].(type) {
+	case *tomlValue:
+		node.position = pos
+		return
+	case *Tree:
+		node.position = pos
+		return
+	case []*Tree:
+		// go to most recent element
+		if len(node) == 0 {
+			return
+		}
+		node[len(node)-1].position = pos
+		return
+	}
+}
+
 // GetPositionPath returns the element in the tree indicated by 'keys'.
 // If keys is of length zero, the current tree is returned.
 func (t *Tree) GetPositionPath(keys []string) Position {


### PR DESCRIPTION
I needed to add this function to support generating arbitrary, ordered TOML from other data serialization formats in [yj](https://github.com/sclevine/yj/).

`*Tree.SetPath` does not set `Position`s correctly when other `*Tree`s are used as values. This makes the `Encoder` behave strangely when `OrderPreserve` is set: https://play.golang.org/p/Lns42AVkEcT

Additionally, `*Tree.SetPath` doesn't appear to be sufficient to generate arbitrary TOML when `*Tree` values are not used. For example, there doesn't appear to be a way to append tables to a list.

Adding this method seems to be all that's necessary to allow arbitrary, ordered TOML to be generated, which seems useful.
