### PR TITLE
Fix lexer allow T-prefix on local dates

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -772,8 +772,6 @@ func init() {
 	// Group 1: nano precision
 	// Group 2: timezone
 	//
-	// /!\ also matches the empty string
-	//
 	// Example matches:
 	// 1979-05-27T07:32:00Z
 	// 1979-05-27T00:32:00-07:00
@@ -788,7 +786,7 @@ func init() {
 	// 1979-05-27
 	// 07:32:00
 	// 00:32:00.999999
-	dateRegexp = regexp.MustCompile(`^(?:\d{4}-\d{2}-\d{2})?(?:[T ]?\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})?)?`)
+	dateRegexp = regexp.MustCompile(`^(?:\d{4}-\d{2}-\d{2}[T\s]?)?(?:\d{2}:\d{2}:\d{2}(\.\d{1,9})?(Z|[+-]\d{2}:\d{2})?)?`)
 }
 
 // Entry point

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -317,6 +317,7 @@ func TestDateRegexp(t *testing.T) {
 		"err:date-1year":      "9-05-27",
 		"err:date-2year":      "79-05-27",
 		"err:date-3year":      "979-05-27",
+		"err:date-T-prefix":   "T07:32:00",
 	}
 
 	for name, value := range cases {
@@ -355,6 +356,24 @@ func TestKeyEqualDate(t *testing.T) {
 		{Position{1, 5}, tokenEqual, "="},
 		{Position{1, 7}, tokenDate, "1979-05-27 07:32:00Z"},
 		{Position{1, 27}, tokenEOF, ""},
+	})
+	testFlow(t, "foo = 07:32:00", []token{
+		{Position{1, 1}, tokenKey, "foo"},
+		{Position{1, 5}, tokenEqual, "="},
+		{Position{1, 7}, tokenLocalDate, "07:32:00"},
+		{Position{1, 15}, tokenEOF, ""},
+	})
+	testFlow(t, "foo = 07:32:00Z", []token{
+		{Position{1, 1}, tokenKey, "foo"},
+		{Position{1, 5}, tokenEqual, "="},
+		{Position{1, 7}, tokenDate, "07:32:00Z"},
+		{Position{1, 16}, tokenEOF, ""},
+	})
+	testFlow(t, "foo = 00:32:00.999999-07:00", []token{
+		{Position{1, 1}, tokenKey, "foo"},
+		{Position{1, 5}, tokenEqual, "="},
+		{Position{1, 7}, tokenDate, "00:32:00.999999-07:00"},
+		{Position{1, 28}, tokenEOF, ""},
 	})
 }
 


### PR DESCRIPTION
The dateRegex matched localDate with T, we should remove it.

Fix #442 
