### PR TITLE
Fix ToMap for tables in mixed-type arrays

### DIFF
--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -510,8 +510,27 @@ func (t *Tree) ToMap() map[string]interface{} {
 		case *Tree:
 			result[k] = node.ToMap()
 		case *tomlValue:
-			result[k] = node.value
+			result[k] = node.toValue()
 		}
 	}
 	return result
+}
+
+// toValue converts a tomlValue to a built-in Go type.
+func (t *tomlValue) toValue() interface{} {
+	switch v := t.value.(type) {
+	case []interface{}:
+		s := make([]interface{}, len(v))
+		for i := range s {
+			switch e := v[i].(type) {
+			case *Tree:
+				s[i] = e.ToMap()
+			default:
+				s[i] = e
+			}
+		}
+		return s
+	default:
+		return v
+	}
 }

--- a/tomltree_write_test.go
+++ b/tomltree_write_test.go
@@ -295,6 +295,21 @@ func TestTreeWriteToMapWithArrayOfInlineTables(t *testing.T) {
 	testMaps(t, treeMap, expected)
 }
 
+func TestTreeWriteToMapWithTableInMixedArray(t *testing.T) {
+	tree, _ := Load(`a = ["foo", {bar = "baz"}]`)
+	expected := map[string]interface{}{
+		"a": []interface{}{
+			"foo",
+			map[string]interface{}{
+				"bar": "baz",
+			},
+		},
+	}
+	treeMap := tree.ToMap()
+
+	testMaps(t, treeMap, expected)
+}
+
 func TestTreeWriteToFloat(t *testing.T) {
 	tree, err := Load(`a = 3.0`)
 	if err != nil {


### PR DESCRIPTION
ToMap doesn't convert tables to maps if they're inline tables in a mixed-type array.

```toml
a = ["foo", { bar = "baz" }]
```

Before this change, `ToMap` will return a map where the second element of the array `a` will be a `*toml.Tree` instead of a `map[string]interface{}`.