### PR TITLE
Fix ToMap for tables in nested mixed-type arrays

### DIFF
--- a/tomltree_write_test.go
+++ b/tomltree_write_test.go
@@ -296,12 +296,33 @@ func TestTreeWriteToMapWithArrayOfInlineTables(t *testing.T) {
 }
 
 func TestTreeWriteToMapWithTableInMixedArray(t *testing.T) {
-	tree, _ := Load(`a = ["foo", {bar = "baz"}]`)
+	tree, _ := Load(`a = [
+		"foo",
+		[
+			"bar",
+			{baz = "quux"},
+		],
+		[
+			{a = "b"},
+			{c = "d"},
+		],
+	]`)
 	expected := map[string]interface{}{
 		"a": []interface{}{
 			"foo",
-			map[string]interface{}{
-				"bar": "baz",
+			[]interface{}{
+				"bar",
+				map[string]interface{}{
+					"baz": "quux",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"a": "b",
+				},
+				map[string]interface{}{
+					"c": "d",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
I wasn't thorough enough in my earlier PR. #453 fixed tables in mixed arrays, but only in the top-level array, not in any nested array. This updated fix scans arrays recursively looking for tables. It supports constructs like this:

```toml
UglyValue = ["blah", [
    {foo = "bar"},
    {baz = "quux"},
]]
```
