### PR TITLE
Update docs to reference pkg.go.dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ improve the documentation. Fix a typo, clarify an interface, add an
 example, anything goes!
 
 The documentation is present in the [README][readme] and thorough the
-source code. On release, it gets updated on [GoDoc][godoc]. To make a
+source code. On release, it gets updated on [pkg.go.dev][pkg.go.dev]. To make a
 change to the documentation, create a pull request with your proposed
 changes. For simple changes like that, the easiest way to go is probably
 the "Fork this project and edit the file" button on Github, displayed at
@@ -123,7 +123,7 @@ Checklist:
 
 [issues-tracker]: https://github.com/pelletier/go-toml/issues
 [bug-report]: https://github.com/pelletier/go-toml/issues/new?template=bug_report.md
-[godoc]: https://godoc.org/github.com/pelletier/go-toml
+[pkg.go.dev]: https://pkg.go.dev/github.com/pelletier/go-toml
 [readme]: ./README.md
 [fork]: https://help.github.com/articles/fork-a-repo
 [pull-request]: https://help.github.com/en/articles/creating-a-pull-request

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Go library for the [TOML](https://toml.io/) format.
 This library supports TOML version
 [v1.0.0-rc.3](https://toml.io/en/v1.0.0-rc.3)
 
-[![GoDoc](https://godoc.org/github.com/pelletier/go-toml?status.svg)](http://godoc.org/github.com/pelletier/go-toml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/pelletier/go-toml.svg)](https://pkg.go.dev/github.com/pelletier/go-toml)
 [![license](https://img.shields.io/github/license/pelletier/go-toml.svg)](https://github.com/pelletier/go-toml/blob/master/LICENSE)
 [![Build Status](https://dev.azure.com/pelletierthomas/go-toml-ci/_apis/build/status/pelletier.go-toml?branchName=master)](https://dev.azure.com/pelletierthomas/go-toml-ci/_build/latest?definitionId=1&branchName=master)
 [![codecov](https://codecov.io/gh/pelletier/go-toml/branch/master/graph/badge.svg)](https://codecov.io/gh/pelletier/go-toml)
@@ -81,7 +81,7 @@ for ii, item := range results.Values() {
 ## Documentation
 
 The documentation and additional examples are available at
-[godoc.org](http://godoc.org/github.com/pelletier/go-toml).
+[pkg.go.dev](https://pkg.go.dev/github.com/pelletier/go-toml).
 
 ## Tools
 


### PR DESCRIPTION
godoc.org  is still alive. But requests are going to redirect to pkg.go.dev. 
This fixed to point to pkg.go.dev direct to reduce unneeded redirect.

Ref: https://blog.golang.org/godoc.org-redirect

