### PR TITLE
Expose MarshalOrder

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -57,12 +57,12 @@ var annotationDefault = annotation{
 	defaultValue: tagDefault,
 }
 
-type marshalOrder int
+type MarshalOrder int
 
 // Orders the Encoder can write the fields to the output stream.
 const (
 	// Sort fields alphabetically.
-	OrderAlphabetical marshalOrder = iota + 1
+	OrderAlphabetical MarshalOrder = iota + 1
 	// Preserve the order the fields are encountered. For example, the order of fields in
 	// a struct.
 	OrderPreserve
@@ -256,7 +256,7 @@ type Encoder struct {
 	annotation
 	line        int
 	col         int
-	order       marshalOrder
+	order       MarshalOrder
 	promoteAnon bool
 	indentation string
 }
@@ -317,7 +317,7 @@ func (e *Encoder) ArraysWithOneElementPerLine(v bool) *Encoder {
 }
 
 // Order allows to change in which order fields will be written to the output stream.
-func (e *Encoder) Order(ord marshalOrder) *Encoder {
+func (e *Encoder) Order(ord MarshalOrder) *Encoder {
 	e.order = ord
 	return e
 }

--- a/tomltree_write.go
+++ b/tomltree_write.go
@@ -103,7 +103,7 @@ func encodeTomlString(value string) string {
 	return b.String()
 }
 
-func tomlTreeStringRepresentation(t *Tree, ord marshalOrder) (string, error) {
+func tomlTreeStringRepresentation(t *Tree, ord MarshalOrder) (string, error) {
 	var orderedVals []sortNode
 	switch ord {
 	case OrderPreserve:
@@ -126,7 +126,7 @@ func tomlTreeStringRepresentation(t *Tree, ord marshalOrder) (string, error) {
 	return "{ " + strings.Join(values, ", ") + " }", nil
 }
 
-func tomlValueStringRepresentation(v interface{}, commented string, indent string, ord marshalOrder, arraysOneElementPerLine bool) (string, error) {
+func tomlValueStringRepresentation(v interface{}, commented string, indent string, ord MarshalOrder, arraysOneElementPerLine bool) (string, error) {
 	// this interface check is added to dereference the change made in the writeTo function.
 	// That change was made to allow this function to see formatting options.
 	tv, ok := v.(*tomlValue)
@@ -310,7 +310,7 @@ func (t *Tree) writeTo(w io.Writer, indent, keyspace string, bytesCount int64, a
 	return t.writeToOrdered(w, indent, keyspace, bytesCount, arraysOneElementPerLine, OrderAlphabetical, "  ", false)
 }
 
-func (t *Tree) writeToOrdered(w io.Writer, indent, keyspace string, bytesCount int64, arraysOneElementPerLine bool, ord marshalOrder, indentString string, parentCommented bool) (int64, error) {
+func (t *Tree) writeToOrdered(w io.Writer, indent, keyspace string, bytesCount int64, arraysOneElementPerLine bool, ord MarshalOrder, indentString string, parentCommented bool) (int64, error) {
 	var orderedVals []sortNode
 
 	switch ord {


### PR DESCRIPTION
It is needed as argument to some already public function.

Fixes #459
Ref #469
