### PR TITLE
Remove go-spew dependency

### DIFF
--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -1,7 +1,5 @@
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/pelletier/go-toml
 
 go 1.12
-
-require github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/parser_test.go
+++ b/parser_test.go
@@ -6,8 +6,6 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 func assertSubTree(t *testing.T, path []string, tree *Tree, err error, ref map[string]interface{}) {
@@ -39,7 +37,7 @@ func assertSubTree(t *testing.T, path []string, tree *Tree, err error, ref map[s
 }
 
 func assertTree(t *testing.T, tree *Tree, err error, ref map[string]interface{}) {
-	t.Log("Asserting tree:\n", spew.Sdump(tree))
+	t.Logf("Asserting tree:\n (%T)(%p)(%+v)", tree, tree, tree)
 	assertSubTree(t, []string{}, tree, err, ref)
 	t.Log("Finished tree assertion.")
 }

--- a/toml_testgen_support_test.go
+++ b/toml_testgen_support_test.go
@@ -8,8 +8,6 @@ import (
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 func testgenInvalid(t *testing.T, input string) {
@@ -56,7 +54,7 @@ func testgenValid(t *testing.T, input string, jsonRef string) {
 	}
 
 	if !reflect.DeepEqual(jsonExpected, jsonTest) {
-		t.Logf("Diff:\n%s", spew.Sdump(jsonExpected, jsonTest))
+		t.Logf("Diff:\n%#+v\n%#+v", jsonExpected, jsonTest)
 		t.Fatal("parsed TOML tree is different than expected structure")
 	}
 }


### PR DESCRIPTION
Removed the go-spew dependency since it's not really necessary. There were two places it was being used.

For parser_test I recreated the same form Sdump was outputting with pure fmt flags.

This was not possible for toml_testgen_support_test without reimplementing the functionality of go-spew, so I just did a basic, non-pretty dump. Personally, I think the non-pretty dump is better than prettying it up with json.MarshalIndent (which loses typing information but does not seem necessary). The reason for this is that it's easy to copy/redirect the terminal out to a file and visually compare the flattened lines to see when they stop being the same, this is much more difficult with pretty-printing as you have to jump back and forth etc. If you don't agree, I'm happy to change it to MarshalIndent.

For the original outputs vs the ones produced by the changes in this PR (and also the json.MarshalIndent version), see [here](https://gist.github.com/sapphire-janrain/fedff592624d9a31b1a163dbdc00ed8a). 
