### PR TITLE
Address golangci-lint warnings in unmarshal_imported_test.go

### DIFF
--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -177,7 +177,7 @@ type testDoc struct {
 	Subdocs     testDocSubs       `toml:"subdoc"`
 	Basics      testDocBasics     `toml:"basic"`
 	SubDocList  []testSubDoc      `toml:"subdoclist"`
-	err         int               `toml:"shouldntBeHere"`
+	err         int               `toml:"shouldntBeHere"` // nolint:structcheck,unused
 	unexported  int               `toml:"shouldntBeHere"`
 	Unexported2 int               `toml:"-"`
 }

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -668,6 +668,8 @@ func (m *textPointerMarshaler) MarshalText() ([]byte, error) {
 	return []byte("hidden"), nil
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var commentTestToml = []byte(`
 # it's a comment on type
 [postgres]

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -703,6 +703,8 @@ type mapsTestStruct struct {
 	}
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var mapsTestData = mapsTestStruct{
 	Simple: map[string]string{
 		"one plus one": "two",

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -858,6 +858,8 @@ type testDocBasicsCustomTag struct {
 	unexported int       `file:"shouldntBeHere"`
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,varcheck
 var testDocCustomTagData = testDocCustomTag{
 	Doc: testDocBasicsCustomTag{
 		Bool:       true,

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -743,6 +743,8 @@ var mapsTestToml = []byte(`
       "is.Nested" = true
 `)
 
+// TODO: Remove nolint once type is used by a test
+//nolint:deadcode,unused
 type structArrayNoTag struct {
 	A struct {
 		B []int64

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -264,6 +264,8 @@ var docData = testDoc{
 	SubDocPtrs: []*testSubDoc{&subdoc},
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var mapTestDoc = testMapDoc{
 	Title: "TOML Marshal Testing",
 	BasicMap: map[string]string{

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -961,8 +961,10 @@ type testBadDuration struct {
 	Val time.Duration `toml:"val"`
 }
 
-var testCamelCaseKeyToml = []byte(`fooBar = 10`)
+// TODO: add back camelCase test
+var testCamelCaseKeyToml = []byte(`fooBar = 10`) //nolint:unused
 
+//nolint:unused
 func TestUnmarshalCamelCaseKey(t *testing.T) {
 	t.Skipf("don't know if it is a good idea to automatically convert like that yet")
 	var x struct {

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -652,11 +652,14 @@ func (m *customPointerMarshaler) MarshalTOML() ([]byte, error) {
 	return []byte(`"hidden"`), nil
 }
 
+// TODO: Remove nolint once type and method are used by a test
+//nolint:unused
 type textPointerMarshaler struct {
 	FirstName string
 	LastName  string
 }
 
+//nolint:unused
 func (m *textPointerMarshaler) MarshalText() ([]byte, error) {
 	return []byte("hidden"), nil
 }

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -842,9 +842,12 @@ var testDocBasicToml = []byte(`
   uint_val = 5001
 `)
 
+// TODO: Remove nolint once type is used by a test
+//nolint:deadcode
 type testDocCustomTag struct {
 	Doc testDocBasicsCustomTag `file:"document"`
 }
+
 type testDocBasicsCustomTag struct {
 	Bool       bool      `file:"bool_val"`
 	Date       time.Time `file:"date_val"`

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -944,6 +944,8 @@ type testDuration struct {
 	AString   string         `toml:"a_string"`
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var testDurationToml = []byte(`
 nanosec = "1ns"
 microsec1 = "1us"

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -640,11 +640,14 @@ func (m precedentMarshaler) MarshalTOML() ([]byte, error) {
 	return []byte(fullName), nil
 }
 
+// TODO: Remove nolint once type and method are used by a test
+//nolint:unused
 type customPointerMarshaler struct {
 	FirstName string
 	LastName  string
 }
 
+//nolint:unused
 func (m *customPointerMarshaler) MarshalTOML() ([]byte, error) {
 	return []byte(`"hidden"`), nil
 }

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -752,6 +752,8 @@ type structArrayNoTag struct {
 	}
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var customTagTestToml = []byte(`
 [postgres]
   password = "bvalue"

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -574,6 +574,9 @@ func (c customMarshaler) MarshalTOML() ([]byte, error) {
 
 var customMarshalerData = customMarshaler{FirstName: "Sally", LastName: "Fields"}
 var customMarshalerToml = []byte(`Sally Fields`)
+
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var nestedCustomMarshalerData = customMarshalerParent{
 	Self:    customMarshaler{FirstName: "Maiku", LastName: "Suteda"},
 	Friends: []customMarshaler{customMarshalerData},

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -626,15 +626,19 @@ func TestUnmarshalTextMarshaler(t *testing.T) {
 	}
 }
 
+// TODO: Remove nolint once type and methods are used by a test
+//nolint:unused
 type precedentMarshaler struct {
 	FirstName string
 	LastName  string
 }
 
+//nolint:unused
 func (m precedentMarshaler) MarshalText() ([]byte, error) {
 	return []byte("shadowed"), nil
 }
 
+//nolint:unused
 func (m precedentMarshaler) MarshalTOML() ([]byte, error) {
 	fullName := fmt.Sprintf("%s %s", m.FirstName, m.LastName)
 	return []byte(fullName), nil

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -832,6 +832,8 @@ var customMultilineTagTestToml = []byte(`int_slice = [
 ]
 `)
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var testDocBasicToml = []byte(`
 [document]
   bool_val = true

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -848,6 +848,8 @@ type testDocCustomTag struct {
 	Doc testDocBasicsCustomTag `file:"document"`
 }
 
+// TODO: Remove nolint once type is used by a test
+//nolint:deadcode
 type testDocBasicsCustomTag struct {
 	Bool       bool      `file:"bool_val"`
 	Date       time.Time `file:"date_val"`

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -578,6 +578,9 @@ var nestedCustomMarshalerData = customMarshalerParent{
 	Self:    customMarshaler{FirstName: "Maiku", LastName: "Suteda"},
 	Friends: []customMarshaler{customMarshalerData},
 }
+
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var nestedCustomMarshalerToml = []byte(`friends = ["Sally Fields"]
 me = "Maiku Suteda"
 `)

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -956,6 +956,8 @@ mixed = "1h1m1s1ms1µs1ns"
 a_string = "15s"
 `)
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var testDurationToml2 = []byte(`a_string = "15s"
 hour = "1h0m0s"
 microsec1 = "1µs"

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -149,6 +149,8 @@ type quotedKeyMarshalTestStruct struct {
 	SubList []basicMarshalTestSubStruct `toml:"W.sublist-𝟘"`
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var quotedKeyMarshalTestData = quotedKeyMarshalTestStruct{
 	String:  "Hello",
 	Float:   3.5,

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -573,6 +573,9 @@ func (c customMarshaler) MarshalTOML() ([]byte, error) {
 }
 
 var customMarshalerData = customMarshaler{FirstName: "Sally", LastName: "Fields"}
+
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var customMarshalerToml = []byte(`Sally Fields`)
 
 // TODO: Remove nolint once var is used by a test

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -156,6 +156,8 @@ var quotedKeyMarshalTestData = quotedKeyMarshalTestStruct{
 	SubList: []basicMarshalTestSubStruct{{"Two"}, {"Three"}},
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var quotedKeyMarshalTestToml = []byte(`"Yfloat-𝟘" = 3.5
 "Z.string-àéù" = "Hello"
 

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -723,6 +723,9 @@ var mapsTestData = mapsTestStruct{
 		},
 	},
 }
+
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var mapsTestToml = []byte(`
 [Other]
   "testing" = 3.9999

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -775,6 +775,8 @@ var customCommentTagTestToml = []byte(`
   user = "avalue"
 `)
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var customCommentedTagTestToml = []byte(`
 [postgres]
   # password = "bvalue"

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -764,6 +764,8 @@ var customTagTestToml = []byte(`
     My = "Baar"
 `)
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var customCommentTagTestToml = []byte(`
 # db connection
 [postgres]

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -932,6 +932,8 @@ func TestUnmarshalInvalidPointerKind(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused
 type testDuration struct {
 	Nanosec   time.Duration  `toml:"nanosec"`
 	Microsec1 time.Duration  `toml:"microsec1"`

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -1012,7 +1012,7 @@ func TestUnmarshalCamelCaseKey(t *testing.T) {
 
 func TestUnmarshalNegativeUint(t *testing.T) {
 	t.Skipf("not sure if we this should always error")
-	type check struct{ U uint }
+	type check struct{ U uint } // nolint:unused
 	err := toml.Unmarshal([]byte("U = -1"), &check{})
 	assert.Error(t, err)
 }

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -827,6 +827,8 @@ func TestUnmarshalTabInStringAndQuotedKey(t *testing.T) {
 	}
 }
 
+// TODO: Remove nolint once var is used by a test
+//nolint:deadcode,unused,varcheck
 var customMultilineTagTestToml = []byte(`int_slice = [
   1,
   2,

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -969,6 +969,8 @@ nanosec = "1ns"
 sec = "1s"
 `)
 
+// TODO: Remove nolint once type is used by a test
+//nolint:deadcode,unused
 type testBadDuration struct {
 	Val time.Duration `toml:"val"`
 }

--- a/internal/tracker/tracker.go
+++ b/internal/tracker/tracker.go
@@ -97,7 +97,7 @@ func (s *Seen) CheckExpression(node ast.Node) error {
 	default:
 		panic(fmt.Errorf("this should not be a top level node type: %s", node.Kind))
 	}
-	return nil
+
 }
 func (s *Seen) checkTable(node ast.Node) error {
 	s.current = s.root


### PR DESCRIPTION
**Issue:**#492

Following discussion with @vincentserpoul and @pelletier, this PR addresses linting issues only in `unmarshal_imported_test.go`, which are mostly unused type and var warnings. Instead of removing the unused types and vars, I've instead chosen to mark them with a TODO and `//nolint` comment to both silence the linter and mark the symbols for later review when their dependents are added to the v2 rewrite.

I've split up each warning that's addressed by commit - each commit message body also names the symbol being marked. Note that there's 1 commit handling a lint error in a different file (`tracker.go`) that I'm including in this PR as well since it's a relatively small change.