### PR TITLE
v2: Add tests for empty tables into interface{}

### DIFF
--- a/targets.go
+++ b/targets.go
@@ -159,6 +159,14 @@ func ensureValueIndexable(t target) error {
 var sliceInterfaceType = reflect.TypeOf([]interface{}{})
 var mapStringInterfaceType = reflect.TypeOf(map[string]interface{}{})
 
+func ensureMapIfInterface(x target) {
+	v := x.get()
+	if v.Kind() == reflect.Interface && v.IsNil() {
+		newElement := reflect.MakeMap(mapStringInterfaceType)
+		x.set(newElement)
+	}
+}
+
 func setString(t target, v string) error {
 	f := t.get()
 

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -120,11 +120,7 @@ func (d *decoder) fromParser(p *parser, v interface{}) error {
 				// looks like a table. Otherwise the information
 				// of a table is lost, and marshal cannot do the
 				// round trip.
-				v := current.get()
-				if v.Kind() == reflect.Interface && v.IsNil() {
-					newElement := reflect.MakeMap(mapStringInterfaceType)
-					current.set(newElement)
-				}
+				ensureMapIfInterface(current)
 			}
 		case ast.ArrayTable:
 			current, found, err = d.scopeWithArrayTable(root, node.Key())
@@ -380,6 +376,8 @@ func unmarshalFloat(x target, node ast.Node) error {
 
 func (d *decoder) unmarshalInlineTable(x target, node ast.Node) error {
 	assertNode(ast.InlineTable, node)
+
+	ensureMapIfInterface(x)
 
 	it := node.Children()
 	for it.Next() {

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -382,12 +382,6 @@ func (d *decoder) unmarshalInlineTable(x target, node ast.Node) error {
 	assertNode(ast.InlineTable, node)
 
 	it := node.Children()
-
-	// Handle the case of an empty inline table
-	if !it.Next() {
-		return x.set(reflect.MakeMap(mapStringInterfaceType))
-	}
-
 	for it.Next() {
 		n := it.Node()
 		err := d.unmarshalKeyValue(x, n)

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -382,6 +382,12 @@ func (d *decoder) unmarshalInlineTable(x target, node ast.Node) error {
 	assertNode(ast.InlineTable, node)
 
 	it := node.Children()
+
+	// Handle the case of an empty inline table
+	if !it.Next() {
+		return x.set(reflect.MakeMap(mapStringInterfaceType))
+	}
+
 	for it.Next() {
 		n := it.Node()
 		err := d.unmarshalKeyValue(x, n)

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -297,6 +297,17 @@ B = "data"`,
 			},
 		},
 		{
+			desc:  "standard empty table",
+			input: `[A]`,
+			gen: func() test {
+				var v map[string]interface{}
+				return test{
+					target:   &v,
+					expected: &map[string]interface{}{`A`: map[string]interface{}{}},
+				}
+			},
+		},
+		{
 			desc:  "inline table",
 			input: `Name = {First = "hello", Last = "world"}`,
 			gen: func() test {
@@ -313,6 +324,17 @@ B = "data"`,
 						First: "hello",
 						Last:  "world",
 					}},
+				}
+			},
+		},
+		{
+			desc:  "inline empty table",
+			input: `A = {}`,
+			gen: func() test {
+				var v map[string]interface{}
+				return test{
+					target:   &v,
+					expected: &map[string]interface{}{`A`: map[string]interface{}{}},
 				}
 			},
 		},
@@ -713,6 +735,7 @@ type Integer484 struct {
 func (i Integer484) MarshalText() ([]byte, error) {
 	return []byte(strconv.Itoa(i.Value)), nil
 }
+
 func (i *Integer484) UnmarshalText(data []byte) error {
 	conv, err := strconv.Atoi(string(data))
 	if err != nil {

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -918,7 +918,7 @@ func TestIssue287(t *testing.T) {
 	expected := map[string]interface{}{
 		"y": []interface{}{
 			[]interface{}{
-				nil,
+				map[string]interface{}{},
 			},
 		},
 	}


### PR DESCRIPTION
When unmarshaling an empty table into an interface{}, ensure that an
empty map is created.  The standard table test failed prior to commit
37714006.