### PR TITLE
v2: Add sanity check tests to benchmark dataset

### DIFF
--- a/benchmark/bench_datasets_test.go
+++ b/benchmark/bench_datasets_test.go
@@ -2,35 +2,61 @@ package benchmark_test
 
 import (
 	"compress/gzip"
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-var bench_inputs = []string{
+var bench_inputs = []struct {
+	name    string
+	jsonLen int
+}{
 	// from https://gist.githubusercontent.com/feeeper/2197d6d734729625a037af1df14cf2aa/raw/2f22b120e476d897179be3c1e2483d18067aa7df/config.toml
-	"config",
+	{"config", 806507},
 
 	// converted from https://github.com/miloyip/nativejson-benchmark
-	"canada",
-	"citm_catalog",
-	"twitter",
-	"code",
+	{"canada", 2090234},
+	{"citm_catalog", 479897},
+	{"twitter", 428778},
+	{"code", 1940472},
 
 	// converted from https://raw.githubusercontent.com/mailru/easyjson/master/benchmark/example.json
-	"example",
+	{"example", 7779},
+}
+
+func TestUnmarshalDatasetCode(t *testing.T) {
+	for _, tc := range bench_inputs {
+		buf := fixture(t, tc.name)
+		t.Run(tc.name, func(t *testing.T) {
+			for _, r := range runners {
+				if r.name == "bs" && tc.name == "canada" {
+					t.Skip("skipping: burntsushi can't handle mixed arrays")
+				}
+
+				t.Run(r.name, func(t *testing.T) {
+					var v interface{}
+					check(t, r.unmarshal(buf, &v))
+
+					b, err := json.Marshal(v)
+					check(t, err)
+					require.Equal(t, len(b), tc.jsonLen)
+				})
+			}
+		})
+	}
 }
 
 func BenchmarkUnmarshalDataset(b *testing.B) {
 	for _, tc := range bench_inputs {
-		buf := fixture(b, tc)
-		b.Run(tc, func(b *testing.B) {
+		buf := fixture(b, tc.name)
+		b.Run(tc.name, func(b *testing.B) {
 			bench(b, func(r runner, b *testing.B) {
-				if r.name == "bs" && tc == "canada" {
-					// bs can't handle the canada dataset due to mixed integer &
-					// floats values in an array.
-					b.Skip()
+				if r.name == "bs" && tc.name == "canada" {
+					b.Skip("skipping: burntsushi can't handle mixed arrays")
 				}
 
 				b.SetBytes(int64(len(buf)))


### PR DESCRIPTION
Marshal results into JSON and ensure all runners match

----
NOTE: this failed prior to 466bfe8