### PR TITLE
Simplify scanFollows usage

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -2,29 +2,37 @@ package toml
 
 import "fmt"
 
-func scanFollows(pattern []byte) func(b []byte) bool {
-	return func(b []byte) bool {
-		if len(b) < len(pattern) {
-			return false
-		}
-		for i, c := range pattern {
-			if b[i] != c {
-				return false
-			}
-		}
-		return true
-	}
+func scanFollows(b []byte, pattern string) bool {
+	n := len(pattern)
+	return len(b) >= n && string(b[:n]) == pattern
 }
 
-var scanFollowsMultilineBasicStringDelimiter = scanFollows([]byte{'"', '"', '"'})
-var scanFollowsMultilineLiteralStringDelimiter = scanFollows([]byte{'\'', '\'', '\''})
-var scanFollowsTrue = scanFollows([]byte{'t', 'r', 'u', 'e'})
-var scanFollowsFalse = scanFollows([]byte{'f', 'a', 'l', 's', 'e'})
-var scanFollowsInf = scanFollows([]byte{'i', 'n', 'f'})
-var scanFollowsNan = scanFollows([]byte{'n', 'a', 'n'})
+func scanFollowsMultilineBasicStringDelimiter(b []byte) bool {
+	return scanFollows(b, `"""`)
+}
+
+func scanFollowsMultilineLiteralStringDelimiter(b []byte) bool {
+	return scanFollows(b, `'''`)
+}
+
+func scanFollowsTrue(b []byte) bool {
+	return scanFollows(b, `true`)
+}
+
+func scanFollowsFalse(b []byte) bool {
+	return scanFollows(b, `false`)
+}
+
+func scanFollowsInf(b []byte) bool {
+	return scanFollows(b, `inf`)
+}
+
+func scanFollowsNan(b []byte) bool {
+	return scanFollows(b, `nan`)
+}
 
 func scanUnquotedKey(b []byte) ([]byte, []byte, error) {
-	//unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
+	// unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
 	for i := 0; i < len(b); i++ {
 		if !isUnquotedKeyChar(b[i]) {
 			return b[:i], b[i:], nil
@@ -38,9 +46,9 @@ func isUnquotedKeyChar(r byte) bool {
 }
 
 func scanLiteralString(b []byte) ([]byte, []byte, error) {
-	//literal-string = apostrophe *literal-char apostrophe
-	//apostrophe = %x27 ; ' apostrophe
-	//literal-char = %x09 / %x20-26 / %x28-7E / non-ascii
+	// literal-string = apostrophe *literal-char apostrophe
+	// apostrophe = %x27 ; ' apostrophe
+	// literal-char = %x09 / %x20-26 / %x28-7E / non-ascii
 	for i := 1; i < len(b); i++ {
 		switch b[i] {
 		case '\'':
@@ -115,11 +123,11 @@ func scanComment(b []byte) ([]byte, []byte, error) {
 
 // TODO perform validation on the string?
 func scanBasicString(b []byte) ([]byte, []byte, error) {
-	//basic-string = quotation-mark *basic-char quotation-mark
-	//quotation-mark = %x22            ; "
-	//basic-char = basic-unescaped / escaped
-	//basic-unescaped = wschar / %x21 / %x23-5B / %x5D-7E / non-ascii
-	//escaped = escape escape-seq-char
+	// basic-string = quotation-mark *basic-char quotation-mark
+	// quotation-mark = %x22            ; "
+	// basic-char = basic-unescaped / escaped
+	// basic-unescaped = wschar / %x21 / %x23-5B / %x5D-7E / non-ascii
+	// escaped = escape escape-seq-char
 	for i := 1; i < len(b); i++ {
 		switch b[i] {
 		case '"':


### PR DESCRIPTION
Use static functions to avoid declaring global vars and creating more
package init costs.  This change has no negative effects on benchmarks
in my testing.