### PR TITLE
Move field paths cache out of global state

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/pelletier/go-toml/v2/internal/ast"
@@ -79,6 +80,9 @@ type decoder struct {
 
 	// Strict mode
 	strict strict
+
+	fieldPathsCache     fieldPathsCache
+	fieldPathsCacheOnce sync.Once
 }
 
 func (d *decoder) arrayIndex(shouldAppend bool, v reflect.Value) int {


### PR DESCRIPTION
Move the globalFieldPathsCache variable into the decoder struct.

----
The goal is to get rid of global state.  This may need a little polish, but I wanted to see if the approach is acceptable.

Before and after init cost (saves 48 bytes in 1 alloc):
```
init github.com/pelletier/go-toml/v2 @9.4 ms, 0.047 ms clock, 1736 bytes, 67 allocs

init github.com/pelletier/go-toml/v2 @0.69 ms, 0.087 ms clock, 1688 bytes, 66 allocs
```

Benchmarks vs 3f2bb0b36386a476cc920330c97abc7451b0bac4 (timings are a little unreliable on my laptop):
```
name                             old time/op    new time/op    delta
UnmarshalDataset/config-2          66.4ms ± 2%    67.5ms ± 5%     ~     (p=0.286 n=4+5)
UnmarshalDataset/canada-2           142ms ±13%     178ms ±11%  +25.24%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-2    68.1ms ±24%    71.6ms ± 3%     ~     (p=0.151 n=5+5)
UnmarshalDataset/twitter-2         29.5ms ± 9%    32.6ms ±10%     ~     (p=0.056 n=5+5)
UnmarshalDataset/code-2             338ms ±10%     352ms ±17%     ~     (p=0.841 n=5+5)
UnmarshalDataset/example-2          553µs ±22%     547µs ± 1%     ~     (p=0.730 n=5+4)
UnmarshalSimple-2                  1.39µs ± 8%    2.28µs ±15%  +63.81%  (p=0.008 n=5+5)
ReferenceFile-2                    46.3µs ± 8%    65.4µs ± 1%  +41.26%  (p=0.016 n=5+4)

name                             old speed      new speed      delta
UnmarshalDataset/config-2        14.9MB/s ±25%  15.5MB/s ± 5%     ~     (p=0.690 n=5+5)
UnmarshalDataset/canada-2        15.6MB/s ±12%  12.4MB/s ±10%  -20.00%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-2  8.30MB/s ±20%  7.80MB/s ± 3%     ~     (p=0.151 n=5+5)
UnmarshalDataset/twitter-2       15.0MB/s ± 8%  13.6MB/s ± 9%     ~     (p=0.056 n=5+5)
UnmarshalDataset/code-2          8.00MB/s ±11%  7.67MB/s ±15%     ~     (p=0.841 n=5+5)
UnmarshalDataset/example-2       14.8MB/s ±19%  14.8MB/s ± 1%     ~     (p=0.730 n=5+4)
ReferenceFile-2                   113MB/s ± 7%    80MB/s ± 1%  -29.35%  (p=0.016 n=5+4)

name                             old alloc/op   new alloc/op   delta
UnmarshalDataset/config-2          16.9MB ± 0%    16.9MB ± 0%     ~     (p=0.238 n=5+5)
UnmarshalDataset/canada-2          74.3MB ± 0%    74.3MB ± 0%   +0.00%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-2    37.1MB ± 0%    37.1MB ± 0%     ~     (p=0.063 n=5+5)
UnmarshalDataset/twitter-2         15.6MB ± 0%    15.6MB ± 0%     ~     (p=0.151 n=5+5)
UnmarshalDataset/code-2            59.3MB ± 0%    59.3MB ± 0%   +0.00%  (p=0.008 n=5+5)
UnmarshalDataset/example-2          238kB ± 0%     238kB ± 0%   +0.05%  (p=0.008 n=5+5)
ReferenceFile-2                    11.8kB ± 0%    20.8kB ± 0%  +76.07%  (p=0.008 n=5+5)

name                             old allocs/op  new allocs/op  delta
UnmarshalDataset/config-2            645k ± 0%      645k ± 0%     ~     (p=0.079 n=5+5)
UnmarshalDataset/canada-2            896k ± 0%      896k ± 0%   +0.00%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-2      370k ± 0%      370k ± 0%     ~     (p=0.333 n=4+5)
UnmarshalDataset/twitter-2           157k ± 0%      157k ± 0%     ~     (p=0.056 n=5+5)
UnmarshalDataset/code-2             2.91M ± 0%     2.91M ± 0%   +0.00%  (p=0.008 n=5+5)
UnmarshalDataset/example-2          3.63k ± 0%     3.63k ± 0%   +0.03%  (p=0.008 n=5+5)
ReferenceFile-2                       253 ± 0%       387 ± 0%  +52.96%  (p=0.008 n=5+5)
```