### PR TITLE
v2: errors

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -327,18 +327,30 @@ func checkAndRemoveUnderscores(b []byte) ([]byte, error) {
 		return nil, newDecodeError(b[len(b)-1:], "number cannot end with underscore")
 	}
 
-	cleaned := make([]byte, 0, len(b))
+	var cleaned []byte
 	before := false
+
 	for i, c := range b {
 		if c == '_' {
 			if !before {
 				return nil, newDecodeError(b[i-1:i+1], "number must have at least one digit between underscores")
 			}
 			before = false
+
+			if cleaned == nil {
+				cleaned = make([]byte, i, len(b))
+				copy(cleaned, b)
+			}
 		} else {
 			before = true
-			cleaned = append(cleaned, c)
+			if cleaned != nil {
+				cleaned = append(cleaned, c)
+			}
 		}
 	}
-	return cleaned, nil
+
+	if cleaned != nil {
+		return cleaned, nil
+	}
+	return b, nil
 }

--- a/decode.go
+++ b/decode.go
@@ -327,30 +327,33 @@ func checkAndRemoveUnderscores(b []byte) ([]byte, error) {
 		return nil, newDecodeError(b[len(b)-1:], "number cannot end with underscore")
 	}
 
-	var cleaned []byte
-	before := false
+	// fast path
+	i := 0
+	for ; i < len(b); i++ {
+		if b[i] == '_' {
+			break
+		}
+	}
+	if i == len(b) {
+		return b, nil
+	}
 
-	for i, c := range b {
+	before := false
+	cleaned := make([]byte, i, len(b))
+	copy(cleaned, b)
+
+	for i++; i < len(b); i++ {
+		c := b[i]
 		if c == '_' {
 			if !before {
 				return nil, newDecodeError(b[i-1:i+1], "number must have at least one digit between underscores")
 			}
 			before = false
-
-			if cleaned == nil {
-				cleaned = make([]byte, i, len(b))
-				copy(cleaned, b)
-			}
 		} else {
 			before = true
-			if cleaned != nil {
-				cleaned = append(cleaned, c)
-			}
+			cleaned = append(cleaned, c)
 		}
 	}
 
-	if cleaned != nil {
-		return cleaned, nil
-	}
-	return b, nil
+	return cleaned, nil
 }

--- a/errors.go
+++ b/errors.go
@@ -70,13 +70,13 @@ func (de *decodeError) Error() string {
 func newDecodeError(highlight []byte, format string, args ...interface{}) error {
 	return &decodeError{
 		highlight: highlight,
-		message:   fmt.Sprintf(format, args...),
+		message:   fmt.Errorf(format, args...).Error(),
 	}
 }
 
 // Error returns the error message contained in the DecodeError.
 func (e *DecodeError) Error() string {
-	return e.message
+	return "toml: " + e.message
 }
 
 // String returns the human-readable contextualized error. This string is multi-line.

--- a/internal/tracker/seen.go
+++ b/internal/tracker/seen.go
@@ -123,10 +123,10 @@ func (s *SeenTracker) checkTable(node ast.Node) error {
 	i, found := s.current.Has(k)
 	if found {
 		if i.kind != tableKind {
-			return fmt.Errorf("key %s should be a table", k)
+			return fmt.Errorf("toml: key %s should be a table, not a %s", k, i.kind)
 		}
 		if i.explicit {
-			return fmt.Errorf("table %s already exists", k)
+			return fmt.Errorf("toml: table %s already exists", k)
 		}
 		i.explicit = true
 		s.current = i
@@ -162,7 +162,7 @@ func (s *SeenTracker) checkArrayTable(node ast.Node) error {
 	info, found := s.current.Has(k)
 	if found {
 		if info.kind != arrayTableKind {
-			return fmt.Errorf("key %s already exists but is not an array table", k)
+			return fmt.Errorf("toml: key %s already exists as a %s,  but should be an array table", info.kind, k)
 		}
 		info.Clear()
 	} else {
@@ -182,7 +182,7 @@ func (s *SeenTracker) checkKeyValue(context *info, node ast.Node) error {
 		child, found := context.Has(k)
 		if found {
 			if child.kind != tableKind {
-				return fmt.Errorf("expected %s to be a table, not a %s", k, child.kind)
+				return fmt.Errorf("toml: expected %s to be a table, not a %s", k, child.kind)
 			}
 		} else {
 			child = context.CreateTable(k, false)

--- a/localtime.go
+++ b/localtime.go
@@ -53,7 +53,7 @@ func LocalDateOf(t time.Time) LocalDate {
 func ParseLocalDate(s string) (LocalDate, error) {
 	t, err := time.Parse("2006-01-02", s)
 	if err != nil {
-		return LocalDate{}, fmt.Errorf("ParseLocalDate: %w", err)
+		return LocalDate{}, err
 	}
 
 	return LocalDateOf(t), nil
@@ -166,7 +166,7 @@ func LocalTimeOf(t time.Time) LocalTime {
 func ParseLocalTime(s string) (LocalTime, error) {
 	t, err := time.Parse("15:04:05.999999999", s)
 	if err != nil {
-		return LocalTime{}, fmt.Errorf("ParseLocalTime: %w", err)
+		return LocalTime{}, err
 	}
 
 	return LocalTimeOf(t), nil
@@ -237,7 +237,7 @@ func ParseLocalDateTime(s string) (LocalDateTime, error) {
 	if err != nil {
 		t, err = time.Parse("2006-01-02t15:04:05.999999999", s)
 		if err != nil {
-			return LocalDateTime{}, fmt.Errorf("ParseLocalDateTime: %w", err)
+			return LocalDateTime{}, err
 		}
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -731,12 +731,13 @@ func hexToString(b []byte, length int) (string, error) {
 	if len(b) < length {
 		return "", newDecodeError(b, "unicode point needs %d character, not %d", length, len(b))
 	}
+	b = b[:length]
 
 	//nolint:godox
 	// TODO: slow
-	intcode, err := strconv.ParseInt(string(b[:length]), 16, 32)
+	intcode, err := strconv.ParseInt(string(b), 16, 32)
 	if err != nil {
-		return "", fmt.Errorf("hexToString: %w", err)
+		return "", newDecodeError(b, "couldn't parse hexadecimal number: %w", err)
 	}
 
 	return string(rune(intcode)), nil

--- a/parser.go
+++ b/parser.go
@@ -2,7 +2,6 @@ package toml
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -225,19 +224,13 @@ func (p *parser) parseKeyval(b []byte) (ast.Reference, []byte, error) {
 	return ref, b, err
 }
 
-var (
-	errExpectedValNotEOF = errors.New("expected value, not eof")
-	errExpectedTrue      = errors.New("expected 'true'")
-	errExpectedFalse     = errors.New("expected 'false'")
-)
-
 //nolint:cyclop,funlen
 func (p *parser) parseVal(b []byte) (ast.Reference, []byte, error) {
 	// val = string / boolean / array / inline-table / date-time / float / integer
 	var ref ast.Reference
 
 	if len(b) == 0 {
-		return ref, nil, errExpectedValNotEOF
+		return ref, nil, newDecodeError(b, "expected value, not eof")
 	}
 
 	var err error
@@ -278,7 +271,7 @@ func (p *parser) parseVal(b []byte) (ast.Reference, []byte, error) {
 		return ref, b, err
 	case 't':
 		if !scanFollowsTrue(b) {
-			return ref, nil, errExpectedTrue
+			return ref, nil, newDecodeError(atmost(b, 4), "expected 'true'")
 		}
 
 		ref = p.builder.Push(ast.Node{
@@ -289,7 +282,7 @@ func (p *parser) parseVal(b []byte) (ast.Reference, []byte, error) {
 		return ref, b[4:], nil
 	case 'f':
 		if !scanFollowsFalse(b) {
-			return ast.Reference{}, nil, errExpectedFalse
+			return ref, nil, newDecodeError(atmost(b, 5), "expected 'false'")
 		}
 
 		ref = p.builder.Push(ast.Node{
@@ -305,6 +298,13 @@ func (p *parser) parseVal(b []byte) (ast.Reference, []byte, error) {
 	default:
 		return p.parseIntOrFloatOrDateTime(b)
 	}
+}
+
+func atmost(b []byte, n int) []byte {
+	if n >= len(b) {
+		return b
+	}
+	return b[:n]
 }
 
 func (p *parser) parseLiteralString(b []byte) ([]byte, []byte, error) {
@@ -370,8 +370,6 @@ func (p *parser) parseInlineTable(b []byte) (ast.Reference, []byte, error) {
 	return parent, rest, err
 }
 
-var errArrayCannotStartWithComma = errors.New("array cannot start with comma")
-
 //nolint:funlen,cyclop
 func (p *parser) parseValArray(b []byte) (ast.Reference, []byte, error) {
 	// array = array-open [ array-values ] ws-comment-newline array-close
@@ -409,7 +407,7 @@ func (p *parser) parseValArray(b []byte) (ast.Reference, []byte, error) {
 
 		if b[0] == ',' {
 			if first {
-				return parent, nil, errArrayCannotStartWithComma
+				return parent, nil, newDecodeError(b[0:1], "array cannot start with comma")
 			}
 			b = b[1:]
 
@@ -493,8 +491,6 @@ func (p *parser) parseMultilineLiteralString(b []byte) ([]byte, []byte, error) {
 
 	return token[i : len(token)-3], rest, err
 }
-
-var errInvalidEscapeChar = errors.New("invalid escaped character")
 
 //nolint:funlen,gocognit,cyclop
 func (p *parser) parseMultilineBasicString(b []byte) ([]byte, []byte, error) {
@@ -582,7 +578,7 @@ func (p *parser) parseMultilineBasicString(b []byte) ([]byte, []byte, error) {
 				builder.WriteString(x)
 				i += 8
 			default:
-				return nil, nil, fmt.Errorf("parseMultilineBasicString: %w - %#U", errInvalidEscapeChar, c)
+				return nil, nil, newDecodeError(token[i:i+1], "invalid escaped character %#U", c)
 			}
 		} else {
 			builder.WriteByte(c)
@@ -721,7 +717,7 @@ func (p *parser) parseBasicString(b []byte) ([]byte, []byte, error) {
 				builder.WriteString(x)
 				i += 8
 			default:
-				return nil, nil, fmt.Errorf("parseBasicString: %w - %#U", errInvalidEscapeChar, c)
+				return nil, nil, newDecodeError(token[i:i+1], "invalid escaped character %#U", c)
 			}
 		} else {
 			builder.WriteByte(c)
@@ -731,11 +727,9 @@ func (p *parser) parseBasicString(b []byte) ([]byte, []byte, error) {
 	return builder.Bytes(), rest, nil
 }
 
-var errUnicodePointNeedsRightCountChar = errors.New("unicode point needs right number of hex characters")
-
 func hexToString(b []byte, length int) (string, error) {
 	if len(b) < length {
-		return "", fmt.Errorf("hexToString: %w - %d", errUnicodePointNeedsRightCountChar, length)
+		return "", newDecodeError(b, "unicode point needs %d character, not %d", length, len(b))
 	}
 
 	//nolint:godox
@@ -757,17 +751,12 @@ func (p *parser) parseWhitespace(b []byte) []byte {
 	return rest
 }
 
-var (
-	errExpectedInf = errors.New("expected 'inf'")
-	errExpectedNan = errors.New("expected 'nan'")
-)
-
 //nolint:cyclop
 func (p *parser) parseIntOrFloatOrDateTime(b []byte) (ast.Reference, []byte, error) {
 	switch b[0] {
 	case 'i':
 		if !scanFollowsInf(b) {
-			return ast.Reference{}, nil, errExpectedInf
+			return ast.Reference{}, nil, newDecodeError(atmost(b, 3), "expected 'inf'")
 		}
 
 		return p.builder.Push(ast.Node{
@@ -776,7 +765,7 @@ func (p *parser) parseIntOrFloatOrDateTime(b []byte) (ast.Reference, []byte, err
 		}), b[3:], nil
 	case 'n':
 		if !scanFollowsNan(b) {
-			return ast.Reference{}, nil, errExpectedNan
+			return ast.Reference{}, nil, newDecodeError(atmost(b, 3), "expected 'nan'")
 		}
 
 		return p.builder.Push(ast.Node{
@@ -820,8 +809,6 @@ func digitsToInt(b []byte) int {
 
 	return x
 }
-
-var errTimezoneButNoTimeComponent = errors.New("possible DateTime cannot have a timezone but no time component")
 
 //nolint:gocognit,cyclop
 func (p *parser) scanDateTime(b []byte) (ast.Reference, []byte, error) {
@@ -867,7 +854,7 @@ byteLoop:
 		}
 	} else {
 		if hasTz {
-			return ast.Reference{}, nil, errTimezoneButNoTimeComponent
+			return ast.Reference{}, nil, newDecodeError(b, "date-time has timezone but not time component")
 		}
 		kind = ast.LocalDate
 	}
@@ -877,12 +864,6 @@ byteLoop:
 		Data: b[:i],
 	}), b[i:], nil
 }
-
-var (
-	errUnexpectedCharI    = fmt.Errorf("unexpected character i while scanning for a number")
-	errUnexpectedCharN    = fmt.Errorf("unexpected character n while scanning for a number")
-	errExpectedIntOrFloat = fmt.Errorf("expected integer or float")
-)
 
 //nolint:funlen,gocognit,cyclop
 func (p *parser) scanIntOrFloat(b []byte) (ast.Reference, []byte, error) {
@@ -940,7 +921,7 @@ func (p *parser) scanIntOrFloat(b []byte) (ast.Reference, []byte, error) {
 				}), b[i+3:], nil
 			}
 
-			return ast.Reference{}, nil, errUnexpectedCharI
+			return ast.Reference{}, nil, newDecodeError(b[i:i+1], "unexpected character 'i' while scanning for a number")
 		}
 
 		if c == 'n' {
@@ -951,14 +932,14 @@ func (p *parser) scanIntOrFloat(b []byte) (ast.Reference, []byte, error) {
 				}), b[i+3:], nil
 			}
 
-			return ast.Reference{}, nil, errUnexpectedCharN
+			return ast.Reference{}, nil, newDecodeError(b[i:i+1], "unexpected character 'n' while scanning for a number")
 		}
 
 		break
 	}
 
 	if i == 0 {
-		return ast.Reference{}, b, errExpectedIntOrFloat
+		return ast.Reference{}, b, newDecodeError(b, "incomplete number")
 	}
 
 	kind := ast.Integer

--- a/scanner.go
+++ b/scanner.go
@@ -1,9 +1,5 @@
 package toml
 
-import (
-	"errors"
-)
-
 func scanFollows(b []byte, pattern string) bool {
 	n := len(pattern)
 
@@ -83,22 +79,17 @@ func scanMultilineLiteralString(b []byte) ([]byte, []byte, error) {
 	return nil, nil, newDecodeError(b[len(b):], `multiline literal string not terminated by '''`)
 }
 
-var (
-	errWindowsNewLineMissing = errors.New(`windows new line missing \n`)
-	errWindowsNewLineCRLF    = errors.New(`windows new line should be \r\n`)
-)
-
 func scanWindowsNewline(b []byte) ([]byte, []byte, error) {
-	const lenLF = 2
-	if len(b) < lenLF {
-		return nil, nil, errWindowsNewLineMissing
+	const lenCRLF = 2
+	if len(b) < lenCRLF {
+		return nil, nil, newDecodeError(b, "windows new line expected")
 	}
 
 	if b[1] != '\n' {
-		return nil, nil, errWindowsNewLineCRLF
+		return nil, nil, newDecodeError(b, `windows new line should be \r\n`)
 	}
 
-	return b[:lenLF], b[lenLF:], nil
+	return b[:lenCRLF], b[lenCRLF:], nil
 }
 
 func scanWhitespace(b []byte) ([]byte, []byte) {
@@ -116,8 +107,6 @@ func scanWhitespace(b []byte) ([]byte, []byte) {
 
 //nolint:unparam
 func scanComment(b []byte) ([]byte, []byte) {
-	// ;; Comment
-	//
 	// comment-start-symbol = %x23 ; #
 	// non-ascii = %x80-D7FF / %xE000-10FFFF
 	// non-eol = %x09 / %x20-7F / non-ascii
@@ -132,10 +121,6 @@ func scanComment(b []byte) ([]byte, []byte) {
 	return b, nil
 }
 
-var errBasicLineNotTerminatedByQuote = errors.New(`basic string not terminated by "`)
-
-//nolint:godox
-// TODO perform validation on the string?
 func scanBasicString(b []byte) ([]byte, []byte, error) {
 	// basic-string = quotation-mark *basic-char quotation-mark
 	// quotation-mark = %x22            ; "
@@ -156,11 +141,9 @@ func scanBasicString(b []byte) ([]byte, []byte, error) {
 		}
 	}
 
-	return nil, nil, errBasicLineNotTerminatedByQuote
+	return nil, nil, newDecodeError(b[len(b):], `basic string not terminated by "`)
 }
 
-//nolint:godox
-// TODO perform validation on the string?
 func scanMultilineBasicString(b []byte) ([]byte, []byte, error) {
 	// ml-basic-string = ml-basic-string-delim [ newline ] ml-basic-body
 	// ml-basic-string-delim

--- a/targets_test.go
+++ b/targets_test.go
@@ -128,14 +128,12 @@ func TestPushNew(t *testing.T) {
 		x, _, err := dec.scopeTableTarget(false, valueTarget(reflect.ValueOf(&d).Elem()), "A")
 		require.NoError(t, err)
 
-		n, err := elementAt(x, 0)
-		require.NoError(t, err)
-		require.NoError(t, n.setString("hello"))
+		n := elementAt(x, 0)
+		n.setString("hello")
 		require.Equal(t, []string{"hello"}, d.A)
 
-		n, err = elementAt(x, 1)
-		require.NoError(t, err)
-		require.NoError(t, n.setString("world"))
+		n = elementAt(x, 1)
+		n.setString("world")
 		require.Equal(t, []string{"hello", "world"}, d.A)
 	})
 
@@ -151,13 +149,11 @@ func TestPushNew(t *testing.T) {
 		x, _, err := dec.scopeTableTarget(false, valueTarget(reflect.ValueOf(&d).Elem()), "A")
 		require.NoError(t, err)
 
-		n, err := elementAt(x, 0)
-		require.NoError(t, err)
+		n := elementAt(x, 0)
 		require.NoError(t, setString(n, "hello"))
 		require.Equal(t, []interface{}{"hello"}, d.A)
 
-		n, err = elementAt(x, 1)
-		require.NoError(t, err)
+		n = elementAt(x, 1)
 		require.NoError(t, setString(n, "world"))
 		require.Equal(t, []interface{}{"hello", "world"}, d.A)
 	})

--- a/toml_testgen_support_test.go
+++ b/toml_testgen_support_test.go
@@ -94,12 +94,7 @@ func testGenTranslateDesc(input interface{}) interface{} {
 		if ok {
 			dvalue, ok = d["value"]
 			if ok {
-				var okdt bool
-
-				dtype, okdt = dtypeiface.(string)
-				if !okdt {
-					panic(fmt.Sprintf("dtypeiface should be valid string: %v", dtypeiface))
-				}
+				dtype = dtypeiface.(string)
 
 				switch dtype {
 				case "string":
@@ -132,10 +127,7 @@ func testGenTranslateDesc(input interface{}) interface{} {
 						return nil
 					}
 
-					a, oka := dvalue.([]interface{})
-					if !oka {
-						panic(fmt.Sprintf("a should be valid []interface{}: %v", a))
-					}
+					a := dvalue.([]interface{})
 
 					xs := make([]interface{}, len(a))
 

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -56,7 +56,7 @@ func (d *Decoder) SetStrict(strict bool) {
 func (d *Decoder) Decode(v interface{}) error {
 	b, err := ioutil.ReadAll(d.r)
 	if err != nil {
-		return fmt.Errorf("Decode: %w", err)
+		return fmt.Errorf("toml: %w", err)
 	}
 
 	p := parser{}
@@ -130,20 +130,15 @@ func keyLocation(node ast.Node) []byte {
 	return unsafe.BytesRange(start, end)
 }
 
-var (
-	errFromParserExpectingPointer       = errors.New("expecting a pointer as target")
-	errFromParserExpectingNonNilPointer = errors.New("expecting non nil pointer as target")
-)
-
 //nolint:funlen,cyclop
 func (d *decoder) fromParser(p *parser, v interface{}) error {
 	r := reflect.ValueOf(v)
 	if r.Kind() != reflect.Ptr {
-		return fmt.Errorf("fromParser: %w, not %s", errFromParserExpectingPointer, r.Kind())
+		return fmt.Errorf("toml: decoding can only be performed into a pointer, not %s", r.Kind())
 	}
 
 	if r.IsNil() {
-		return errFromParserExpectingNonNilPointer
+		return fmt.Errorf("toml: decoding pointer target cannot be nil")
 	}
 
 	var (
@@ -162,7 +157,7 @@ func (d *decoder) fromParser(p *parser, v interface{}) error {
 
 		err := d.seen.CheckExpression(node)
 		if err != nil {
-			return fmt.Errorf("fromParser: %w", err)
+			return err
 		}
 
 		var found bool

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -176,16 +176,13 @@ func (d *decoder) fromParser(p *parser, v interface{}) error {
 				// looks like a table. Otherwise the information
 				// of a table is lost, and marshal cannot do the
 				// round trip.
-				err := ensureMapIfInterface(current)
-				if err != nil {
-					panic(fmt.Sprintf("ensureMapIfInterface: %s", err))
-				}
+				ensureMapIfInterface(current)
 			}
 		case ast.ArrayTable:
 			d.strict.EnterArrayTable(node)
 			current, found, err = d.scopeWithArrayTable(root, node.Key())
 		default:
-			panic(fmt.Sprintf("fromParser: this should not be a top level node type: %s", node.Kind))
+			panic(fmt.Sprintf("this should not be a top level node type: %s", node.Kind))
 		}
 
 		if err != nil {
@@ -262,26 +259,18 @@ func (d *decoder) scopeWithArrayTable(x target, key ast.Iterator) (target, bool,
 	v := x.get()
 
 	if v.Kind() == reflect.Ptr {
-		x, err = scopePtr(x)
-		if err != nil {
-			return x, false, err
-		}
-
+		x = scopePtr(x)
 		v = x.get()
 	}
 
 	if v.Kind() == reflect.Interface {
-		x, err = scopeInterface(true, x)
-		if err != nil {
-			return x, found, err
-		}
-
+		x = scopeInterface(true, x)
 		v = x.get()
 	}
 
 	switch v.Kind() {
 	case reflect.Slice:
-		x, err = scopeSlice(true, x)
+		x = scopeSlice(true, x)
 	case reflect.Array:
 		x, err = d.scopeArray(true, x)
 	default:
@@ -329,7 +318,7 @@ func tryTextUnmarshaler(x target, node ast.Node) (bool, error) {
 	if v.Type().Implements(textUnmarshalerType) {
 		err := v.Interface().(encoding.TextUnmarshaler).UnmarshalText(node.Data)
 		if err != nil {
-			return false, fmt.Errorf("tryTextUnmarshaler: %w", err)
+			return false, newDecodeError(node.Data, "error calling UnmarshalText: %w", err)
 		}
 
 		return true, nil
@@ -338,7 +327,7 @@ func tryTextUnmarshaler(x target, node ast.Node) (bool, error) {
 	if v.CanAddr() && v.Addr().Type().Implements(textUnmarshalerType) {
 		err := v.Addr().Interface().(encoding.TextUnmarshaler).UnmarshalText(node.Data)
 		if err != nil {
-			return false, fmt.Errorf("tryTextUnmarshaler: %w", err)
+			return false, newDecodeError(node.Data, "error calling UnmarshalText: %w", err)
 		}
 
 		return true, nil
@@ -353,11 +342,7 @@ func (d *decoder) unmarshalValue(x target, node ast.Node) error {
 
 	if v.Kind() == reflect.Ptr {
 		if !v.Elem().IsValid() {
-			err := x.set(reflect.New(v.Type().Elem()))
-			if err != nil {
-				return fmt.Errorf("unmarshalValue: %w", err)
-			}
-
+			x.set(reflect.New(v.Type().Elem()))
 			v = x.get()
 		}
 
@@ -389,7 +374,7 @@ func (d *decoder) unmarshalValue(x target, node ast.Node) error {
 	case ast.LocalDate:
 		return unmarshalLocalDate(x, node)
 	default:
-		panic(fmt.Sprintf("unmarshalValue: unhandled unmarshalValue kind %s", node.Kind))
+		panic(fmt.Sprintf("unhandled node kind %s", node.Kind))
 	}
 }
 
@@ -401,7 +386,9 @@ func unmarshalLocalDate(x target, node ast.Node) error {
 		return err
 	}
 
-	return setDate(x, v)
+	setDate(x, v)
+
+	return nil
 }
 
 func unmarshalLocalDateTime(x target, node ast.Node) error {
@@ -416,7 +403,9 @@ func unmarshalLocalDateTime(x target, node ast.Node) error {
 		return newDecodeError(rest, "extra characters at the end of a local date time")
 	}
 
-	return setLocalDateTime(x, v)
+	setLocalDateTime(x, v)
+
+	return nil
 }
 
 func unmarshalDateTime(x target, node ast.Node) error {
@@ -427,48 +416,37 @@ func unmarshalDateTime(x target, node ast.Node) error {
 		return err
 	}
 
-	return setDateTime(x, v)
+	setDateTime(x, v)
+
+	return nil
 }
 
-func setLocalDateTime(x target, v LocalDateTime) error {
+func setLocalDateTime(x target, v LocalDateTime) {
 	if x.get().Type() == timeType {
 		cast := v.In(time.Local)
 
-		return setDateTime(x, cast)
+		setDateTime(x, cast)
+		return
 	}
 
-	err := x.set(reflect.ValueOf(v))
-	if err != nil {
-		return fmt.Errorf("setLocalDateTime: %w", err)
-	}
-
-	return nil
+	x.set(reflect.ValueOf(v))
 }
 
-func setDateTime(x target, v time.Time) error {
-	err := x.set(reflect.ValueOf(v))
-	if err != nil {
-		return fmt.Errorf("setDateTime: %w", err)
-	}
-
-	return nil
+func setDateTime(x target, v time.Time) {
+	x.set(reflect.ValueOf(v))
 }
 
 var timeType = reflect.TypeOf(time.Time{})
 
-func setDate(x target, v LocalDate) error {
+func setDate(x target, v LocalDate) {
 	if x.get().Type() == timeType {
 		cast := v.In(time.Local)
 
-		return setDateTime(x, cast)
+		setDateTime(x, cast)
+		return
 	}
 
-	err := x.set(reflect.ValueOf(v))
-	if err != nil {
-		return fmt.Errorf("setDate: %w", err)
-	}
-
-	return nil
+	x.set(reflect.ValueOf(v))
 }
 
 func unmarshalString(x target, node ast.Node) error {
@@ -509,10 +487,7 @@ func unmarshalFloat(x target, node ast.Node) error {
 func (d *decoder) unmarshalInlineTable(x target, node ast.Node) error {
 	assertNode(ast.InlineTable, node)
 
-	err := ensureMapIfInterface(x)
-	if err != nil {
-		return fmt.Errorf("unmarshalInlineTable: %w", err)
-	}
+	ensureMapIfInterface(x)
 
 	it := node.Children()
 	for it.Next() {
@@ -541,10 +516,7 @@ func (d *decoder) unmarshalArray(x target, node ast.Node) error {
 	for it.Next() {
 		n := it.Node()
 
-		v, err := elementAt(x, idx)
-		if err != nil {
-			return err
-		}
+		v := elementAt(x, idx)
 
 		if v == nil {
 			// when we go out of bound for an array just stop processing it to

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -818,6 +818,33 @@ B = "data"`,
 				}
 			},
 		},
+		{
+			desc:  "mismatch types int to string",
+			input: `A = 42`,
+			gen: func() test {
+				type S struct {
+					A string
+				}
+				return test{
+					target: &S{},
+					err:    true,
+				}
+			},
+		},
+		{
+			desc:  "mismatch types array of int to interface with non-slice",
+			input: `A = [[42]]`,
+			skip:  true,
+			gen: func() test {
+				type S struct {
+					A *string
+				}
+				return test{
+					target:   &S{},
+					expected: &S{},
+				}
+			},
+		},
 	}
 
 	for _, e := range examples {
@@ -834,6 +861,9 @@ B = "data"`,
 			}
 			err := toml.Unmarshal([]byte(e.input), test.target)
 			if test.err {
+				if err == nil {
+					t.Log("=>", test.target)
+				}
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1049,7 +1049,7 @@ world'`,
 
 			if e.msg != "" {
 				t.Log("\n" + de.String())
-				require.Equal(t, e.msg, de.Error())
+				require.Equal(t, "toml: "+e.msg, de.Error())
 			}
 		})
 	}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -39,6 +39,11 @@ func TestUnmarshal_Integers(t *testing.T) {
 			expected: 99,
 		},
 		{
+			desc:     "integer decimal underscore",
+			input:    `123_456`,
+			expected: 123456,
+		},
+		{
 			desc:     "integer hex uppercase",
 			input:    `0xDEADBEEF`,
 			expected: 0xDEADBEEF,

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -58,6 +58,21 @@ func TestUnmarshal_Integers(t *testing.T) {
 			input:    `0b11010110`,
 			expected: 0b11010110,
 		},
+		{
+			desc:  "double underscore",
+			input: "12__3",
+			err:   true,
+		},
+		{
+			desc:  "starts with underscore",
+			input: "_1",
+			err:   true,
+		},
+		{
+			desc:  "ends with underscore",
+			input: "1_",
+			err:   true,
+		},
 	}
 
 	type doc struct {
@@ -71,8 +86,12 @@ func TestUnmarshal_Integers(t *testing.T) {
 
 			doc := doc{}
 			err := toml.Unmarshal([]byte(`A = `+e.input), &doc)
-			require.NoError(t, err)
-			assert.Equal(t, e.expected, doc.A)
+			if e.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, e.expected, doc.A)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Follow up to https://github.com/pelletier/go-toml/pull/530 and https://github.com/pelletier/go-toml/discussions/532.

This is what I'm proposing for error handling:

* `panic` when assumption in the code are found to be wrong. We could eventually
  remove those calls, but it seems right to develop defensively while the
  library is not stable.
* When possible, use `newDecodeError` to generate an error with full context.
* Errors should be as descriptive as possible to give a chance to the user to
  understand what's going on and fix it.
* Create the error only when needed to avoid increasing load up time and memory.


Here's the impact on init performance:


| version        | init perf                                                                              |
|----------------|----------------------------------------------------------------------------------------|
| v2.0.0-alpha.2 | `init github.com/pelletier/go-toml/v2 @0.32 ms, 0.001 ms clock, 368 bytes, 18 allocs`  |
| #530           | `init github.com/pelletier/go-toml/v2 @0.35 ms, 0.010 ms clock, 5576 bytes, 67 allocs` |
| this           | `init github.com/pelletier/go-toml/v2 @0.38 ms, 0.004 ms clock, 176 bytes, 6 allocs`   |


When doing this I realized that all the `set*()` methods on the `target`
interface didn't need to return an error, as the calling functions
(`unmarshal*`) are responsible for type checking.


Also I've noticed the code that removes underscores from numbers was not
returning an error for invalid use of `_`. While I was at it, removed the
allocation for the common case of not using underscores.


```
name                              old time/op    new time/op    delta
UnmarshalDataset/config-32          86.7ms ± 2%    87.5ms ± 2%     ~     (p=0.113 n=9+10)
UnmarshalDataset/canada-32           129ms ± 4%     106ms ± 3%  -17.94%  (p=0.000 n=10+10)
UnmarshalDataset/citm_catalog-32    59.4ms ± 5%    58.7ms ± 5%     ~     (p=0.393 n=10+10)
UnmarshalDataset/twitter-32         27.0ms ± 7%    26.9ms ± 6%     ~     (p=0.720 n=10+9)
UnmarshalDataset/code-32             326ms ± 4%     322ms ± 7%     ~     (p=0.661 n=9+10)
UnmarshalDataset/example-32          510µs ±11%     526µs ± 7%     ~     (p=0.182 n=10+9)
UnmarshalSimple-32                  1.41µs ± 6%    1.41µs ± 4%     ~     (p=0.736 n=10+9)
ReferenceFile-32                    45.6µs ± 3%    43.9µs ±10%     ~     (p=0.089 n=10+10)

name                              old speed      new speed      delta
UnmarshalDataset/config-32        12.1MB/s ± 2%  12.0MB/s ± 2%     ~     (p=0.108 n=9+10)
UnmarshalDataset/canada-32        17.1MB/s ± 4%  20.9MB/s ± 3%  +21.86%  (p=0.000 n=10+10)
UnmarshalDataset/citm_catalog-32  9.41MB/s ± 5%  9.51MB/s ± 5%     ~     (p=0.362 n=10+10)
UnmarshalDataset/twitter-32       16.4MB/s ± 8%  16.5MB/s ± 6%     ~     (p=0.704 n=10+9)
UnmarshalDataset/code-32          8.24MB/s ± 4%  8.34MB/s ± 7%     ~     (p=0.675 n=9+10)
UnmarshalDataset/example-32       15.9MB/s ±11%  15.4MB/s ± 7%     ~     (p=0.182 n=10+9)
ReferenceFile-32                   115MB/s ± 4%   120MB/s ±10%     ~     (p=0.085 n=10+10)

name                              old alloc/op   new alloc/op   delta
UnmarshalDataset/config-32          16.9MB ± 0%    16.9MB ± 0%   -0.02%  (p=0.000 n=10+10)
UnmarshalDataset/canada-32          76.8MB ± 0%    74.3MB ± 0%   -3.31%  (p=0.000 n=10+10)
UnmarshalDataset/citm_catalog-32    37.3MB ± 0%    37.1MB ± 0%   -0.60%  (p=0.000 n=9+10)
UnmarshalDataset/twitter-32         15.6MB ± 0%    15.6MB ± 0%   -0.09%  (p=0.000 n=10+10)
UnmarshalDataset/code-32            60.2MB ± 0%    59.3MB ± 0%   -1.51%  (p=0.000 n=10+9)
UnmarshalDataset/example-32          238kB ± 0%     238kB ± 0%   -0.18%  (p=0.000 n=10+10)
ReferenceFile-32                    11.8kB ± 0%    11.8kB ± 0%     ~     (all equal)

name                              old allocs/op  new allocs/op  delta
UnmarshalDataset/config-32            653k ± 0%      645k ± 0%   -1.20%  (p=0.000 n=10+6)
UnmarshalDataset/canada-32           1.01M ± 0%     0.90M ± 0%  -11.04%  (p=0.000 n=9+10)
UnmarshalDataset/citm_catalog-32      384k ± 0%      370k ± 0%   -3.75%  (p=0.000 n=10+10)
UnmarshalDataset/twitter-32           160k ± 0%      157k ± 0%   -1.32%  (p=0.000 n=10+10)
UnmarshalDataset/code-32             2.97M ± 0%     2.91M ± 0%   -2.15%  (p=0.000 n=10+7)
UnmarshalDataset/example-32          3.69k ± 0%     3.63k ± 0%   -1.52%  (p=0.000 n=10+10)
ReferenceFile-32                       253 ± 0%       253 ± 0%     ~     (all equal)
```