### PR TITLE
Increase test coverage

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -24,7 +24,7 @@ enable = [
     # "exhaustivestruct",
     "exportloopref",
     "forbidigo",
-    "forcetypeassert",
+    # "forcetypeassert",
     "funlen",
     "gci",
     # "gochecknoglobals",
@@ -80,5 +80,5 @@ enable = [
     "wastedassign",
     "whitespace",
     # "wrapcheck",
-    "wsl"
+    # "wsl"
 ]

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -57,7 +57,7 @@ enable = [
     "nakedret",
     "nestif",
     "nilerr",
-    "nlreturn",
+    # "nlreturn",
     "noctx",
     "nolintlint",
     "paralleltest",

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -35,7 +35,7 @@ enable = [
     "gocyclo",
     "godot",
     "godox",
-    "goerr113",
+    # "goerr113",
     "gofmt",
     "gofumpt",
     "goheader",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,17 +51,17 @@ Want to contribute a patch? Very happy to hear that!
 
 First, some high-level rules:
 
-* A short proposal with some POC code is better than a lengthy piece of text
+- A short proposal with some POC code is better than a lengthy piece of text
   with no code. Code speaks louder than words. That being said, bigger changes
   should probably start with a [discussion][discussions].
-* No backward-incompatible patch will be accepted unless discussed. Sometimes
+- No backward-incompatible patch will be accepted unless discussed. Sometimes
   it's hard, but we try not to break people's programs unless we absolutely have
   to.
-* If you are writing a new feature or extending an existing one, make sure to
+- If you are writing a new feature or extending an existing one, make sure to
   write some documentation.
-* Bug fixes need to be accompanied with regression tests.
-* New code needs to be tested.
-* Your commit messages need to explain why the change is needed, even if already
+- Bug fixes need to be accompanied with regression tests.
+- New code needs to be tested.
+- Your commit messages need to explain why the change is needed, even if already
   included in the PR description.
 
 It does sound like a lot, but those best practices are here to save time overall
@@ -129,12 +129,14 @@ Benchmark results should be compared against each other with
    `new.txt`).
 4. Run `benchstat old.txt new.txt` to check that time/op does not go up in any
    test.
-   
+
+On Unix you can use `./ci.sh benchmark -d v2` to verify how your code impacts
+performance.
+
 It is highly encouraged to add the benchstat results to your pull request
 description. Pull requests that lower performance will receive more scrutiny.
 
 [benchstat]: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
-
 
 ### Style
 
@@ -149,10 +151,10 @@ code. We enforce using `go fmt` on the whole code base.
 
 Checklist:
 
-* Passing CI.
-* Does not introduce backward-incompatible changes (unless discussed).
-* Has relevant doc changes.
-* Benchstat does not show performance regression.
+- Passing CI.
+- Does not introduce backward-incompatible changes (unless discussed).
+- Has relevant doc changes.
+- Benchstat does not show performance regression.
 
 1. Merge using "squash and merge".
 2. Make sure to edit the commit message to keep all the useful information

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,2 @@
-/*
-   Package toml is a library to read and write TOML documents.
-*/
+// Package toml is a library to read and write TOML documents.
 package toml

--- a/errors.go
+++ b/errors.go
@@ -105,10 +105,6 @@ func (e *DecodeError) Key() Key {
 // highlight can be freely deallocated.
 //nolint:funlen
 func wrapDecodeError(document []byte, de *decodeError) *DecodeError {
-	if de == nil {
-		return nil
-	}
-
 	offset := unsafe.SubsliceOffset(document, de.highlight)
 
 	errMessage := de.message

--- a/errors.go
+++ b/errors.go
@@ -107,7 +107,7 @@ func (e *DecodeError) Key() Key {
 func wrapDecodeError(document []byte, de *decodeError) *DecodeError {
 	offset := unsafe.SubsliceOffset(document, de.highlight)
 
-	errMessage := de.message
+	errMessage := de.Error()
 	errLine, errColumn := positionAtEnd(document[:offset])
 	before, after := linesOfContext(document, de.highlight, offset, 3)
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -182,6 +182,8 @@ line 5`,
 }
 
 func TestDecodeError_Accessors(t *testing.T) {
+	t.Parallel()
+
 	e := DecodeError{
 		message: "foo",
 		line:    1,

--- a/errors_test.go
+++ b/errors_test.go
@@ -189,14 +189,15 @@ func ExampleDecodeError() {
 
 	fmt.Println(err)
 
+	//nolint:errorlint
 	de := err.(*DecodeError)
 	fmt.Println(de.String())
 
 	row, col := de.Position()
-	fmt.Println("error occured at row", row, "column", col)
+	fmt.Println("error occurred at row", row, "column", col)
 	// Output:
 	// toml: number must have at least one digit between underscores
 	// 1| name = 123__456
 	//  |           ~~ number must have at least one digit between underscores
-	// error occured at row 1 column 11
+	// error occurred at row 1 column 11
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -181,6 +181,22 @@ line 5`,
 	}
 }
 
+func TestDecodeError_Accessors(t *testing.T) {
+	e := DecodeError{
+		message: "foo",
+		line:    1,
+		column:  2,
+		key:     []string{"one", "two"},
+		human:   "bar",
+	}
+	assert.Equal(t, "toml: foo", e.Error())
+	r, c := e.Position()
+	assert.Equal(t, 1, r)
+	assert.Equal(t, 2, c)
+	assert.Equal(t, Key{"one", "two"}, e.Key())
+	assert.Equal(t, "bar", e.String())
+}
+
 func ExampleDecodeError() {
 	doc := `name = 123__456`
 

--- a/marshaler.go
+++ b/marshaler.go
@@ -197,7 +197,7 @@ func (ctx *encoderCtx) isRoot() bool {
 
 //nolint:cyclop,funlen
 func (enc *Encoder) encode(b []byte, ctx encoderCtx, v reflect.Value) ([]byte, error) {
-	if v.Kind() == reflect.Interface && !v.IsZero() {
+	if !v.IsZero() {
 		i, ok := v.Interface().(time.Time)
 		if ok {
 			return i.AppendFormat(b, time.RFC3339), nil

--- a/marshaler.go
+++ b/marshaler.go
@@ -127,6 +127,10 @@ func (enc *Encoder) Encode(v interface{}) error {
 
 	ctx.inline = enc.tablesInline
 
+	if v == nil {
+		return fmt.Errorf("toml: cannot encode a nil interface")
+	}
+
 	b, err := enc.encode(b, ctx, reflect.ValueOf(v))
 	if err != nil {
 		return err
@@ -193,9 +197,11 @@ func (ctx *encoderCtx) isRoot() bool {
 
 //nolint:cyclop,funlen
 func (enc *Encoder) encode(b []byte, ctx encoderCtx, v reflect.Value) ([]byte, error) {
-	i, ok := v.Interface().(time.Time)
-	if ok {
-		return i.AppendFormat(b, time.RFC3339), nil
+	if v.Kind() == reflect.Interface && !v.IsZero() {
+		i, ok := v.Interface().(time.Time)
+		if ok {
+			return i.AppendFormat(b, time.RFC3339), nil
+		}
 	}
 
 	if v.Type().Implements(textMarshalerType) {

--- a/marshaler.go
+++ b/marshaler.go
@@ -279,11 +279,6 @@ func (enc *Encoder) encodeKv(b []byte, ctx encoderCtx, options valueOptions, v r
 	if !ctx.hasKey {
 		panic("caller of encodeKv should have set the key in the context")
 	}
-
-	if isNil(v) {
-		return b, nil
-	}
-
 	b = enc.indent(ctx.indent, b)
 
 	b, err = enc.encodeKey(b, ctx.key)
@@ -476,12 +471,7 @@ func (enc *Encoder) encodeMap(b []byte, ctx encoderCtx, v reflect.Value) ([]byte
 			continue
 		}
 
-		table, err := willConvertToTableOrArrayTable(ctx, v)
-		if err != nil {
-			return nil, err
-		}
-
-		if table {
+		if willConvertToTableOrArrayTable(ctx, v) {
 			t.pushTable(k, v, emptyValueOptions)
 		} else {
 			t.pushKV(k, v, emptyValueOptions)
@@ -549,18 +539,13 @@ func (enc *Encoder) encodeStruct(b []byte, ctx encoderCtx, v reflect.Value) ([]b
 			continue
 		}
 
-		willConvert, err := willConvertToTableOrArrayTable(ctx, f)
-		if err != nil {
-			return nil, err
-		}
-
 		options := valueOptions{
 			multiline: fieldBoolTag(fieldType, "multiline"),
 		}
 
 		inline := fieldBoolTag(fieldType, "inline")
 
-		if inline || !willConvert {
+		if inline || !willConvertToTableOrArrayTable(ctx, f) {
 			t.pushKV(k, f, options)
 		} else {
 			t.pushTable(k, f, options)
@@ -646,21 +631,8 @@ func (enc *Encoder) encodeTableInline(b []byte, ctx encoderCtx, t table) ([]byte
 		}
 	}
 
-	for _, table := range t.tables {
-		if first {
-			first = false
-		} else {
-			b = append(b, `, `...)
-		}
-
-		ctx.setKey(table.Key)
-
-		b, err = enc.encode(b, ctx, table.Value)
-		if err != nil {
-			return nil, err
-		}
-
-		b = append(b, '\n')
+	if len(t.tables) > 0 {
+		panic("inline table cannot contain nested tables, online key-values")
 	}
 
 	b = append(b, "}"...)
@@ -670,61 +642,50 @@ func (enc *Encoder) encodeTableInline(b []byte, ctx encoderCtx, t table) ([]byte
 
 var textMarshalerType = reflect.TypeOf(new(encoding.TextMarshaler)).Elem()
 
-func willConvertToTable(ctx encoderCtx, v reflect.Value) (bool, error) {
+func willConvertToTable(ctx encoderCtx, v reflect.Value) bool {
 	if v.Type() == timeType || v.Type().Implements(textMarshalerType) {
-		return false, nil
+		return false
 	}
 
 	t := v.Type()
 	switch t.Kind() {
 	case reflect.Map, reflect.Struct:
-		return !ctx.inline, nil
+		return !ctx.inline
 	case reflect.Interface:
-		if v.IsNil() {
-			return false, fmt.Errorf("toml: encoding a nil interface is not supported")
-		}
-
 		return willConvertToTable(ctx, v.Elem())
 	case reflect.Ptr:
 		if v.IsNil() {
-			return false, nil
+			return false
 		}
 
 		return willConvertToTable(ctx, v.Elem())
 	default:
-		return false, nil
+		return false
 	}
 }
 
-func willConvertToTableOrArrayTable(ctx encoderCtx, v reflect.Value) (bool, error) {
+func willConvertToTableOrArrayTable(ctx encoderCtx, v reflect.Value) bool {
 	t := v.Type()
 
 	if t.Kind() == reflect.Interface {
-		if v.IsNil() {
-			return false, fmt.Errorf("toml: encoding a nil interface is not supported")
-		}
-
 		return willConvertToTableOrArrayTable(ctx, v.Elem())
 	}
 
 	if t.Kind() == reflect.Slice {
 		if v.Len() == 0 {
 			// An empty slice should be a kv = [].
-			return false, nil
+			return false
 		}
 
 		for i := 0; i < v.Len(); i++ {
-			t, err := willConvertToTable(ctx, v.Index(i))
-			if err != nil {
-				return false, err
-			}
+			t := willConvertToTable(ctx, v.Index(i))
 
 			if !t {
-				return false, nil
+				return false
 			}
 		}
 
-		return true, nil
+		return true
 	}
 
 	return willConvertToTable(ctx, v)
@@ -737,12 +698,7 @@ func (enc *Encoder) encodeSlice(b []byte, ctx encoderCtx, v reflect.Value) ([]by
 		return b, nil
 	}
 
-	allTables, err := willConvertToTableOrArrayTable(ctx, v)
-	if err != nil {
-		return nil, err
-	}
-
-	if allTables {
+	if willConvertToTableOrArrayTable(ctx, v) {
 		return enc.encodeSliceAsArrayTable(b, ctx, v)
 	}
 
@@ -752,10 +708,6 @@ func (enc *Encoder) encodeSlice(b []byte, ctx encoderCtx, v reflect.Value) ([]by
 // caller should have checked that v is a slice that only contains values that
 // encode into tables.
 func (enc *Encoder) encodeSliceAsArrayTable(b []byte, ctx encoderCtx, v reflect.Value) ([]byte, error) {
-	if v.Len() == 0 {
-		return b, nil
-	}
-
 	ctx.shiftKey()
 
 	var err error

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -685,18 +685,24 @@ func (c *customTextMarshaler) MarshalText() ([]byte, error) {
 }
 
 func TestMarshalTextMarshaler_NoRoot(t *testing.T) {
+	t.Parallel()
+
 	c := customTextMarshaler{}
 	_, err := toml.Marshal(&c)
 	require.Error(t, err)
 }
 
 func TestMarshalTextMarshaler_Error(t *testing.T) {
+	t.Parallel()
+
 	m := map[string]interface{}{"a": &customTextMarshaler{value: 1}}
 	_, err := toml.Marshal(m)
 	require.Error(t, err)
 }
 
 func TestMarshalTextMarshaler_ErrorInline(t *testing.T) {
+	t.Parallel()
+
 	type s struct {
 		A map[string]interface{} `inline:"true"`
 	}
@@ -710,6 +716,8 @@ func TestMarshalTextMarshaler_ErrorInline(t *testing.T) {
 }
 
 func TestMarshalTextMarshaler(t *testing.T) {
+	t.Parallel()
+
 	m := map[string]interface{}{"a": &customTextMarshaler{value: 2}}
 	r, err := toml.Marshal(m)
 	require.NoError(t, err)

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -460,6 +460,36 @@ root = 'value0'
 	}
 }
 
+type customTextMarshaler struct {
+	value int64
+}
+
+func (c *customTextMarshaler) MarshalText() ([]byte, error) {
+	if c.value == 1 {
+		return nil, fmt.Errorf("cannot represent 1 because this is a silly test")
+	}
+	return []byte(fmt.Sprintf("::%d", c.value)), nil
+}
+
+func TestMarshalTextMarshaler_NoRoot(t *testing.T) {
+	c := customTextMarshaler{}
+	_, err := toml.Marshal(&c)
+	require.Error(t, err)
+}
+
+func TestMarshalTextMarshaler_Error(t *testing.T) {
+	m := map[string]interface{}{"a": &customTextMarshaler{value: 1}}
+	_, err := toml.Marshal(m)
+	require.Error(t, err)
+}
+
+func TestMarshalTextMarshaler(t *testing.T) {
+	m := map[string]interface{}{"a": &customTextMarshaler{value: 2}}
+	r, err := toml.Marshal(m)
+	require.NoError(t, err)
+	equalStringsIgnoreNewlines(t, "a = '::2'", string(r))
+}
+
 func TestIssue436(t *testing.T) {
 	t.Parallel()
 

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -385,7 +385,7 @@ hello = 'world'`,
 			err: true,
 		},
 		{
-			desc: "empty slice of empty structs",
+			desc: "empty slice of empty struct",
 			v: struct {
 				A []struct{}
 			}{

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -16,6 +16,8 @@ import (
 func TestMarshal(t *testing.T) {
 	t.Parallel()
 
+	someInt := 42
+
 	examples := []struct {
 		desc     string
 		v        interface{}
@@ -297,6 +299,45 @@ A = [
   [3, 4]
 ]
 `,
+		},
+		{
+			desc: "nil interface not supported at root",
+			v:    nil,
+			err:  true,
+		},
+		{
+			desc: "nil interface not supported in slice",
+			v: map[string]interface{}{
+				"a": []interface{}{"a", nil, 2},
+			},
+			err: true,
+		},
+		{
+			desc: "nil pointer in slice uses zero value",
+			v: struct {
+				A []*int
+			}{
+				A: []*int{nil},
+			},
+			expected: `A = [0]`,
+		},
+		{
+			desc: "nil pointer in slice uses zero value",
+			v: struct {
+				A []*int
+			}{
+				A: []*int{nil},
+			},
+			expected: `A = [0]`,
+		},
+		{
+			desc: "pointer in slice",
+			v: struct {
+				A []*int
+			}{
+				A: []*int{&someInt},
+			},
+			expected: `A = [42]`,
 		},
 	}
 

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -18,6 +18,10 @@ func TestMarshal(t *testing.T) {
 
 	someInt := 42
 
+	type structInline struct {
+		A interface{} `inline:"true"`
+	}
+
 	examples := []struct {
 		desc     string
 		v        interface{}
@@ -339,6 +343,174 @@ A = [
 			},
 			expected: `A = [42]`,
 		},
+		{
+			desc: "inline table in inline table",
+			v: structInline{
+				A: structInline{
+					A: structInline{
+						A: "hello",
+					},
+				},
+			},
+			expected: `A = {A = {A = 'hello'}}`,
+		},
+		{
+			desc: "empty slice in map",
+			v: map[string][]string{
+				"a": {},
+			},
+			expected: `a = []`,
+		},
+		{
+			desc: "map in slice",
+			v: map[string][]map[string]string{
+				"a": {{"hello": "world"}},
+			},
+			expected: `
+[[a]]
+hello = 'world'`,
+		},
+		{
+			desc: "newline in map in slice",
+			v: map[string][]map[string]string{
+				"a\n": {{"hello": "world"}},
+			},
+			err: true,
+		},
+		{
+			desc: "newline in map in slice",
+			v: map[string][]map[string]*customTextMarshaler{
+				"a": {{"hello": &customTextMarshaler{1}}},
+			},
+			err: true,
+		},
+		{
+			desc: "empty slice of empty structs",
+			v: struct {
+				A []struct{}
+			}{
+				A: []struct{}{},
+			},
+			expected: `A = []`,
+		},
+		{
+			desc: "nil field is ignored",
+			v: struct {
+				A interface{}
+			}{
+				A: nil,
+			},
+			expected: ``,
+		},
+		{
+			desc: "private fields are ignored",
+			v: struct {
+				Public  string
+				private string
+			}{
+				Public:  "shown",
+				private: "hidden",
+			},
+			expected: `Public = 'shown'`,
+		},
+		{
+			desc: "fields tagged - are ignored",
+			v: struct {
+				Public  string `toml:"-"`
+				private string
+			}{
+				Public: "hidden",
+			},
+			expected: ``,
+		},
+		{
+			desc: "nil value in map is ignored",
+			v: map[string]interface{}{
+				"A": nil,
+			},
+			expected: ``,
+		},
+		{
+			desc: "new line in table key",
+			v: map[string]interface{}{
+				"hello\nworld": 42,
+			},
+			err: true,
+		},
+		{
+			desc: "new line in parent of nested table key",
+			v: map[string]interface{}{
+				"hello\nworld": map[string]interface{}{
+					"inner": 42,
+				},
+			},
+			err: true,
+		},
+		{
+			desc: "new line in nested table key",
+			v: map[string]interface{}{
+				"parent": map[string]interface{}{
+					"in\ner": map[string]interface{}{
+						"foo": 42,
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			desc: "invalid map key",
+			v:    map[int]interface{}{},
+			err:  true,
+		},
+		{
+			desc: "unhandled type",
+			v: struct {
+				A chan int
+			}{
+				A: make(chan int),
+			},
+			err: true,
+		},
+		{
+			desc: "numbers",
+			v: struct {
+				A float32
+				B uint64
+				C uint32
+				D uint16
+				E uint8
+				F uint
+				G int64
+				H int32
+				I int16
+				J int8
+				K int
+			}{
+				A: 1.1,
+				B: 42,
+				C: 42,
+				D: 42,
+				E: 42,
+				F: 42,
+				G: 42,
+				H: 42,
+				I: 42,
+				J: 42,
+				K: 42,
+			},
+			expected: `
+A = 1.1
+B = 42
+C = 42
+D = 42
+E = 42
+F = 42
+G = 42
+H = 42
+I = 42
+J = 42
+K = 42`,
+		},
 	}
 
 	for _, e := range examples {
@@ -524,11 +696,52 @@ func TestMarshalTextMarshaler_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestMarshalTextMarshaler_ErrorInline(t *testing.T) {
+	type s struct {
+		A map[string]interface{} `inline:"true"`
+	}
+
+	d := s{
+		A: map[string]interface{}{"a": &customTextMarshaler{value: 1}},
+	}
+
+	_, err := toml.Marshal(d)
+	require.Error(t, err)
+}
+
 func TestMarshalTextMarshaler(t *testing.T) {
 	m := map[string]interface{}{"a": &customTextMarshaler{value: 2}}
 	r, err := toml.Marshal(m)
 	require.NoError(t, err)
 	equalStringsIgnoreNewlines(t, "a = '::2'", string(r))
+}
+
+type brokenWriter struct{}
+
+func (b *brokenWriter) Write([]byte) (int, error) {
+	return 0, fmt.Errorf("dead")
+}
+
+func TestEncodeToBrokenWriter(t *testing.T) {
+	t.Parallel()
+	w := brokenWriter{}
+	enc := toml.NewEncoder(&w)
+	err := enc.Encode(map[string]string{"hello": "world"})
+	require.Error(t, err)
+}
+
+func TestEncoderSetIndentSymbol(t *testing.T) {
+	t.Parallel()
+	var w strings.Builder
+	enc := toml.NewEncoder(&w)
+	enc.SetIndentTables(true)
+	enc.SetIndentSymbol(">>>")
+	err := enc.Encode(map[string]map[string]string{"parent": {"hello": "world"}})
+	require.NoError(t, err)
+	expected := `
+[parent]
+>>>hello = 'world'`
+	equalStringsIgnoreNewlines(t, expected, w.String())
 }
 
 func TestIssue436(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -304,6 +304,7 @@ func atmost(b []byte, n int) []byte {
 	if n >= len(b) {
 		return b
 	}
+
 	return b[:n]
 }
 

--- a/parser.go
+++ b/parser.go
@@ -826,11 +826,14 @@ byteLoop:
 		c := b[i]
 
 		switch {
-		case isDigit(c) || c == '-':
+		case isDigit(c):
+		case c == '-':
+			const offsetOfTz = 19
+			if i == offsetOfTz {
+				hasTz = true
+			}
 		case c == 'T' || c == ':' || c == '.':
 			hasTime = true
-
-			continue byteLoop
 		case c == '+' || c == '-' || c == 'Z':
 			hasTz = true
 		case c == ' ':

--- a/parser.go
+++ b/parser.go
@@ -204,6 +204,10 @@ func (p *parser) parseKeyval(b []byte) (ast.Reference, []byte, error) {
 
 	b = p.parseWhitespace(b)
 
+	if len(b) == 0 {
+		return ast.Reference{}, nil, newDecodeError(b, "expected = after a key, but the document ends there")
+	}
+
 	b, err = expect('=', b)
 	if err != nil {
 		return ast.Reference{}, nil, err
@@ -641,7 +645,8 @@ func (p *parser) parseSimpleKey(b []byte) (key, rest []byte, err error) {
 	case b[0] == '"':
 		return p.parseBasicString(b)
 	case isUnquotedKeyChar(b[0]):
-		return scanUnquotedKey(b)
+		key, rest = scanUnquotedKey(b)
+		return key, rest, nil
 	default:
 		return nil, nil, newDecodeError(b[0:1], "invalid character at start of key: %c", b[0])
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -30,15 +30,15 @@ func scanFollowsNan(b []byte) bool {
 	return scanFollows(b, `nan`)
 }
 
-func scanUnquotedKey(b []byte) ([]byte, []byte, error) {
+func scanUnquotedKey(b []byte) ([]byte, []byte) {
 	// unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
 	for i := 0; i < len(b); i++ {
 		if !isUnquotedKeyChar(b[i]) {
-			return b[:i], b[i:], nil
+			return b[:i], b[i:]
 		}
 	}
 
-	return b, b[len(b):], nil
+	return b, b[len(b):]
 }
 
 func isUnquotedKeyChar(r byte) bool {

--- a/targets.go
+++ b/targets.go
@@ -115,7 +115,6 @@ func (t mapTarget) setFloat64(v float64) {
 	t.set(reflect.ValueOf(v))
 }
 
-//nolint:cyclop
 // makes sure that the value pointed at by t is indexable (Slice, Array), or
 // dereferences to an indexable (Ptr, Interface).
 func ensureValueIndexable(t target) error {
@@ -193,7 +192,7 @@ const (
 	minInt = -maxInt - 1
 )
 
-//nolint:funlen,gocognit,cyclop,gocyclo
+//nolint:funlen,gocognit,cyclop
 func setInt64(t target, v int64) error {
 	f := t.get()
 
@@ -285,7 +284,6 @@ func setFloat64(t target, v float64) error {
 	return nil
 }
 
-//nolint:cyclop
 // Returns the element at idx of the value pointed at by target, or an error if
 // t does not point to an indexable.
 // If the target points to an Array and idx is out of bounds, it returns
@@ -311,7 +309,6 @@ func elementAt(t target, idx int) target {
 	case reflect.Interface:
 		// This function is called after ensureValueIndexable, so it's
 		// guaranteed that f contains an initialized slice.
-
 		ifaceElem := f.Elem()
 		idx := ifaceElem.Len()
 		newElem := reflect.New(ifaceElem.Type().Elem()).Elem()
@@ -326,7 +323,6 @@ func elementAt(t target, idx int) target {
 	}
 }
 
-//nolint:cyclop
 func (d *decoder) scopeTableTarget(shouldAppend bool, t target, name string) (target, bool, error) {
 	x := t.get()
 

--- a/targets.go
+++ b/targets.go
@@ -70,19 +70,19 @@ func (t interfaceTarget) set(v reflect.Value) {
 }
 
 func (t interfaceTarget) setString(v string) {
-	t.x.setString(v)
+	panic("interface targets should always go through set")
 }
 
 func (t interfaceTarget) setBool(v bool) {
-	t.x.setBool(v)
+	panic("interface targets should always go through set")
 }
 
 func (t interfaceTarget) setInt64(v int64) {
-	t.x.setInt64(v)
+	panic("interface targets should always go through set")
 }
 
 func (t interfaceTarget) setFloat64(v float64) {
-	t.x.setFloat64(v)
+	panic("interface targets should always go through set")
 }
 
 // mapTarget targets a specific key of a map.

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// nolint:funlen
 func TestUnmarshal_Integers(t *testing.T) {
 	t.Parallel()
 

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1518,21 +1518,35 @@ bar = 42
 		t.Run(e.desc, func(t *testing.T) {
 			t.Parallel()
 
-			r := strings.NewReader(e.input)
-			d := toml.NewDecoder(r)
-			d.SetStrict(true)
-			x := e.target
-			if x == nil {
-				x = &struct{}{}
-			}
-			err := d.Decode(x)
+			t.Run("strict", func(t *testing.T) {
+				r := strings.NewReader(e.input)
+				d := toml.NewDecoder(r)
+				d.SetStrict(true)
+				x := e.target
+				if x == nil {
+					x = &struct{}{}
+				}
+				err := d.Decode(x)
 
-			var tsm *toml.StrictMissingError
-			if errors.As(err, &tsm) {
-				equalStringsIgnoreNewlines(t, e.expected, tsm.String())
-			} else {
-				t.Fatalf("err should have been a *toml.StrictMissingError, but got %s (%T)", err, err)
-			}
+				var tsm *toml.StrictMissingError
+				if errors.As(err, &tsm) {
+					equalStringsIgnoreNewlines(t, e.expected, tsm.String())
+				} else {
+					t.Fatalf("err should have been a *toml.StrictMissingError, but got %s (%T)", err, err)
+				}
+			})
+
+			t.Run("default", func(t *testing.T) {
+				r := strings.NewReader(e.input)
+				d := toml.NewDecoder(r)
+				d.SetStrict(false)
+				x := e.target
+				if x == nil {
+					x = &struct{}{}
+				}
+				err := d.Decode(x)
+				require.NoError(t, err)
+			})
 		})
 	}
 }

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -863,6 +863,49 @@ B = "data"`,
 			},
 		},
 		{
+			desc:  "array of int in map",
+			input: `A = [1,2,3]`,
+			gen: func() test {
+				return test{
+					target:   &map[string][3]int{},
+					expected: &map[string][3]int{"A": {1, 2, 3}},
+				}
+			},
+		},
+		{
+			desc:  "array of int in map with too many elements",
+			input: `A = [1,2,3,4,5]`,
+			gen: func() test {
+				return test{
+					target:   &map[string][3]int{},
+					expected: &map[string][3]int{"A": {1, 2, 3}},
+				}
+			},
+		},
+		{
+			desc:  "array of int in map with invalid element",
+			input: `A = [1,2,false]`,
+			gen: func() test {
+				return test{
+					target: &map[string][3]int{},
+					err:    true,
+				}
+			},
+		},
+		{
+			desc:  "array of int in struct",
+			input: `A = [1,2,3]`,
+			gen: func() test {
+				type s struct {
+					A [3]int
+				}
+				return test{
+					target:   &s{},
+					expected: &s{A: [3]int{1, 2, 3}},
+				}
+			},
+		},
+		{
 			desc:  "assign bool to float",
 			input: `A = true`,
 			gen: func() test {
@@ -1028,7 +1071,6 @@ B = "data"`,
 	}
 }
 
-//nolint:funlen
 func TestUnmarshalOverflows(t *testing.T) {
 	examples := []struct {
 		t      interface{}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1230,6 +1230,10 @@ world'`,
 			data: `a = 0n`,
 		},
 		{
+			desc: `invalid unquoted key`,
+			data: `a`,
+		},
+		{
 			desc: "dt with tz has no time",
 			data: `a = 2021-03-30TZ`,
 		},

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -241,6 +241,34 @@ func TestUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			desc:  "time.time with negative zone",
+			input: `a = 1979-05-27T00:32:00-07:00 `, // space intentional
+			gen: func() test {
+				var v map[string]time.Time
+
+				return test{
+					target: &v,
+					expected: &map[string]time.Time{
+						"a": time.Date(1979, 5, 27, 0, 32, 0, 0, time.FixedZone("", -7*3600)),
+					},
+				}
+			},
+		},
+		{
+			desc:  "time.time with positive zone",
+			input: `a = 1979-05-27T00:32:00+07:00`,
+			gen: func() test {
+				var v map[string]time.Time
+
+				return test{
+					target: &v,
+					expected: &map[string]time.Time{
+						"a": time.Date(1979, 5, 27, 0, 32, 0, 0, time.FixedZone("", 7*3600)),
+					},
+				}
+			},
+		},
+		{
 			desc: "issue 475 - space between dots in key",
 			input: `fruit. color = "yellow"
 					fruit . flavor = "banana"`,
@@ -1005,8 +1033,60 @@ func TestUnmarshalDecodeErrors(t *testing.T) {
 			data: `a = 20x1-05-21`,
 		},
 		{
+			desc: "local time with fractional",
+			data: `a = 11:22:33.x`,
+		},
+		{
+			desc: "local time frac precision too large",
+			data: `a = 2021-05-09T11:22:33.99999999999`,
+		},
+		{
+			desc: "wrong time offset separator",
+			data: `a = 1979-05-27T00:32:00T07:00`,
+		},
+		{
+			desc: "wrong time offset separator",
+			data: `a = 1979-05-27T00:32:00Z07:00`,
+		},
+		{
+			desc: "float with double _",
+			data: `flt8 = 224_617.445_991__228`,
+		},
+		{
+			desc: "float with double _",
+			data: `flt8 = 1..2`,
+		},
+		{
 			desc: "int with wrong base",
 			data: `a = 0f2`,
+		},
+		{
+			desc: "int hex with double underscore",
+			data: `a = 0xFFF__FFF`,
+		},
+		{
+			desc: "int hex very large",
+			data: `a = 0xFFFFFFFFFFFFFFFFF`,
+		},
+		{
+			desc: "int oct with double underscore",
+			data: `a = 0o777__77`,
+		},
+		{
+			desc: "int oct very large",
+			data: `a = 0o77777777777777777777777`,
+		},
+		{
+			desc: "int bin with double underscore",
+			data: `a = 0b111__111`,
+		},
+		{
+			desc: "int bin very large",
+			data: `a = 0b11111111111111111111111111111111111111111111111111111111111111111111111111111`,
+		},
+		{
+			desc: "int dec very large",
+			data: `a = 999999999999999999999999`,
 		},
 		{
 			desc: "literal string with new lines",

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -818,6 +818,61 @@ B = "data"`,
 			},
 		},
 		{
+			desc:  "interface holding a string",
+			input: `A = "Hello"`,
+			gen: func() test {
+				type doc struct {
+					A interface{}
+				}
+				return test{
+					target: &doc{},
+					expected: &doc{
+						A: "Hello",
+					},
+				}
+			},
+		},
+		{
+			desc:  "map of bools",
+			input: `A = true`,
+			gen: func() test {
+				return test{
+					target:   &map[string]bool{},
+					expected: &map[string]bool{"A": true},
+				}
+			},
+		},
+		{
+			desc:  "map of int64",
+			input: `A = 42`,
+			gen: func() test {
+				return test{
+					target:   &map[string]int64{},
+					expected: &map[string]int64{"A": 42},
+				}
+			},
+		},
+		{
+			desc:  "map of float64",
+			input: `A = 4.2`,
+			gen: func() test {
+				return test{
+					target:   &map[string]float64{},
+					expected: &map[string]float64{"A": 4.2},
+				}
+			},
+		},
+		{
+			desc:  "assign bool to float",
+			input: `A = true`,
+			gen: func() test {
+				return test{
+					target: &map[string]float64{},
+					err:    true,
+				}
+			},
+		},
+		{
 			desc: "interface holding a struct",
 			input: `[A]
 					B = "After"`,

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -318,6 +318,73 @@ func TestUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			desc:  "multiline literal string with windows newline",
+			input: "A = '''\r\nTest'''",
+			gen: func() test {
+				type doc struct {
+					A string
+				}
+
+				return test{
+					target:   &doc{},
+					expected: &doc{A: "Test"},
+				}
+			},
+		},
+		{
+			desc:  "multiline basic string with windows newline",
+			input: "A = \"\"\"\r\nTest\"\"\"",
+			gen: func() test {
+				type doc struct {
+					A string
+				}
+
+				return test{
+					target:   &doc{},
+					expected: &doc{A: "Test"},
+				}
+			},
+		},
+		{
+			desc: "multiline basic string escapes",
+			input: `A = """
+\\\b\f\n\r\t\uffff\U0001D11E"""`,
+			gen: func() test {
+				type doc struct {
+					A string
+				}
+
+				return test{
+					target:   &doc{},
+					expected: &doc{A: "\\\b\f\n\r\t\uffff\U0001D11E"},
+				}
+			},
+		},
+		{
+			desc:  "basic string escapes",
+			input: `A = "\\\b\f\n\r\t\uffff\U0001D11E"`,
+			gen: func() test {
+				type doc struct {
+					A string
+				}
+
+				return test{
+					target:   &doc{},
+					expected: &doc{A: "\\\b\f\n\r\t\uffff\U0001D11E"},
+				}
+			},
+		},
+		{
+			desc:  "spaces around dotted keys",
+			input: "a . b = 1",
+			gen: func() test {
+				return test{
+					target:   &map[string]map[string]interface{}{},
+					expected: &map[string]map[string]interface{}{"a": {"b": int64(1)}},
+				}
+			},
+		},
+		{
 			desc:  "kv bool true",
 			input: `A = true`,
 			gen: func() test {
@@ -1149,6 +1216,98 @@ world'`,
 			desc: "bad char between minutes and seconds",
 			data: `a = 2021-03-30 21:312:0`,
 			msg:  `expecting colon between minutes and seconds`,
+		},
+		{
+			desc: `binary with invalid digit`,
+			data: `a = 0bf`,
+		},
+		{
+			desc: `invalid i in dec`,
+			data: `a = 0i`,
+		},
+		{
+			desc: `invalid n in dec`,
+			data: `a = 0n`,
+		},
+		{
+			desc: "dt with tz has no time",
+			data: `a = 2021-03-30TZ`,
+		},
+		{
+			desc: "invalid end of array table",
+			data: `[[a}`,
+		},
+		{
+			desc: "invalid end of array table two",
+			data: `[[a]}`,
+		},
+		{
+			desc: "eof after equal",
+			data: `a =`,
+		},
+		{
+			desc: "invalid true boolean",
+			data: `a = trois`,
+		},
+		{
+			desc: "invalid false boolean",
+			data: `a = faux`,
+		},
+		{
+			desc: "inline table with incorrect separator",
+			data: `a = {b=1;}`,
+		},
+		{
+			desc: "inline table with invalid value",
+			data: `a = {b=faux}`,
+		},
+		{
+			desc: `incomplete array after whitespace`,
+			data: `a = [ `,
+		},
+		{
+			desc: `array with comma first`,
+			data: `a = [ ,]`,
+		},
+		{
+			desc: `array staring with incomplete newline`,
+			data: "a = [\r]",
+		},
+		{
+			desc: `array with incomplete newline after comma`,
+			data: "a = [1,\r]",
+		},
+		{
+			desc: `array with incomplete newline after value`,
+			data: "a = [1\r]",
+		},
+		{
+			desc: `invalid unicode in basic multiline string`,
+			data: `A = """\u123"""`,
+		},
+		{
+			desc: `invalid long unicode in basic multiline string`,
+			data: `A = """\U0001D11"""`,
+		},
+		{
+			desc: `invalid unicode in basic string`,
+			data: `A = "\u123"`,
+		},
+		{
+			desc: `invalid long unicode in basic string`,
+			data: `A = "\U0001D11"`,
+		},
+		{
+			desc: `invalid escape char basic multiline string`,
+			data: `A = """\z"""`,
+		},
+		{
+			desc: `invalid inf`,
+			data: `A = ick`,
+		},
+		{
+			desc: `invalid nan`,
+			data: `A = non`,
 		},
 	}
 

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1001,6 +1001,10 @@ func TestUnmarshalDecodeErrors(t *testing.T) {
 		msg  string
 	}{
 		{
+			desc: "local date with invalid digit",
+			data: `a = 20x1-05-21`,
+		},
+		{
 			desc: "int with wrong base",
 			data: `a = 0f2`,
 		},


### PR DESCRIPTION
~Goal is 95%~ ✅ 97.6%

--- 

Some more allocations. Guessing this comes from the new array handling. Will get rid of them during the performance round.

```
name                              old time/op    new time/op    delta
UnmarshalDataset/config-32          78.6ms ± 4%    79.7ms ± 2%    ~     (p=0.165 n=10+10)
UnmarshalDataset/canada-32           105ms ± 2%     106ms ± 6%    ~     (p=0.356 n=9+10)
UnmarshalDataset/citm_catalog-32    55.6ms ± 6%    56.7ms ± 4%    ~     (p=0.143 n=10+10)
UnmarshalDataset/twitter-32         24.4ms ± 7%    24.9ms ± 5%    ~     (p=0.218 n=10+10)
UnmarshalDataset/code-32             294ms ± 4%     297ms ± 4%    ~     (p=0.113 n=10+9)
UnmarshalDataset/example-32          481µs ± 3%     475µs ± 4%    ~     (p=0.278 n=9+10)
UnmarshalSimple-32                  1.29µs ± 3%    1.27µs ± 4%    ~     (p=0.171 n=10+10)
ReferenceFile-32                    42.1µs ± 3%    40.4µs ± 3%  -3.99%  (p=0.000 n=9+9)

name                              old speed      new speed      delta
UnmarshalDataset/config-32        13.3MB/s ± 3%  13.2MB/s ± 2%    ~     (p=0.251 n=9+10)
UnmarshalDataset/canada-32        21.0MB/s ± 2%  20.8MB/s ± 6%    ~     (p=0.345 n=9+10)
UnmarshalDataset/citm_catalog-32  10.0MB/s ± 6%   9.8MB/s ± 4%    ~     (p=0.143 n=10+10)
UnmarshalDataset/twitter-32       18.1MB/s ± 7%  17.8MB/s ± 5%    ~     (p=0.197 n=10+10)
UnmarshalDataset/code-32          9.15MB/s ± 4%  9.03MB/s ± 4%    ~     (p=0.099 n=10+9)
UnmarshalDataset/example-32       16.9MB/s ± 3%  17.1MB/s ± 4%    ~     (p=0.278 n=9+10)
ReferenceFile-32                   125MB/s ± 3%   130MB/s ± 3%  +4.17%  (p=0.000 n=9+9)

name                              old alloc/op   new alloc/op   delta
UnmarshalDataset/config-32          16.9MB ± 0%    16.9MB ± 0%  +0.00%  (p=0.000 n=9+10)
UnmarshalDataset/canada-32          74.3MB ± 0%    74.3MB ± 0%  +0.00%  (p=0.000 n=10+10)
UnmarshalDataset/citm_catalog-32    37.1MB ± 0%    37.3MB ± 0%  +0.45%  (p=0.000 n=9+10)
UnmarshalDataset/twitter-32         15.6MB ± 0%    15.6MB ± 0%  +0.11%  (p=0.000 n=10+10)
UnmarshalDataset/code-32            59.3MB ± 0%    59.5MB ± 0%  +0.33%  (p=0.000 n=10+8)
UnmarshalDataset/example-32          238kB ± 0%     238kB ± 0%  +0.19%  (p=0.000 n=10+10)
ReferenceFile-32                    11.8kB ± 0%    11.8kB ± 0%    ~     (all equal)

name                              old allocs/op  new allocs/op  delta
UnmarshalDataset/config-32            645k ± 0%      645k ± 0%  +0.00%  (p=0.000 n=10+7)
UnmarshalDataset/canada-32            896k ± 0%      896k ± 0%  +0.00%  (p=0.000 n=10+10)
UnmarshalDataset/citm_catalog-32      370k ± 0%      380k ± 0%  +2.83%  (p=0.000 n=9+10)
UnmarshalDataset/twitter-32           157k ± 0%      158k ± 0%  +0.67%  (p=0.000 n=10+10)
UnmarshalDataset/code-32             2.91M ± 0%     2.92M ± 0%  +0.42%  (p=0.000 n=10+7)
UnmarshalDataset/example-32          3.63k ± 0%     3.66k ± 0%  +0.80%  (p=0.000 n=10+10)
ReferenceFile-32                       253 ± 0%       253 ± 0%    ~     (all equal)

```