### PR TITLE
Fix timezone detection when time has fractional component

### DIFF
--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -145,6 +145,25 @@ func BenchmarkReferenceFile(b *testing.B) {
 	}
 }
 
+func BenchmarkReferenceFileMap(b *testing.B) {
+	bytes, err := ioutil.ReadFile("benchmark.toml")
+	if err != nil {
+		b.Fatal(err)
+	}
+	benchmetrics.ResetCounters()
+	b.SetBytes(int64(len(bytes)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m := map[string]interface{}{}
+		err := toml.Unmarshal(bytes, &m)
+		if err != nil {
+			panic(err)
+		}
+	}
+	benchmetrics.Report(b)
+}
+
 func TestReferenceFile(t *testing.T) {
 	bytes, err := ioutil.ReadFile("benchmark.toml")
 	require.NoError(t, err)

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -150,7 +150,6 @@ func BenchmarkReferenceFileMap(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	benchmetrics.ResetCounters()
 	b.SetBytes(int64(len(bytes)))
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -161,7 +160,6 @@ func BenchmarkReferenceFileMap(b *testing.B) {
 			panic(err)
 		}
 	}
-	benchmetrics.Report(b)
 }
 
 func TestReferenceFile(t *testing.T) {

--- a/decode.go
+++ b/decode.go
@@ -172,6 +172,14 @@ func parseLocalTime(b []byte) (LocalTime, []byte, error) {
 		digits := 0
 
 		for i, c := range b[minLengthWithFrac:] {
+			if !isDigit(c) {
+				if i == 0 {
+					return t, nil, newDecodeError(b[i:i+1], "need at least one digit after fraction point")
+				}
+
+				break
+			}
+
 			const maxFracPrecision = 9
 			if i >= maxFracPrecision {
 				return t, nil, newDecodeError(b[i:i+1], "maximum precision for date time is nanosecond")

--- a/parser.go
+++ b/parser.go
@@ -823,8 +823,8 @@ byteLoop:
 		switch {
 		case isDigit(c):
 		case c == '-':
-			const offsetOfTz = 19
-			if i == offsetOfTz {
+			const minOffsetOfTz = 8
+			if i >= minOffsetOfTz {
 				hasTz = true
 			}
 		case c == 'T' || c == ':' || c == '.':

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -269,6 +269,20 @@ func TestUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			desc:  "time.time with zone and fractional",
+			input: `a = 1979-05-27T00:32:00.999999-07:00`,
+			gen: func() test {
+				var v map[string]time.Time
+
+				return test{
+					target: &v,
+					expected: &map[string]time.Time{
+						"a": time.Date(1979, 5, 27, 0, 32, 0, 999999000, time.FixedZone("", -7*3600)),
+					},
+				}
+			},
+		},
+		{
 			desc: "issue 475 - space between dots in key",
 			input: `fruit. color = "yellow"
 					fruit . flavor = "banana"`,
@@ -1376,7 +1390,11 @@ func TestUnmarshalDecodeErrors(t *testing.T) {
 		},
 		{
 			desc: "wrong time offset separator",
-			data: `a = 1979-05-27T00:32:00T07:00`,
+			data: `a = 1979-05-27T00:32:00.-07:00`,
+		},
+		{
+			desc: "missing fractional with tz",
+			data: `a = 2021-05-09T11:22:33.99999999999`,
 		},
 		{
 			desc: "wrong time offset separator",


### PR DESCRIPTION
When I added `BenchmarkReferenceFileMap`, the test started crashing. Because it unmarshals into a map[string]interface{}, the parser was using the time decoding function instead of the local time, which uncovered the bug.

