### PR TITLE
hexToString  optimization

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -791,7 +791,12 @@ func hexToString(b []byte, length int) (string, error) {
 	}
 	b = b[:length]
 
-	return string(hexToRune(b)), nil
+	r := hexToRune(b)
+	if r == -1 {
+		return "", newDecodeError(b, "contains non-hex character")
+	}
+
+	return string(r), nil
 }
 
 func (p *parser) parseWhitespace(b []byte) []byte {

--- a/parser_test.go
+++ b/parser_test.go
@@ -348,3 +348,22 @@ func TestParser_AST(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkHexToString(b *testing.B) {
+	b.Run("4", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(4)
+
+		for i := 0; i < b.N; i++ {
+			_, _ = hexToString([]byte("ABCD"), 4)
+		}
+	})
+	b.Run("8", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(8)
+
+		for i := 0; i < b.N; i++ {
+			_, _ = hexToString([]byte("0001F680"), 8)
+		}
+	})
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -349,21 +349,24 @@ func TestParser_AST(t *testing.T) {
 	}
 }
 
-func BenchmarkHexToString(b *testing.B) {
+func BenchmarkParseBasicStringWithUnicode(b *testing.B) {
+	p := &parser{}
 	b.Run("4", func(b *testing.B) {
+		input := []byte(`"\u1234\u5678\u9ABC\u1234\u5678\u9ABC"`)
 		b.ReportAllocs()
-		b.SetBytes(4)
+		b.SetBytes(int64(len(input)))
 
 		for i := 0; i < b.N; i++ {
-			_, _ = hexToString([]byte("ABCD"), 4)
+			p.parseBasicString(input)
 		}
 	})
 	b.Run("8", func(b *testing.B) {
+		input := []byte(`"\u12345678\u9ABCDEF0\u12345678\u9ABCDEF0"`)
 		b.ReportAllocs()
-		b.SetBytes(8)
+		b.SetBytes(int64(len(input)))
 
 		for i := 0; i < b.N; i++ {
-			_, _ = hexToString([]byte("0001F680"), 8)
+			p.parseBasicString(input)
 		}
 	})
 }


### PR DESCRIPTION
simple optimize hexToString..
hexToRune is copy from encoding/json

benchmark
```
func Benchmark_hexToString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		hexToString([]byte("0001F680"), 8)
	}
}
```

```
goos: darwin
goarch: arm64
pkg: tstgo
Benchmark_hexToString
Benchmark_hexToString-8    	30278191	        39.64 ns/op	      16 B/op	       2 allocs/op
Benchmark_hexToString2
Benchmark_hexToString2-8   	134665851	         8.828 ns/op	       0 B/op	       0 allocs/op
```