### PR TITLE
Go 1.17 release

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest']
-        go: [ '1.15', '1.16' ]
+        go: [ '1.16', '1.17' ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.go }}/${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pelletier/go-toml/v2
 
-go 1.15
+go 1.16
 
 // latest (v1.7.0) doesn't have the fix for time.Time
 require github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942


### PR DESCRIPTION
old: 1.16.7
new: 1.17

~ 7% faster.

```
name                                old time/op    new time/op    delta
UnmarshalDataset/config-32            24.4ms ± 0%    22.2ms ± 1%   -8.82%  (p=0.000 n=9+9)
UnmarshalDataset/canada-32            85.8ms ± 1%    81.2ms ± 1%   -5.37%  (p=0.000 n=10+10)
UnmarshalDataset/citm_catalog-32      27.1ms ± 1%    26.3ms ± 2%   -3.07%  (p=0.000 n=10+10)
UnmarshalDataset/twitter-32           10.5ms ± 1%    10.2ms ± 1%   -3.05%  (p=0.000 n=10+10)
UnmarshalDataset/code-32               107ms ± 0%      97ms ± 0%   -8.65%  (p=0.000 n=10+10)
UnmarshalDataset/example-32            176µs ± 4%     170µs ± 1%   -3.56%  (p=0.009 n=10+10)
Unmarshal/SimpleDocument/struct-32     591ns ± 3%     559ns ± 2%   -5.43%  (p=0.000 n=10+10)
Unmarshal/SimpleDocument/map-32        974ns ± 1%     813ns ± 5%  -16.52%  (p=0.000 n=10+10)
Unmarshal/ReferenceFile/struct-32     42.0µs ± 0%    38.1µs ± 1%   -9.23%  (p=0.000 n=9+10)
Unmarshal/ReferenceFile/map-32        72.0µs ± 1%    66.1µs ± 1%   -8.28%  (p=0.000 n=9+10)
Unmarshal/HugoFrontMatter-32          14.3µs ± 1%    13.7µs ± 1%   -4.32%  (p=0.000 n=10+9)
Marshal/SimpleDocument/struct-32       474ns ± 2%     486ns ± 1%   +2.38%  (p=0.000 n=10+10)
Marshal/SimpleDocument/map-32          799ns ± 1%     718ns ± 2%  -10.16%  (p=0.000 n=10+10)
Marshal/ReferenceFile/struct-32       37.1µs ± 0%    34.5µs ± 1%   -6.97%  (p=0.000 n=8+10)
Marshal/ReferenceFile/map-32          58.0µs ± 0%    53.6µs ± 4%   -7.48%  (p=0.000 n=10+10)
Marshal/HugoFrontMatter-32            10.5µs ± 2%     9.9µs ± 2%   -5.68%  (p=0.000 n=10+10)
[Geo mean]                             122µs          114µs        -6.60%

name                                old speed      new speed      delta
UnmarshalDataset/config-32          43.1MB/s ± 0%  47.2MB/s ± 1%   +9.67%  (p=0.000 n=9+9)
UnmarshalDataset/canada-32          25.7MB/s ± 1%  27.1MB/s ± 1%   +5.68%  (p=0.000 n=10+10)
UnmarshalDataset/citm_catalog-32    20.6MB/s ± 1%  21.2MB/s ± 2%   +3.18%  (p=0.000 n=10+10)
UnmarshalDataset/twitter-32         42.0MB/s ± 1%  43.4MB/s ± 1%   +3.14%  (p=0.000 n=10+10)
UnmarshalDataset/code-32            25.2MB/s ± 0%  27.6MB/s ± 0%   +9.47%  (p=0.000 n=10+10)
UnmarshalDataset/example-32         46.1MB/s ± 4%  47.7MB/s ± 1%   +3.61%  (p=0.009 n=10+10)
Unmarshal/SimpleDocument/struct-32  18.6MB/s ± 3%  19.7MB/s ± 2%   +5.70%  (p=0.000 n=10+10)
Unmarshal/SimpleDocument/map-32     11.3MB/s ± 1%  13.5MB/s ± 5%  +19.87%  (p=0.000 n=10+10)
Unmarshal/ReferenceFile/struct-32    125MB/s ± 0%   138MB/s ± 1%  +10.16%  (p=0.000 n=9+10)
Unmarshal/ReferenceFile/map-32      72.8MB/s ± 1%  79.3MB/s ± 1%   +9.04%  (p=0.000 n=9+10)
Unmarshal/HugoFrontMatter-32        38.1MB/s ± 1%  39.8MB/s ± 1%   +4.52%  (p=0.000 n=10+9)
Marshal/SimpleDocument/struct-32    25.3MB/s ± 2%  24.7MB/s ± 1%   -2.33%  (p=0.000 n=10+10)
Marshal/SimpleDocument/map-32       15.0MB/s ± 1%  16.7MB/s ± 2%  +11.31%  (p=0.000 n=10+10)
Marshal/ReferenceFile/struct-32     55.0MB/s ± 0%  59.1MB/s ± 1%   +7.49%  (p=0.000 n=8+10)
Marshal/ReferenceFile/map-32        34.4MB/s ± 0%  37.2MB/s ± 4%   +8.12%  (p=0.000 n=10+10)
Marshal/HugoFrontMatter-32          49.9MB/s ± 2%  52.9MB/s ± 2%   +6.02%  (p=0.000 n=10+10)
[Geo mean]                          33.8MB/s       36.2MB/s        +7.07%

name                                old alloc/op   new alloc/op   delta
UnmarshalDataset/config-32            5.91MB ± 0%    5.91MB ± 0%     ~     (p=0.436 n=10+10)
UnmarshalDataset/canada-32            84.4MB ± 0%    84.4MB ± 0%     ~     (p=0.091 n=10+10)
UnmarshalDataset/citm_catalog-32      35.6MB ± 0%    35.6MB ± 0%     ~     (p=0.684 n=10+10)
UnmarshalDataset/twitter-32           13.5MB ± 0%    13.5MB ± 0%     ~     (p=0.631 n=10+10)
UnmarshalDataset/code-32              22.2MB ± 0%    22.2MB ± 0%     ~     (p=0.118 n=10+10)
UnmarshalDataset/example-32            193kB ± 0%     193kB ± 0%     ~     (p=0.490 n=10+10)
Unmarshal/SimpleDocument/struct-32      581B ± 0%      581B ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/map-32         957B ± 0%      957B ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/struct-32     11.6kB ± 0%    11.6kB ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/map-32        28.9kB ± 0%    28.9kB ± 0%     ~     (all equal)
Unmarshal/HugoFrontMatter-32          7.38kB ± 0%    7.38kB ± 0%     ~     (all equal)
Marshal/SimpleDocument/struct-32        224B ± 0%      224B ± 0%     ~     (all equal)
Marshal/SimpleDocument/map-32           384B ± 0%      384B ± 0%     ~     (all equal)
Marshal/ReferenceFile/struct-32       23.9kB ± 0%    23.9kB ± 0%     ~     (all equal)
Marshal/ReferenceFile/map-32          31.4kB ± 0%    31.4kB ± 0%     ~     (all equal)
Marshal/HugoFrontMatter-32            6.10kB ± 0%    6.10kB ± 0%     ~     (all equal)
[Geo mean]                            72.3kB         72.3kB        +0.00%

name                                old allocs/op  new allocs/op  delta
UnmarshalDataset/config-32              233k ± 0%      233k ± 0%     ~     (all equal)
UnmarshalDataset/canada-32              782k ± 0%      782k ± 0%     ~     (all equal)
UnmarshalDataset/citm_catalog-32        192k ± 0%      192k ± 0%     ~     (all equal)
UnmarshalDataset/twitter-32            56.9k ± 0%     56.9k ± 0%     ~     (p=0.689 n=10+10)
UnmarshalDataset/code-32               1.06M ± 0%     1.06M ± 0%     ~     (p=0.137 n=8+10)
UnmarshalDataset/example-32            1.36k ± 0%     1.36k ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/struct-32      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/map-32         12.0 ± 0%      12.0 ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/struct-32        180 ± 0%       180 ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/map-32           647 ± 0%       647 ± 0%     ~     (all equal)
Unmarshal/HugoFrontMatter-32             143 ± 0%       143 ± 0%     ~     (all equal)
Marshal/SimpleDocument/struct-32        8.00 ± 0%      8.00 ± 0%     ~     (all equal)
Marshal/SimpleDocument/map-32           11.0 ± 0%      11.0 ± 0%     ~     (all equal)
Marshal/ReferenceFile/struct-32          309 ± 0%       309 ± 0%     ~     (all equal)
Marshal/ReferenceFile/map-32             500 ± 0%       500 ± 0%     ~     (all equal)
Marshal/HugoFrontMatter-32              95.0 ± 0%      95.0 ± 0%     ~     (all equal)
[Geo mean]                             1.11k          1.11k        +0.00%
```
