### PR TITLE
unmarshal: don't crash on unterminated inline table

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -353,7 +353,13 @@ func (p *parser) parseInlineTable(b []byte) (ast.Reference, []byte, error) {
 	var err error
 
 	for len(b) > 0 {
+		previousB := b
 		b = p.parseWhitespace(b)
+
+		if len(b) == 0 {
+			return parent, nil, newDecodeError(previousB[:1], "inline table is incomplete")
+		}
+
 		if b[0] == '}' {
 			break
 		}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1734,6 +1734,12 @@ func TestIssue581(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIssue586(t *testing.T) {
+	var v interface{}
+	err := toml.Unmarshal([]byte(`a={ `), &v)
+	require.Error(t, err)
+}
+
 //nolint:funlen
 func TestUnmarshalDecodeErrors(t *testing.T) {
 	examples := []struct {


### PR DESCRIPTION
Fixes #586