### PR TITLE
parser: don't overflow when parsing bad times

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -894,6 +894,11 @@ byteLoop:
 		case c == ' ':
 			if !seenSpace && i+1 < len(b) && isDigit(b[i+1]) {
 				i += 2
+				// Avoid reaching past the end of the document in case the time
+				// is malformed. See TestIssue585.
+				if i >= len(b) {
+					i--
+				}
 				seenSpace = true
 				hasTime = true
 			} else {

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1746,6 +1746,12 @@ func TestIssue588(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIssue585(t *testing.T) {
+	var v interface{}
+	err := toml.Unmarshal([]byte(`a=1979-05127T 0`), &v)
+	require.Error(t, err)
+}
+
 //nolint:funlen
 func TestUnmarshalDecodeErrors(t *testing.T) {
 	examples := []struct {


### PR DESCRIPTION
Fixes https://github.com/pelletier/go-toml/issues/585