### PR TITLE
unmarshal: support lowercase 'T' and 'Z' in date-time parsing

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -75,7 +75,7 @@ func parseDateTime(b []byte) (time.Time, error) {
 		panic("date time should have a timezone")
 	}
 
-	if b[0] == 'Z' {
+	if b[0] == 'Z' || b[0] == 'z' {
 		b = b[1:]
 		zone = time.UTC
 	} else {
@@ -127,7 +127,7 @@ func parseLocalDateTime(b []byte) (LocalDateTime, []byte, error) {
 	dt.LocalDate = date
 
 	sep := b[10]
-	if sep != 'T' && sep != ' ' {
+	if sep != 'T' && sep != ' ' && sep != 't' {
 		return dt, nil, newDecodeError(b[10:11], "datetime separator is expected to be T or a space")
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -887,9 +887,9 @@ byteLoop:
 			if i >= minOffsetOfTz {
 				hasTz = true
 			}
-		case c == 'T' || c == ':' || c == '.':
+		case c == 'T' || c == 't' || c == ':' || c == '.':
 			hasTime = true
-		case c == '+' || c == '-' || c == 'Z':
+		case c == '+' || c == '-' || c == 'Z' || c == 'z':
 			hasTz = true
 		case c == ' ':
 			if !seenSpace && i+1 < len(b) && isDigit(b[i+1]) {

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1752,6 +1752,13 @@ func TestIssue585(t *testing.T) {
 	require.Error(t, err)
 }
 
+// Support lowercase 'T' and 'Z'
+func TestIssue600(t *testing.T) {
+	var v interface{}
+	err := toml.Unmarshal([]byte(`a=1979-05-27t00:32:00z`), &v)
+	require.NoError(t, err)
+}
+
 //nolint:funlen
 func TestUnmarshalDecodeErrors(t *testing.T) {
 	examples := []struct {


### PR DESCRIPTION
RFC3399 allows for lowercase 't' and 'z' in date-time values.

Fixes #600