### PR TITLE
support parsing uint64

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1113,7 +1113,7 @@ func (d *Decoder) valueFromToml(mtype reflect.Type, tval interface{}, mval1 *ref
 				return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to %v", tval, tval, mtype.String())
 			}
 
-			if val.Convert(reflect.TypeOf(int(1))).Int() < 0 {
+			if val.Type().Kind() != reflect.Uint64 && val.Convert(reflect.TypeOf(int(1))).Int() < 0 {
 				return reflect.ValueOf(nil), fmt.Errorf("%v(%T) is negative so does not fit in %v", tval, tval, mtype.String())
 			}
 			if reflect.Indirect(reflect.New(mtype)).OverflowUint(val.Convert(reflect.TypeOf(uint64(0))).Uint()) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1162,3 +1162,10 @@ str3 = """\
 		t.Errorf("expected '%s', got '%s'", expected, got)
 	}
 }
+
+func TestUint(t *testing.T) {
+	tree, err := Load("hello = 18446744073709551615")
+	assertTree(t, tree, err, map[string]interface{}{
+		"hello": uint64(math.MaxUint64),
+	})
+}


### PR DESCRIPTION
**Issue:** add link to pelletier/go-toml issue here
https://github.com/spf13/viper/issues/1221

Explanation of what this pull request does.

For the following code snippet, an error will be returned, `(2, 5): strconv.ParseInt: parsing "18446744073709551615": value out of range`, this PR deals with cases where the value is greater than `math.MaxInt64` and less than or equal to `math.MaxUint64`.
```
package main

import (
	"fmt"

	"github.com/pelletier/go-toml"
)

type Config struct {
	V uint64
}

func main() {
	doc := []byte(`
V = 18446744073709551615
`)

```