### PR TITLE
testsuite: add package for toml-test integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,8 @@ module github.com/pelletier/go-toml/v2
 
 go 1.16
 
-// latest (v1.7.0) doesn't have the fix for time.Time
-require github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942
+require (
+	github.com/BurntSushi/toml-test v1.0.1
+	// latest (v1.7.0) doesn't have the fix for time.Time
+	github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/BurntSushi/toml-test v1.0.1 h1:EuoKSP/21iziY0JVvMcNuRI3wnj1xvx6v0JE59grnUE=
+github.com/BurntSushi/toml-test v1.0.1/go.mod h1:LMdIewbFxV5doWcnP4xQ2SMTe9991CgofCUverF7Lb0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -9,3 +13,4 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+zgo.at/zli v0.0.0-20210619044753-e7020a328e59/go.mod h1:HLAc12TjNGT+VRXr76JnsNE3pbooQtwKWhX+RlDjQ2Y=

--- a/testsuite/add.go
+++ b/testsuite/add.go
@@ -1,0 +1,74 @@
+package testsuite
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// addTag adds JSON tags to a data structure as expected by toml-test.
+func addTag(key string, tomlData interface{}) interface{} {
+	// Switch on the data type.
+	switch orig := tomlData.(type) {
+	default:
+		//return map[string]interface{}{}
+		panic(fmt.Sprintf("Unknown type: %T", tomlData))
+
+	// A table: we don't need to add any tags, just recurse for every table
+	// entry.
+	case map[string]interface{}:
+		typed := make(map[string]interface{}, len(orig))
+		for k, v := range orig {
+			typed[k] = addTag(k, v)
+		}
+		return typed
+
+	// An array: we don't need to add any tags, just recurse for every table
+	// entry.
+	case []map[string]interface{}:
+		typed := make([]map[string]interface{}, len(orig))
+		for i, v := range orig {
+			typed[i] = addTag("", v).(map[string]interface{})
+		}
+		return typed
+	case []interface{}:
+		typed := make([]interface{}, len(orig))
+		for i, v := range orig {
+			typed[i] = addTag("", v)
+		}
+		return typed
+
+	// Datetime: tag as datetime.
+	case toml.LocalTime:
+		return tag("time-local", orig.String())
+	case toml.LocalDate:
+		return tag("date-local", orig.String())
+	case toml.LocalDateTime:
+		return tag("datetime-local", orig.String())
+	case time.Time:
+		return tag("datetime", orig.Format("2006-01-02T15:04:05.999999999Z07:00"))
+
+	// Tag primitive values: bool, string, int, and float64.
+	case bool:
+		return tag("bool", fmt.Sprintf("%v", orig))
+	case string:
+		return tag("string", orig)
+	case int64:
+		return tag("integer", fmt.Sprintf("%d", orig))
+	case float64:
+		// Special case for nan since NaN == NaN is false.
+		if math.IsNaN(orig) {
+			return tag("float", "nan")
+		}
+		return tag("float", fmt.Sprintf("%v", orig))
+	}
+}
+
+func tag(typeName string, data interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"type":  typeName,
+		"value": data,
+	}
+}

--- a/testsuite/parser.go
+++ b/testsuite/parser.go
@@ -1,0 +1,69 @@
+package testsuite
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+type parser struct{}
+
+func (p parser) Decode(input string) (output string, outputIsError bool, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch rr := r.(type) {
+			case error:
+				retErr = rr
+			default:
+				retErr = fmt.Errorf("%s", rr)
+			}
+		}
+	}()
+
+	var v interface{}
+
+	if err := toml.Unmarshal([]byte(input), &v); err != nil {
+		return err.Error(), true, nil
+	}
+
+	j, err := json.MarshalIndent(addTag("", v), "", "  ")
+	if err != nil {
+		return "", false, retErr
+	}
+
+	return string(j), false, retErr
+}
+
+func (p parser) Encode(input string) (output string, outputIsError bool, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch rr := r.(type) {
+			case error:
+				retErr = rr
+			default:
+				retErr = fmt.Errorf("%s", rr)
+			}
+		}
+	}()
+
+	var tmp interface{}
+	err := json.Unmarshal([]byte(input), &tmp)
+	if err != nil {
+		return "", false, err
+	}
+
+	rm, err := rmTag(tmp)
+	if err != nil {
+		return err.Error(), true, retErr
+	}
+
+	buf := new(bytes.Buffer)
+	err = toml.NewEncoder(buf).Encode(rm)
+	if err != nil {
+		return err.Error(), true, retErr
+	}
+
+	return buf.String(), false, retErr
+}

--- a/testsuite/rm.go
+++ b/testsuite/rm.go
@@ -1,0 +1,110 @@
+package testsuite
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// Remove JSON tags to a data structure as returned by toml-test.
+func rmTag(typedJson interface{}) (interface{}, error) {
+	// Check if key is in the table m.
+	in := func(key string, m map[string]interface{}) bool {
+		_, ok := m[key]
+		return ok
+	}
+
+	// Switch on the data type.
+	switch v := typedJson.(type) {
+
+	// Object: this can either be a TOML table or a primitive with tags.
+	case map[string]interface{}:
+		// This value represents a primitive: remove the tags and return just
+		// the primitive value.
+		if len(v) == 2 && in("type", v) && in("value", v) {
+			ut, err := untag(v)
+			if err != nil {
+				return ut, fmt.Errorf("tag.Remove: %w", err)
+			}
+			return ut, nil
+		}
+
+		// Table: remove tags on all children.
+		m := make(map[string]interface{}, len(v))
+		for k, v2 := range v {
+			var err error
+			m[k], err = rmTag(v2)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return m, nil
+
+	// Array: remove tags from all itenm.
+	case []interface{}:
+		a := make([]interface{}, len(v))
+		for i := range v {
+			var err error
+			a[i], err = rmTag(v[i])
+			if err != nil {
+				return nil, err
+			}
+		}
+		return a, nil
+	}
+
+	// The top level must be an object or array.
+	return nil, fmt.Errorf("unrecognized JSON format '%T'", typedJson)
+}
+
+// Return a primitive: read the "type" and convert the "value" to that.
+func untag(typed map[string]interface{}) (interface{}, error) {
+	t := typed["type"].(string)
+	v := typed["value"].(string)
+	switch t {
+	case "string":
+		return v, nil
+	case "integer":
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("untag: %w", err)
+		}
+		return n, nil
+	case "float":
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return nil, fmt.Errorf("untag: %w", err)
+		}
+		return f, nil
+	case "datetime":
+		return parseTime(v, "2006-01-02T15:04:05.999999999Z07:00", false)
+	case "datetime-local":
+		return parseTime(v, "2006-01-02T15:04:05.999999999", true)
+	case "date-local":
+		return parseTime(v, "2006-01-02", true)
+	case "time-local":
+		return parseTime(v, "15:04:05.999999999", true)
+	case "bool":
+		switch v {
+		case "true":
+			return true, nil
+		case "false":
+			return false, nil
+		}
+		return nil, fmt.Errorf("untag: could not parse %q as a boolean", v)
+	}
+
+	return nil, fmt.Errorf("untag: unrecognized tag type %q", t)
+}
+
+func parseTime(v, format string, local bool) (t time.Time, err error) {
+	if local {
+		t, err = time.ParseInLocation(format, v, time.Local)
+	} else {
+		t, err = time.Parse(format, v)
+	}
+	if err != nil {
+		return time.Time{}, fmt.Errorf("Could not parse %q as a datetime: %w", v, err)
+	}
+	return t, nil
+}

--- a/testsuite/testsuite.go
+++ b/testsuite/testsuite.go
@@ -1,0 +1,31 @@
+// Package testsuite runs tests from the github.com/BurntSushi/toml-test
+// test suite.
+//
+// The data files are included within the toml-test package, so no file
+// generation is required.
+package testsuite
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// Decode is a helper function for the toml-test binary interface.  TOML input
+// is read from STDIN and a resulting tagged JSON representation is written to
+// STDOUT.
+func Decode() {
+	var decoded map[string]interface{}
+
+	if err := toml.NewDecoder(os.Stdin).Decode(&decoded); err != nil {
+		log.Fatalf("Error decoding TOML: %s", err)
+	}
+
+	j := json.NewEncoder(os.Stdout)
+	j.SetIndent("", "  ")
+	if err := j.Encode(addTag("", decoded)); err != nil {
+		log.Fatalf("Error encoding JSON: %s", err)
+	}
+}

--- a/testsuite/testsuite_test.go
+++ b/testsuite/testsuite_test.go
@@ -1,0 +1,37 @@
+package testsuite
+
+import (
+	"testing"
+
+	tomltest "github.com/BurntSushi/toml-test"
+)
+
+func TestTomlTestSuite(t *testing.T) {
+	run := func(t *testing.T, enc bool) {
+		r := tomltest.Runner{
+			Files:     tomltest.EmbeddedTests(),
+			Encoder:   enc,
+			Parser:    parser{},
+			SkipTests: []string{},
+		}
+
+		tests, err := r.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, test := range tests.Tests {
+			t.Run(test.Path, func(t *testing.T) {
+				if test.Failed() {
+					t.Fatalf("\nError:\n%s\n\nInput:\n%s\nOutput:\n%s\nWant:\n%s\n",
+						test.Failure, test.Input, test.Output, test.Want)
+					return
+				}
+			})
+		}
+		t.Logf("passed: %d; failed: %d; skipped: %d", tests.Passed, tests.Failed, tests.Skipped)
+	}
+
+	t.Run("decode", func(t *testing.T) { run(t, false) })
+	t.Run("encode", func(t *testing.T) { run(t, true) })
+}


### PR DESCRIPTION
Does not generate local test files but uses tests embedded in `toml-test` package.  Kept out of internal packages to make `testsuite.Decode` accessible from a future cmd package.

**Discussion:** #599