### PR TITLE
Fix failing tests for invalid control characters in comments

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -106,7 +106,10 @@ func (p *parser) parseExpression(b []byte) (ast.Reference, []byte, error) {
 	}
 
 	if b[0] == '#' {
-		_, rest := scanComment(b)
+		_, rest, err := scanComment(b)
+		if err != nil {
+			return ref, rest, err
+		}
 
 		return ref, rest, nil
 	}
@@ -129,7 +132,10 @@ func (p *parser) parseExpression(b []byte) (ast.Reference, []byte, error) {
 	b = p.parseWhitespace(b)
 
 	if len(b) > 0 && b[0] == '#' {
-		_, rest := scanComment(b)
+		_, rest, err := scanComment(b)
+		if err != nil {
+			return ref, rest, err
+		}
 
 		return ref, rest, nil
 	}
@@ -478,7 +484,10 @@ func (p *parser) parseOptionalWhitespaceCommentNewline(b []byte) ([]byte, error)
 		b = p.parseWhitespace(b)
 
 		if len(b) > 0 && b[0] == '#' {
-			_, b = scanComment(b)
+			_, b, err = scanComment(b)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		if len(b) == 0 {

--- a/scanner.go
+++ b/scanner.go
@@ -106,7 +106,7 @@ func scanWhitespace(b []byte) ([]byte, []byte) {
 }
 
 //nolint:unparam
-func scanComment(b []byte) ([]byte, []byte) {
+func scanComment(b []byte) ([]byte, []byte, error) {
 	// comment-start-symbol = %x23 ; #
 	// non-ascii = %x80-D7FF / %xE000-10FFFF
 	// non-eol = %x09 / %x20-7F / non-ascii
@@ -114,11 +114,11 @@ func scanComment(b []byte) ([]byte, []byte) {
 	// comment = comment-start-symbol *non-eol
 	for i := 1; i < len(b); i++ {
 		if b[i] == '\n' {
-			return b[:i], b[i:]
+			return b[:i], b[i:], nil
 		}
 	}
 
-	return b, b[len(b):]
+	return b, b[len(b):], nil
 }
 
 func scanBasicString(b []byte) ([]byte, []byte, error) {

--- a/scanner.go
+++ b/scanner.go
@@ -122,6 +122,9 @@ func scanComment(b []byte) ([]byte, []byte, error) {
 		if b[i] == 0x00 {
 			return b[:i], b[i:], newDecodeError(b[:i], "comments cannot include the 0x00 NUL character")
 		}
+		if b[i] == 0x1f {
+			return b[:i], b[i:], newDecodeError(b[:i], "comments cannot include the 0x1f US character")
+		}
 		if b[i] == '\n' {
 			return b[:i], b[i:], nil
 		}

--- a/scanner.go
+++ b/scanner.go
@@ -116,6 +116,10 @@ func scanComment(b []byte) ([]byte, []byte, error) {
 		if b[i] == 0x7f {
 			return b[:i], b[i:], newDecodeError(b[:i], "comments cannot include the 0x7f DEL character")
 		}
+		if b[i] == 0x0a {
+			return b[:i], b[i:], newDecodeError(b[:i], "comments cannot include the 0x0a LF character")
+			return b[:i], b[i:], newDecodeError(b[:i], "comments cannot include the 0x0A LF character")
+		}
 		if b[i] == '\n' {
 			return b[:i], b[i:], nil
 		}

--- a/scanner.go
+++ b/scanner.go
@@ -113,6 +113,9 @@ func scanComment(b []byte) ([]byte, []byte, error) {
 	//
 	// comment = comment-start-symbol *non-eol
 	for i := 1; i < len(b); i++ {
+		if b[i] == 0x7f {
+			return b[:i], b[i:], newDecodeError(b[:i], "comments cannot include the 0x7f DEL character")
+		}
 		if b[i] == '\n' {
 			return b[:i], b[i:], nil
 		}

--- a/scanner.go
+++ b/scanner.go
@@ -118,7 +118,9 @@ func scanComment(b []byte) ([]byte, []byte, error) {
 		}
 		if b[i] == 0x0a {
 			return b[:i], b[i:], newDecodeError(b[:i], "comments cannot include the 0x0a LF character")
-			return b[:i], b[i:], newDecodeError(b[:i], "comments cannot include the 0x0A LF character")
+		}
+		if b[i] == 0x00 {
+			return b[:i], b[i:], newDecodeError(b[:i], "comments cannot include the 0x00 NUL character")
 		}
 		if b[i] == '\n' {
 			return b[:i], b[i:], nil

--- a/toml_testgen_test.go
+++ b/toml_testgen_test.go
@@ -84,12 +84,12 @@ func TestTOMLTest_Invalid_Control_CommentLf(t *testing.T) {
 }
 
 func TestTOMLTest_Invalid_Control_CommentNull(t *testing.T) {
-	input := "comment-null = \"null\" # \x00\n"
+	input := "comment-null = \"null\" # \u0000\n"
 	testgenInvalid(t, input)
 }
 
 func TestTOMLTest_Invalid_Control_CommentUs(t *testing.T) {
-	input := "comment-us = \"ctrl-_\" # \x1f\n"
+	input := "comment-us = \"ctrl-_\" # \u001f\n"
 	testgenInvalid(t, input)
 }
 


### PR DESCRIPTION
**Issue:** #613 

* Modifies `scanComment()` to error out early if an illegal character is found
* Adds illegal characters to `scanComment()`

~~Note that the NUL and US control characters weren't causing tests to fail prior to me making my changes... I took a quick look into why but couldn't crack why those tests weren't failing on my machine (`TestTOMLTest_Invalid_Control_CommentNull` and `TestTOMLTest_Invalid_Control_CommentUs`).~~ Turns out the codegen used the xNN notation instead of Unicode values for NUL and US control characters. I've modified the testgen file accordingly.