### PR TITLE
gotoml-test-decoder: add toml-test decoder command

### DIFF
--- a/cmd/gotoml-test-decoder/main.go
+++ b/cmd/gotoml-test-decoder/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path"
+
+	"github.com/pelletier/go-toml/v2/testsuite"
+)
+
+func main() {
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+	if flag.NArg() != 0 {
+		flag.Usage()
+	}
+
+	err := testsuite.DecodeStdin()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func usage() {
+	log.Printf("Usage: %s < toml-file\n", path.Base(os.Args[0]))
+	flag.PrintDefaults()
+	os.Exit(1)
+}

--- a/testsuite/testsuite.go
+++ b/testsuite/testsuite.go
@@ -4,7 +4,7 @@ package testsuite
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/pelletier/go-toml/v2"
@@ -33,16 +33,18 @@ func ValueToTaggedJSON(doc interface{}) ([]byte, error) {
 // DecodeStdin is a helper function for the toml-test binary interface.  TOML input
 // is read from STDIN and a resulting tagged JSON representation is written to
 // STDOUT.
-func DecodeStdin() {
+func DecodeStdin() error {
 	var decoded map[string]interface{}
 
 	if err := toml.NewDecoder(os.Stdin).Decode(&decoded); err != nil {
-		log.Fatalf("Error decoding TOML: %s", err)
+		return fmt.Errorf("Error decoding TOML: %s", err)
 	}
 
 	j := json.NewEncoder(os.Stdout)
 	j.SetIndent("", "  ")
 	if err := j.Encode(addTag("", decoded)); err != nil {
-		log.Fatalf("Error encoding JSON: %s", err)
+		fmt.Errorf("Error encoding JSON: %s", err)
 	}
+
+	return nil
 }


### PR DESCRIPTION
This command may feel redundant, but providing this command allows us to compare `go-toml` to other implementations with a simple CLI interface.