### PR TITLE
fix: Adjust formatting for local datetime objects

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -37,9 +37,7 @@ func parseLocalDate(b []byte) (LocalDate, error) {
 
 	date.Year = parseDecimalDigits(b[0:4])
 
-	v := parseDecimalDigits(b[5:7])
-
-	date.Month = v
+	date.Month = parseDecimalDigits(b[5:7])
 
 	date.Day = parseDecimalDigits(b[8:10])
 

--- a/localtime.go
+++ b/localtime.go
@@ -2,6 +2,7 @@ package toml
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -52,7 +53,7 @@ func (d LocalTime) String() string {
 	if d.Nanosecond == 0 {
 		return s
 	}
-	return s + fmt.Sprintf(".%09d", d.Nanosecond)
+	return s + strings.Trim(fmt.Sprintf(".%09d", d.Nanosecond), "0")
 }
 
 // MarshalText returns RFC 3339 representation of d.
@@ -86,7 +87,7 @@ func (d LocalDateTime) AsTime(zone *time.Location) time.Time {
 
 // String returns RFC 3339 representation of d.
 func (d LocalDateTime) String() string {
-	return d.LocalDate.String() + " " + d.LocalTime.String()
+	return d.LocalDate.String() + "T" + d.LocalTime.String()
 }
 
 // MarshalText returns RFC 3339 representation of d.


### PR DESCRIPTION
Partially fixes #613
Fixes tests `TestTOMLTest_Valid_Datetime_Local` and `TestTOMLTest_Valid_Datetime_Milliseconds`.

**Issue:** #613 

Explanation of what this pull request does.
Adjusts the string formatting of `LocalTime` structs to comply with test output (uses a `T` as a date/time separator, trims trailing zeros in nanosecond string).
