### PR TITLE
tomltest: unmarshal JSONs for tests

### DIFF
--- a/toml_testgen_support_test.go
+++ b/toml_testgen_support_test.go
@@ -41,5 +41,14 @@ func testgenValid(t *testing.T, input string, jsonRef string) {
 	}
 	j, err := testsuite.ValueToTaggedJSON(doc)
 	require.NoError(t, err)
-	require.Equal(t, jsonRef, string(j)+"\n")
+
+	var ref interface{}
+	err = json.Unmarshal([]byte(jsonRef), &ref)
+	require.NoError(t, err)
+
+	var actual interface{}
+	err = json.Unmarshal([]byte(j), &actual)
+	require.NoError(t, err)
+
+	require.Equal(t, ref, actual)
 }

--- a/toml_testgen_test.go
+++ b/toml_testgen_test.go
@@ -1493,7 +1493,6 @@ func TestTOMLTest_Valid_Table_Empty(t *testing.T) {
 }
 
 func TestTOMLTest_Valid_Table_Keyword(t *testing.T) {
-	t.Skip("FIXME")
 	input := "[true]\n\n[false]\n\n[inf]\n\n[nan]\n\n\n"
 	jsonRef := "{\n  \"true\": {},\n  \"false\": {},\n  \"inf\": {},\n  \"nan\": {}\n}\n"
 	testgenValid(t, input, jsonRef)


### PR DESCRIPTION
Comparing the output and the expected results byte-wise means we get false
negative when order doesn't matter (for example the ValidTableKeyword test).