### PR TITLE
Decoder: flag invalid carriage returns in strings

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -549,7 +549,7 @@ func (p *parser) parseMultilineBasicString(b []byte) ([]byte, []byte, []byte, er
 	startIdx := i
 	endIdx := len(token) - len(`"""`)
 
-	if escaped < 0 {
+	if !escaped {
 		str := token[startIdx:endIdx]
 		verr := utf8TomlValidAlreadyEscaped(str)
 		if verr.Zero() {
@@ -736,7 +736,7 @@ func (p *parser) parseBasicString(b []byte) ([]byte, []byte, []byte, error) {
 	// Fast path. If there is no escape sequence, the string should just be
 	// an UTF-8 encoded string, which is the same as Go. In that case,
 	// validate the string and return a direct reference to the buffer.
-	if escaped < 0 {
+	if !escaped {
 		str := token[startIdx:endIdx]
 		verr := utf8TomlValidAlreadyEscaped(str)
 		if verr.Zero() {

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2211,6 +2211,14 @@ world'`,
 			desc: `invalid month`,
 			data: `a=2021-0--29`,
 		},
+		{
+			desc: `carriage return inside basic key`,
+			data: "\"\r\"=42",
+		},
+		{
+			desc: `carriage return inside basic string`,
+			data: "A = \"\r\"",
+		},
 	}
 
 	for _, e := range examples {


### PR DESCRIPTION
Fixes #651

Also removed the specialized post-escape case, didn't bring us anything.
