### PR TITLE
Decoder: use lookup table to validate ASCII

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1,6 +1,8 @@
 package toml
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/pelletier/go-toml/v2/internal/ast"
@@ -369,6 +371,23 @@ func BenchmarkParseBasicStringWithUnicode(b *testing.B) {
 			p.parseBasicString(input)
 		}
 	})
+}
+
+func BenchmarkParseBasicStringsEasy(b *testing.B) {
+	p := &parser{}
+
+	for _, size := range []int{1, 4, 8, 16, 21} {
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			input := []byte(`"` + strings.Repeat("A", size) + `"`)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(input)))
+
+			for i := 0; i < b.N; i++ {
+				p.parseBasicString(input)
+			}
+		})
+	}
 }
 
 func TestParser_AST_DateTimes(t *testing.T) {

--- a/utf8.go
+++ b/utf8.go
@@ -140,8 +140,45 @@ func utf8ValidNext(p []byte) int {
 	return size
 }
 
+var invalidAsciiTable = [256]bool{
+	0x00: true,
+	0x01: true,
+	0x02: true,
+	0x03: true,
+	0x04: true,
+	0x05: true,
+	0x06: true,
+	0x07: true,
+	0x08: true,
+	// 0x09 TAB
+	// 0x0A LF
+	0x0B: true,
+	0x0C: true,
+	// 0x0D CR
+	0x0E: true,
+	0x0F: true,
+	0x10: true,
+	0x11: true,
+	0x12: true,
+	0x13: true,
+	0x14: true,
+	0x15: true,
+	0x16: true,
+	0x17: true,
+	0x18: true,
+	0x19: true,
+	0x1A: true,
+	0x1B: true,
+	0x1C: true,
+	0x1D: true,
+	0x1E: true,
+	0x1F: true,
+	// 0x20 - 0x7E Printable ASCII characters
+	0x7F: true,
+}
+
 func invalidAscii(b byte) bool {
-	return b <= 0x08 || (b > 0x0A && b < 0x0D) || (b > 0x0D && b <= 0x1F) || b == 0x7F
+	return invalidAsciiTable[b]
 }
 
 // acceptRange gives the range of valid values for the second byte in a UTF-8


### PR DESCRIPTION
Trade-off: adds 256 bytes to the resulting binary. Go 1.17 stores the table in rodata and inline the call:

```
        0x0025 00037 (utf8.go:181)      LEAQ    "".invalidAsciiTable(SB), CX
        0x002c 00044 (utf8.go:181)      MOVBLZX (CX)(DX*1), CX
        0x0030 00048 (utf8.go:181)      TESTB   CL, CL
```

---

### Benchmark results

(allocations omitted as they are unchanged)

```
name                        old time/op    new time/op    delta
ParseBasicStringsEasy/1-2     10.6ns ± 0%    10.3ns ± 0%   -2.90%  (p=0.016 n=4+5)
ParseBasicStringsEasy/4-2     16.0ns ± 0%    14.8ns ± 0%   -7.31%  (p=0.008 n=5+5)
ParseBasicStringsEasy/8-2     23.8ns ± 1%    21.0ns ± 1%  -11.94%  (p=0.008 n=5+5)
ParseBasicStringsEasy/16-2    36.0ns ± 1%    32.0ns ± 3%  -11.04%  (p=0.008 n=5+5)
ParseBasicStringsEasy/21-2    44.9ns ± 1%    40.3ns ± 0%  -10.24%  (p=0.016 n=5+4)

name                        old speed      new speed      delta
ParseBasicStringsEasy/1-2    282MB/s ± 0%   290MB/s ± 0%   +2.98%  (p=0.016 n=4+5)
ParseBasicStringsEasy/4-2    375MB/s ± 0%   405MB/s ± 0%   +7.89%  (p=0.008 n=5+5)
ParseBasicStringsEasy/8-2    420MB/s ± 1%   476MB/s ± 1%  +13.53%  (p=0.008 n=5+5)
ParseBasicStringsEasy/16-2   500MB/s ± 1%   562MB/s ± 3%  +12.47%  (p=0.008 n=5+5)
ParseBasicStringsEasy/21-2   512MB/s ± 1%   573MB/s ± 2%  +11.81%  (p=0.008 n=5+5)

name                               old time/op    new time/op    delta
UnmarshalDataset/config-2            24.7ms ± 0%    24.5ms ± 0%  -1.04%  (p=0.008 n=5+5)
UnmarshalDataset/canada-2            84.6ms ± 0%    85.1ms ± 2%    ~     (p=0.413 n=4+5)
UnmarshalDataset/citm_catalog-2      25.8ms ± 2%    25.7ms ± 1%    ~     (p=1.000 n=5+5)
UnmarshalDataset/twitter-2           9.53ms ± 0%    9.38ms ± 0%  -1.51%  (p=0.008 n=5+5)
UnmarshalDataset/code-2               107ms ± 1%     107ms ± 1%    ~     (p=0.222 n=5+5)
UnmarshalDataset/example-2            165µs ± 2%     163µs ± 0%  -1.06%  (p=0.016 n=5+4)
Unmarshal/SimpleDocument/struct-2     574ns ± 1%     570ns ± 1%    ~     (p=0.056 n=5+5)
Unmarshal/SimpleDocument/map-2        848ns ± 1%     845ns ± 0%    ~     (p=0.310 n=5+5)
Unmarshal/ReferenceFile/struct-2     55.8µs ± 0%    54.0µs ± 0%  -3.24%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/map-2        83.5µs ± 2%    81.0µs ± 0%  -2.98%  (p=0.008 n=5+5)
Unmarshal/HugoFrontMatter-2          14.4µs ± 1%    14.2µs ± 0%  -1.48%  (p=0.008 n=5+5)

name                               old speed      new speed      delta
UnmarshalDataset/config-2          42.4MB/s ± 0%  42.9MB/s ± 0%  +1.05%  (p=0.008 n=5+5)
UnmarshalDataset/canada-2          26.0MB/s ± 0%  25.9MB/s ± 1%    ~     (p=0.460 n=4+5)
UnmarshalDataset/citm_catalog-2    21.6MB/s ± 2%  21.7MB/s ± 1%    ~     (p=0.952 n=5+5)
UnmarshalDataset/twitter-2         46.4MB/s ± 0%  47.1MB/s ± 0%  +1.53%  (p=0.008 n=5+5)
UnmarshalDataset/code-2            25.0MB/s ± 1%  25.1MB/s ± 1%    ~     (p=0.175 n=5+5)
UnmarshalDataset/example-2         49.2MB/s ± 2%  49.7MB/s ± 0%  +1.07%  (p=0.016 n=5+4)
Unmarshal/SimpleDocument/struct-2  19.2MB/s ± 1%  19.3MB/s ± 0%  +0.74%  (p=0.048 n=5+5)
Unmarshal/SimpleDocument/map-2     13.0MB/s ± 1%  13.0MB/s ± 0%    ~     (p=0.254 n=5+5)
Unmarshal/ReferenceFile/struct-2   94.0MB/s ± 0%  97.1MB/s ± 0%  +3.35%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/map-2      62.8MB/s ± 2%  64.7MB/s ± 0%  +3.06%  (p=0.008 n=5+5)
Unmarshal/HugoFrontMatter-2        37.9MB/s ± 1%  38.4MB/s ± 0%  +1.49%  (p=0.008 n=5+5)
```