### PR TITLE
Decode: prevent comments that look like dates to be accepted

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -884,6 +884,8 @@ func (p *parser) parseIntOrFloatOrDateTime(b []byte) (ast.Reference, []byte, err
 		if idx == 2 && c == ':' || (idx == 4 && c == '-') {
 			return p.scanDateTime(b)
 		}
+
+		break
 	}
 
 	return p.scanIntOrFloat(b)

--- a/parser.go
+++ b/parser.go
@@ -692,10 +692,6 @@ func (p *parser) parseSimpleKey(b []byte) (raw, key, rest []byte, err error) {
 	// simple-key = quoted-key / unquoted-key
 	// unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
 	// quoted-key = basic-string / literal-string
-	if len(b) == 0 {
-		return nil, nil, nil, newDecodeError(b, "key is incomplete")
-	}
-
 	switch {
 	case b[0] == '\'':
 		return p.parseLiteralString(b)

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1569,6 +1569,30 @@ B = "data"`,
 				}
 			},
 		},
+		{
+			desc:  "comment that looks like a date",
+			input: "a=19#9-",
+			gen: func() test {
+				doc := map[string]interface{}{}
+
+				return test{
+					target:   &doc,
+					expected: &map[string]interface{}{"a": int64(19)},
+				}
+			},
+		},
+		{
+			desc:  "comment that looks like a date",
+			input: "a=199#-",
+			gen: func() test {
+				doc := map[string]interface{}{}
+
+				return test{
+					target:   &doc,
+					expected: &map[string]interface{}{"a": int64(199)},
+				}
+			},
+		},
 	}
 
 	for _, e := range examples {


### PR DESCRIPTION
When the parser has to decide between parsing and integer or a date, it should
check that all characters are actually acceptable (digits, or date/time
elements).

Fixes #655