### PR TITLE
Decoder: validate inline tables in arrays don't redefine keys

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -136,17 +136,10 @@ func (n *Node) Key() Iterator {
 // Guaranteed to be non-nil.
 // Panics if not called on a KeyValue node, or if the Children are malformed.
 func (n *Node) Value() *Node {
-	assertKind(KeyValue, *n)
 	return n.Child()
 }
 
 // Children returns an iterator over a node's children.
 func (n *Node) Children() Iterator {
 	return Iterator{node: n.Child()}
-}
-
-func assertKind(k Kind, n Node) {
-	if n.Kind != k {
-		panic(fmt.Errorf("method was expecting a %s, not a %s", k, n.Kind))
-	}
 }

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1916,6 +1916,12 @@ func TestIssue658(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIssue662(t *testing.T) {
+	var v map[string]interface{}
+	err := toml.Unmarshal([]byte("a=[{b=1,b=2}]"), &v)
+	require.Error(t, err)
+}
+
 //nolint:funlen
 func TestUnmarshalDecodeErrors(t *testing.T) {
 	examples := []struct {


### PR DESCRIPTION
Fixes #662
