### PR TITLE
Decoder: prevent duplicates of inline tables

### DIFF
--- a/internal/tracker/seen.go
+++ b/internal/tracker/seen.go
@@ -216,16 +216,19 @@ func (s *SeenTracker) checkKeyValue(parentIdx int, node *ast.Node) error {
 
 		idx := s.find(parentIdx, k)
 
-		if idx >= 0 {
-			if s.entries[idx].kind != tableKind {
-				return fmt.Errorf("toml: expected %s to be a table, not a %s", string(k), s.entries[idx].kind)
-			}
-			if s.entries[idx].explicit {
+		if idx < 0 {
+			idx = s.create(parentIdx, k, tableKind, false)
+		} else {
+			entry := s.entries[idx]
+			if it.IsLast() {
+				return fmt.Errorf("toml: key %s is already defined", string(k))
+			} else if entry.kind != tableKind {
+				return fmt.Errorf("toml: expected %s to be a table, not a %s", string(k), entry.kind)
+			} else if entry.explicit {
 				return fmt.Errorf("toml: cannot redefine table %s that has already been explicitly defined", string(k))
 			}
-		} else {
-			idx = s.create(parentIdx, k, tableKind, false)
 		}
+
 		parentIdx = idx
 	}
 

--- a/internal/tracker/seen.go
+++ b/internal/tracker/seen.go
@@ -229,22 +229,18 @@ func (s *SeenTracker) checkKeyValue(parentIdx int, node *ast.Node) error {
 		parentIdx = idx
 	}
 
-	kind := valueKind
-	var err error
+	s.entries[parentIdx].kind = valueKind
 
 	value := node.Value()
 
 	switch value.Kind {
 	case ast.InlineTable:
-		kind = tableKind
-		err = s.checkInlineTable(parentIdx, value)
+		return s.checkInlineTable(parentIdx, value)
 	case ast.Array:
-		err = s.checkArray(parentIdx, value)
+		return s.checkArray(parentIdx, value)
 	}
 
-	s.entries[parentIdx].kind = kind
-
-	return err
+	return nil
 }
 
 func (s *SeenTracker) checkArray(parentIdx int, node *ast.Node) error {


### PR DESCRIPTION
Fixes #666 

Also provides the error message

```
toml: key a is already defined
```

instead of the previously

```
toml: expected a to be a table, not a value
```

This fixes the error at hand, but it's probably worth providing contextualized errors like `DecodeError`, that points where the problem occurred and if not too costly where the source was.