### PR TITLE
Decode: slices specialization

### DIFF
--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -321,7 +321,6 @@ type benchmarkDoc struct {
 		Key1 []int64
 		Key2 []string
 		Key3 [][]int64
-		// TODO: Key4 not supported by go-toml's Unmarshal
 		Key4 []interface{}
 		Key5 []int64
 		Key6 []int64

--- a/internal/danger/danger.go
+++ b/internal/danger/danger.go
@@ -63,3 +63,14 @@ func Stride(ptr unsafe.Pointer, size uintptr, offset int) unsafe.Pointer {
 	//   https://github.com/golang/go/issues/40481
 	return unsafe.Pointer(uintptr(ptr) + uintptr(int(size)*offset))
 }
+
+type Slice struct {
+	Data unsafe.Pointer
+	Len  int
+	Cap  int
+}
+
+type iface struct {
+	typ unsafe.Pointer
+	ptr unsafe.Pointer
+}

--- a/internal/danger/slices.go
+++ b/internal/danger/slices.go
@@ -1,0 +1,20 @@
+//go:build go1.18
+// +build go1.18
+
+package danger
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func ExtendSlice(t reflect.Type, s *Slice, n int) Slice {
+	arrayType := reflect.ArrayOf(n, t.Elem())
+	arrayData := reflect.New(arrayType)
+	reflect.Copy(arrayData.Elem(), reflect.NewAt(t, unsafe.Pointer(s)).Elem())
+	return Slice{
+		Data: unsafe.Pointer(arrayData.Pointer()),
+		Len:  s.Len,
+		Cap:  n,
+	}
+}

--- a/internal/danger/slices_optimized.go
+++ b/internal/danger/slices_optimized.go
@@ -1,0 +1,30 @@
+//go:build !go1.18
+// +build !go1.18
+
+package danger
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+//go:linkname unsafe_NewArray reflect.unsafe_NewArray
+func unsafe_NewArray(rtype unsafe.Pointer, length int) unsafe.Pointer
+
+//go:linkname typedslicecopy reflect.typedslicecopy
+//go:noescape
+func typedslicecopy(elemType unsafe.Pointer, dst, src Slice) int
+
+func ExtendSlice(t reflect.Type, s *Slice, n int) Slice {
+	elemTypeRef := t.Elem()
+	elemTypePtr := ((*iface)(unsafe.Pointer(&elemTypeRef))).ptr
+
+	d := Slice{
+		Data: unsafe_NewArray(elemTypePtr, n),
+		Len:  s.Len,
+		Cap:  n,
+	}
+
+	typedslicecopy(elemTypePtr, d, *s)
+	return d
+}

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -705,11 +705,11 @@ func (d *decoder) unmarshalArray(array *ast.Node, v reflect.Value) error {
 			elem = reflect.ValueOf(&s).Elem()
 		} else if elem.Kind() == reflect.Slice {
 			if elem.Type() != sliceInterfaceType {
-				elem = reflect.New(sliceInterfaceType).Elem()
-				elem.Set(reflect.MakeSlice(sliceInterfaceType, 0, 16))
+				s := make([]interface{}, 0, 16)
+				elem = reflect.ValueOf(&s).Elem()
 			} else if !elem.CanSet() {
-				nelem := reflect.New(sliceInterfaceType).Elem()
-				nelem.Set(reflect.MakeSlice(sliceInterfaceType, elem.Len(), elem.Cap()))
+				s := make([]interface{}, elem.Len(), elem.Cap())
+				nelem := reflect.ValueOf(&s).Elem()
 				reflect.Copy(nelem, elem)
 				elem = nelem
 			}

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -625,7 +625,7 @@ type unmarshalArrayFn func(d *decoder, array *ast.Node, v reflect.Value) error
 
 var globalUnmarshalArrayFnCache atomic.Value // map[danger.TypeID]unmarshalArrayFn
 
-func unmarshalArrayFnFor(vt reflect.Type) unmarshalArrayFn {
+func unmarshalArrayFnForSlice(vt reflect.Type) unmarshalArrayFn {
 	tid := danger.MakeTypeID(vt)
 
 	cache, _ := globalUnmarshalArrayFnCache.Load().(map[danger.TypeID]unmarshalArrayFn)
@@ -693,7 +693,7 @@ func (d *decoder) unmarshalArray(array *ast.Node, v reflect.Value) error {
 	switch v.Kind() {
 	case reflect.Slice:
 		vt = v.Type()
-		fn := unmarshalArrayFnFor(vt)
+		fn := unmarshalArrayFnForSlice(vt)
 		return fn(d, array, v)
 	case reflect.Array:
 		vt = v.Type()
@@ -701,8 +701,8 @@ func (d *decoder) unmarshalArray(array *ast.Node, v reflect.Value) error {
 	case reflect.Interface:
 		elem := v.Elem()
 		if !elem.IsValid() {
-			elem = reflect.New(sliceInterfaceType).Elem()
-			elem.Set(reflect.MakeSlice(sliceInterfaceType, 0, 16))
+			s := make([]interface{}, 0, 16)
+			elem = reflect.ValueOf(&s).Elem()
 		} else if elem.Kind() == reflect.Slice {
 			if elem.Type() != sliceInterfaceType {
 				elem = reflect.New(sliceInterfaceType).Elem()


### PR DESCRIPTION
Taking a shot at specializing unmarshal code to work on concrete types instead of fully in reflect land.

At the moment I experimented with `UnmarshalArray`, as it has simpler semantics than the rest. I only specialized unmarshaling into `[]interface{}`.

Results are quite encouraging!

---

```
name                               old time/op    new time/op     delta
UnmarshalDataset/config-2            24.3ms ± 1%     24.0ms ± 0%   -1.06%  (p=0.008 n=5+5)
UnmarshalDataset/canada-2            85.8ms ± 0%     66.2ms ± 0%  -22.87%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-2      27.2ms ± 3%     25.5ms ± 0%   -6.29%  (p=0.008 n=5+5)
UnmarshalDataset/twitter-2           10.8ms ± 2%     10.8ms ± 2%     ~     (p=0.548 n=5+5)
UnmarshalDataset/code-2               107ms ± 1%      108ms ± 7%     ~     (p=0.841 n=5+5)
UnmarshalDataset/example-2            181µs ± 2%      177µs ± 0%   -2.15%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-2     530ns ± 1%      542ns ± 0%   +2.23%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/map-2        807ns ± 1%      812ns ± 0%     ~     (p=0.151 n=5+5)
Unmarshal/ReferenceFile/struct-2     53.6µs ± 2%     52.2µs ± 0%   -2.69%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/map-2        82.5µs ± 0%     79.7µs ± 0%   -3.46%  (p=0.016 n=4+5)
Unmarshal/HugoFrontMatter-2          14.6µs ± 3%     13.6µs ± 0%   -6.31%  (p=0.008 n=5+5)

name                               old speed      new speed       delta
UnmarshalDataset/config-2          43.1MB/s ± 1%   43.6MB/s ± 0%   +1.08%  (p=0.008 n=5+5)
UnmarshalDataset/canada-2          25.7MB/s ± 0%   33.3MB/s ± 0%  +29.66%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-2    20.6MB/s ± 3%   21.9MB/s ± 0%   +6.68%  (p=0.008 n=5+5)
UnmarshalDataset/twitter-2         40.9MB/s ± 2%   40.8MB/s ± 2%     ~     (p=0.548 n=5+5)
UnmarshalDataset/code-2            25.0MB/s ± 1%   24.8MB/s ± 6%     ~     (p=0.841 n=5+5)
UnmarshalDataset/example-2         44.7MB/s ± 2%   45.7MB/s ± 0%   +2.20%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-2  20.8MB/s ± 1%   20.3MB/s ± 0%   -2.19%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/map-2     13.6MB/s ± 1%   13.5MB/s ± 0%     ~     (p=0.159 n=5+5)
Unmarshal/ReferenceFile/struct-2   97.8MB/s ± 2%  100.5MB/s ± 0%   +2.74%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/map-2      63.5MB/s ± 0%   65.8MB/s ± 0%   +3.59%  (p=0.016 n=4+5)
Unmarshal/HugoFrontMatter-2        37.5MB/s ± 3%   40.0MB/s ± 0%   +6.71%  (p=0.008 n=5+5)

name                               old alloc/op   new alloc/op    delta
UnmarshalDataset/config-2            5.92MB ± 0%     5.85MB ± 0%   -1.05%  (p=0.008 n=5+5)
UnmarshalDataset/canada-2            84.4MB ± 0%     77.3MB ± 0%   -8.34%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-2      35.8MB ± 0%     35.3MB ± 0%   -1.33%  (p=0.008 n=5+5)
UnmarshalDataset/twitter-2           13.5MB ± 0%     13.5MB ± 0%   -0.17%  (p=0.008 n=5+5)
UnmarshalDataset/code-2              22.3MB ± 0%     22.3MB ± 0%     ~     (p=0.135 n=5+5)
UnmarshalDataset/example-2            205kB ± 0%      204kB ± 0%   -0.55%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-2      581B ± 0%       581B ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/map-2         957B ± 0%       957B ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/struct-2     20.8kB ± 0%     20.5kB ± 0%   -1.46%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/map-2        38.1kB ± 0%     37.1kB ± 0%   -2.62%  (p=0.000 n=4+5)
Unmarshal/HugoFrontMatter-2          7.38kB ± 0%     7.14kB ± 0%   -3.25%  (p=0.008 n=5+5)

name                               old allocs/op  new allocs/op   delta
UnmarshalDataset/config-2              233k ± 0%       230k ± 0%   -1.33%  (p=0.008 n=5+5)
UnmarshalDataset/canada-2              782k ± 0%       447k ± 0%  -42.78%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-2        192k ± 0%       169k ± 0%  -12.38%  (p=0.008 n=5+5)
UnmarshalDataset/twitter-2            56.9k ± 0%      55.8k ± 0%   -2.00%  (p=0.008 n=5+5)
UnmarshalDataset/code-2               1.06M ± 0%      1.06M ± 0%     ~     (all equal)
UnmarshalDataset/example-2            1.36k ± 0%      1.31k ± 0%   -4.10%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-2      7.00 ± 0%       7.00 ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/map-2         12.0 ± 0%       12.0 ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/struct-2        182 ± 0%        167 ± 0%   -8.24%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/map-2           649 ± 0%        599 ± 0%   -7.70%  (p=0.008 n=5+5)
Unmarshal/HugoFrontMatter-2             143 ± 0%        131 ± 0%   -8.39%  (p=0.008 n=5+5)

```
