### PR TITLE
Decoder: flag invalid carriage returns in literal strings

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -53,7 +53,7 @@ func scanLiteralString(b []byte) ([]byte, []byte, error) {
 		switch b[i] {
 		case '\'':
 			return b[:i+1], b[i+1:], nil
-		case '\n':
+		case '\n', '\r':
 			return nil, nil, newDecodeError(b[i:i+1], "literal strings cannot have new lines")
 		}
 		size := utf8ValidNext(b[i:])

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2545,8 +2545,16 @@ world'`,
 			data: "\"\r\"=42",
 		},
 		{
+			desc: `carriage return inside literal key`,
+			data: "'\r'=42",
+		},
+		{
 			desc: `carriage return inside basic string`,
 			data: "A = \"\r\"",
+		},
+		{
+			desc: `carriage return inside literal string`,
+			data: "A = '\r'",
 		},
 		{
 			desc: `carriage return in comment`,


### PR DESCRIPTION
Add `\r` to disallowed new line control characters in literal strings.