### PR TITLE
Encoder: mention "-" to prevent encoding field in doc

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -115,7 +115,9 @@ func (enc *Encoder) SetIndentTables(indent bool) *Encoder {
 // basis:
 //
 //   toml:"foo"
-//     Changes the name of the key to use for the field to foo.
+//     Changes the name of the key to use for the field to foo. By default, all
+//     public fields are encoded. If you want to prevent a public field from
+//     being exported, you can use the special field name "-".
 //
 //   multiline:"true"
 //     When the field contains a string, it will be emitted as a quoted


### PR DESCRIPTION
Should help with future questions like https://github.com/pelletier/go-toml/discussions/675.