### PR TITLE
Decoder: check timezones start with +,-,z,Z

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -862,7 +862,6 @@ func (p *parser) parseIntOrFloatOrDateTime(b []byte) (ast.Reference, []byte, err
 		return p.scanIntOrFloat(b)
 	}
 
-	//nolint:gomnd
 	if len(b) < 3 {
 		return p.scanIntOrFloat(b)
 	}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2629,6 +2629,10 @@ world'`,
 			data: `a=2021-00-11`,
 		},
 		{
+			desc: `invalid number of seconds digits with trailling digit`,
+			data: `a=0000-01-01 00:00:000000Z3`,
+		},
+		{
 			desc: `carriage return inside basic key`,
 			data: "\"\r\"=42",
 		},


### PR DESCRIPTION
Also simplifies local time seconds scanning.

Fixes #686
