### PR TITLE
Decoder: allow commas in tags

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -1163,8 +1163,15 @@ func forEachField(t reflect.Type, path []int, do func(name string, path []int)) 
 			continue
 		}
 
-		name, ok := f.Tag.Lookup("toml")
-		if !ok {
+		name := f.Tag.Get("toml")
+		if name == "-" {
+			continue
+		}
+
+		if i := strings.IndexByte(name, ','); i >= 0 {
+			name = name[:i]
+		}
+		if name == "" {
 			name = f.Name
 		}
 

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2698,7 +2698,7 @@ world'`,
 	}
 }
 
-func TesUnmarshaltTags(t *testing.T) {
+func TestUnmarshalTags(t *testing.T) {
 	type doc struct {
 		Dash   string `toml:"-,"`
 		Ignore string `toml:"-"`
@@ -2716,7 +2716,7 @@ comma = 'ok'
 	d := doc{}
 	expected := doc{
 		Dash:   "dash",
-		Ignore: "me",
+		Ignore: "",
 		A:      "content",
 		B:      "ok",
 	}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2698,6 +2698,34 @@ world'`,
 	}
 }
 
+func TesUnmarshaltTags(t *testing.T) {
+	type doc struct {
+		Dash   string `toml:"-,"`
+		Ignore string `toml:"-"`
+		A      string `toml:"hello"`
+		B      string `toml:"comma,omitempty"`
+	}
+
+	data := `
+'-' = "dash"
+Ignore = 'me'
+hello = 'content'
+comma = 'ok'
+`
+
+	d := doc{}
+	expected := doc{
+		Dash:   "dash",
+		Ignore: "me",
+		A:      "content",
+		B:      "ok",
+	}
+
+	err := toml.Unmarshal([]byte(data), &d)
+	require.NoError(t, err)
+	require.Equal(t, expected, d)
+}
+
 func TestASCIIControlCharacters(t *testing.T) {
 	invalidCharacters := []byte{0x7F}
 	for c := byte(0x0); c <= 0x08; c++ {


### PR DESCRIPTION
After https://github.com/pelletier/go-toml/commit/0d20a845236c457da67e2e92d0888dae14865656, this allows the same tags to be used both for encoding and decoding.