### PR TITLE
Decoder: check for invalid chars in timezone

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -113,8 +113,15 @@ func parseDateTime(b []byte) (time.Time, error) {
 			return time.Time{}, newDecodeError(b[3:4], "expected a : separator")
 		}
 
-		hours := digitsToInt(b[1:3])
-		minutes := digitsToInt(b[4:6])
+		hours, err := parseDecimalDigits(b[1:3])
+		if err != nil {
+			return time.Time{}, err
+		}
+		minutes, err := parseDecimalDigits(b[4:6])
+		if err != nil {
+			return time.Time{}, err
+		}
+
 		seconds := direction * (hours*3600 + minutes*60)
 		zone = time.FixedZone("", seconds)
 		b = b[dateTimeByteLen:]

--- a/parser.go
+++ b/parser.go
@@ -886,18 +886,6 @@ func (p *parser) parseIntOrFloatOrDateTime(b []byte) (ast.Reference, []byte, err
 	return p.scanIntOrFloat(b)
 }
 
-func digitsToInt(b []byte) int {
-	x := 0
-
-	for _, d := range b {
-		x *= 10
-		x += int(d - '0')
-	}
-
-	return x
-}
-
-//nolint:gocognit,cyclop
 func (p *parser) scanDateTime(b []byte) (ast.Reference, []byte, error) {
 	// scans for contiguous characters in [0-9T:Z.+-], and up to one space if
 	// followed by a digit.

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2633,6 +2633,14 @@ world'`,
 			data: `a=0000-01-01 00:00:000000Z3`,
 		},
 		{
+			desc: `invalid character in zone offset hours`,
+			data: `a=0000-01-01 00:00:00+0Z:00`,
+		},
+		{
+			desc: `invalid character in zone offset minutes`,
+			data: `a=0000-01-01 00:00:00+00:0Z`,
+		},
+		{
 			desc: `invalid number of seconds`,
 			data: `a=0000-01-01 00:00:00+27000`,
 		},


### PR DESCRIPTION
Fixes #694
