### PR TITLE
Decode: restrict timezone offset values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -117,9 +117,16 @@ func parseDateTime(b []byte) (time.Time, error) {
 		if err != nil {
 			return time.Time{}, err
 		}
+		if hours > 24 {
+			return time.Time{}, newDecodeError(b[:1], "invalid timezone offset hours")
+		}
+
 		minutes, err := parseDecimalDigits(b[4:6])
 		if err != nil {
 			return time.Time{}, err
+		}
+		if minutes > 60 {
+			return time.Time{}, newDecodeError(b[:1], "invalid timezone offset minutes")
 		}
 
 		seconds := direction * (hours*3600 + minutes*60)

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2633,6 +2633,14 @@ world'`,
 			data: `a=0000-01-01 00:00:000000Z3`,
 		},
 		{
+			desc: `invalid zone offset hours`,
+			data: `a=0000-01-01 00:00:00+25:00`,
+		},
+		{
+			desc: `invalid zone offset minutes`,
+			data: `a=0000-01-01 00:00:00+00:61`,
+		},
+		{
 			desc: `invalid character in zone offset hours`,
 			data: `a=0000-01-01 00:00:00+0Z:00`,
 		},


### PR DESCRIPTION
Don't allow hours greater than 24 and minutes greater than 60 per RFC
3339.
