### PR TITLE
Decode: allow maximum seconds value of 60

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -224,8 +224,8 @@ func parseLocalTime(b []byte) (LocalTime, []byte, error) {
 		return t, nil, err
 	}
 
-	if t.Second > 59 {
-		return t, nil, newDecodeError(b[6:8], "seconds cannot be greater 59")
+	if t.Second > 60 {
+		return t, nil, newDecodeError(b[6:8], "seconds cannot be greater 60")
 	}
 
 	b = b[8:]

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2424,7 +2424,7 @@ world'`,
 		{
 			desc: "invalid seconds value",
 			data: `a=1979-05-27T12:45:99`,
-			msg:  `seconds cannot be greater 59`,
+			msg:  `seconds cannot be greater 60`,
 		},
 		{
 			desc: `binary with invalid digit`,


### PR DESCRIPTION
RFC3339 allows seconds to be 60 when adding leap seconds
