### PR TITLE
Decoder: disallow modification of existing table

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -20,8 +20,8 @@ type Iterator struct {
 	node    *Node
 }
 
-// Next moves the iterator forward and returns true if points to a node, false
-// otherwise.
+// Next moves the iterator forward and returns true if points to a
+// node, false otherwise.
 func (c *Iterator) Next() bool {
 	if !c.started {
 		c.started = true
@@ -31,8 +31,8 @@ func (c *Iterator) Next() bool {
 	return c.node.Valid()
 }
 
-// IsLast returns true if the current node of the iterator is the last one.
-// Subsequent call to Next() will return false.
+// IsLast returns true if the current node of the iterator is the last
+// one.  Subsequent call to Next() will return false.
 func (c *Iterator) IsLast() bool {
 	return c.node.next == 0
 }
@@ -62,20 +62,20 @@ func (r *Root) at(idx Reference) *Node {
 	return &r.nodes[idx]
 }
 
-// Arrays have one child per element in the array.
-// InlineTables have one child per key-value pair in the table.
-// KeyValues have at least two children. The first one is the value. The
-// rest make a potentially dotted key.
-// Table and Array table have one child per element of the key they
-// represent (same as KeyValue, but without the last node being the value).
-// children []Node
+// Arrays have one child per element in the array.  InlineTables have
+// one child per key-value pair in the table.  KeyValues have at least
+// two children. The first one is the value. The rest make a
+// potentially dotted key.  Table and Array table have one child per
+// element of the key they represent (same as KeyValue, but without
+// the last node being the value).
 type Node struct {
 	Kind Kind
 	Raw  Range  // Raw bytes from the input.
-	Data []byte // Node value (could be either allocated or referencing the input).
+	Data []byte // Node value (either allocated or referencing the input).
 
-	// References to other nodes, as offsets in the backing array from this
-	// node. References can go backward, so those can be negative.
+	// References to other nodes, as offsets in the backing array
+	// from this node. References can go backward, so those can be
+	// negative.
 	next  int // 0 if last element
 	child int // 0 if no child
 }
@@ -85,8 +85,8 @@ type Range struct {
 	Length uint32
 }
 
-// Next returns a copy of the next node, or an invalid Node if there is no
-// next node.
+// Next returns a copy of the next node, or an invalid Node if there
+// is no next node.
 func (n *Node) Next() *Node {
 	if n.next == 0 {
 		return nil
@@ -96,9 +96,9 @@ func (n *Node) Next() *Node {
 	return (*Node)(danger.Stride(ptr, size, n.next))
 }
 
-// Child returns a copy of the first child node of this node. Other children
-// can be accessed calling Next on the first child.
-// Returns an invalid Node if there is none.
+// Child returns a copy of the first child node of this node. Other
+// children can be accessed calling Next on the first child.  Returns
+// an invalid Node if there is none.
 func (n *Node) Child() *Node {
 	if n.child == 0 {
 		return nil
@@ -113,10 +113,9 @@ func (n *Node) Valid() bool {
 	return n != nil
 }
 
-// Key returns the child nodes making the Key on a supported node. Panics
-// otherwise.
-// They are guaranteed to be all be of the Kind Key. A simple key would return
-// just one element.
+// Key returns the child nodes making the Key on a supported
+// node. Panics otherwise.  They are guaranteed to be all be of the
+// Kind Key. A simple key would return just one element.
 func (n *Node) Key() Iterator {
 	switch n.Kind {
 	case KeyValue:
@@ -133,8 +132,8 @@ func (n *Node) Key() Iterator {
 }
 
 // Value returns a pointer to the value node of a KeyValue.
-// Guaranteed to be non-nil.
-// Panics if not called on a KeyValue node, or if the Children are malformed.
+// Guaranteed to be non-nil.  Panics if not called on a KeyValue node,
+// or if the Children are malformed.
 func (n *Node) Value() *Node {
 	return n.Child()
 }

--- a/internal/tracker/seen.go
+++ b/internal/tracker/seen.go
@@ -126,7 +126,22 @@ func (s *SeenTracker) CheckExpression(node *ast.Node) error {
 	}
 }
 
+func (s *SeenTracker) setExplicitFlag(parentIdx int) {
+	entry := s.entries[parentIdx]
+	parentId := entry.id
+	for idx, e := range s.entries[parentIdx+1:] {
+		if e.parent == parentId {
+			s.entries[parentIdx+1+idx].explicit = true
+			s.setExplicitFlag(parentIdx + 1 + idx)
+		}
+	}
+}
+
 func (s *SeenTracker) checkTable(node *ast.Node) error {
+	if s.currentIdx >= 0 {
+		s.setExplicitFlag(s.currentIdx)
+	}
+
 	it := node.Key()
 
 	parentIdx := -1
@@ -176,6 +191,10 @@ func (s *SeenTracker) checkTable(node *ast.Node) error {
 }
 
 func (s *SeenTracker) checkArrayTable(node *ast.Node) error {
+	if s.currentIdx >= 0 {
+		s.setExplicitFlag(s.currentIdx)
+	}
+
 	it := node.Key()
 
 	parentIdx := -1

--- a/internal/tracker/seen.go
+++ b/internal/tracker/seen.go
@@ -99,11 +99,11 @@ func (s *SeenTracker) clear(idx int) {
 	}
 
 	for i := s.entries[idx].child; i >= 0; {
-		//s.entries[i].name = nil // TODO: helpful for gc?
 		next := s.entries[i].next
 		n := s.entries[0].next
 		s.entries[0].next = i
 		s.entries[i].next = n
+		s.entries[i].name = nil
 		s.clear(i)
 		i = next
 	}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2129,7 +2129,7 @@ xz_hash = "1a48f723fea1f17d786ce6eadd9d00914d38062d28fd9c455ed3c3801905b388"
 
 	expected := doc{
 		Pkg: map[string]pkg{
-			"cargo": pkg{
+			"cargo": {
 				Target: map[string]target{
 					"aarch64-apple-darwin": {
 						XZ_URL: "https://static.rust-lang.org/dist/2021-07-29/cargo-1.54.0-aarch64-apple-darwin.tar.xz",
@@ -2296,6 +2296,12 @@ z=0
 		err := toml.Unmarshal([]byte(doc), &v)
 		assert.Error(t, err)
 	}
+}
+
+func TestIssue703(t *testing.T) {
+	var v interface{}
+	err := toml.Unmarshal([]byte("[a]\nx.y=0\n[a.x]"), &v)
+	require.Error(t, err)
 }
 
 func TestUnmarshalDecodeErrors(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/pelletier/go-toml/issues/703. The idea is to marks tables created by key/values as explicit when entering the following table so that they can only be redefined within the same "block", not after.

This also makes two changes to the way used to track previously seen TOML objects to make up for the performance hit created by the extra marking.

First, introduce a dedicated tracker for inline tables. Because inline tables are self contained and cannot redefine anything outside of their scope, having their own tracker allows for very fast clean up (just forget about the object). To avoid allocating memory for every single inline table, a `sync.Pool` is used to salvage previous allocations.

Second, and more importantly: the tracking structure is now an array-backed intrusive linked list. Nodes are fully addressed using their index in the array (as opposed to the mix of ID and index). Every node points to its first child and sibling (if any). This allows operations to just consider relevant nodes, as opposed to always do range scans on the array. To make index manipulation easier (remove a lot of `if idx >= 0`), the structure now always contains at least one element: the root table. It is special because its siblings are used as a free list of entries. This allows reusing existing memory (less allocations), and avoids the former operation of literally moving data around to keep the array compact -- or to maintain a separate structure just for the free list.

The benchmark for `SimpleDocument` (literally `A = "hello"`) is slower, as the initial setup as more overhead. It is still quite fast, so probably no need to optimize that case further.


---

```
name                               old time/op    new time/op    delta
UnmarshalDataset/config-8            18.9ms ± 0%    18.7ms ± 1%   -1.33%  (p=0.008 n=5+5)
UnmarshalDataset/canada-8            62.9ms ± 1%    62.9ms ± 1%     ~     (p=1.000 n=5+5)
UnmarshalDataset/citm_catalog-8      19.2ms ± 0%    19.1ms ± 1%     ~     (p=0.548 n=5+5)
UnmarshalDataset/twitter-8           8.84ms ± 0%    8.77ms ± 0%   -0.69%  (p=0.008 n=5+5)
UnmarshalDataset/code-8              84.2ms ± 1%    82.6ms ± 0%   -1.83%  (p=0.008 n=5+5)
UnmarshalDataset/example-8            161µs ± 1%     158µs ± 0%   -1.90%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-8     433ns ± 0%     475ns ± 0%   +9.71%  (p=0.016 n=4+5)
Unmarshal/SimpleDocument/map-8        610ns ± 0%     657ns ± 1%   +7.69%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/struct-8     44.7µs ± 1%    43.7µs ± 0%   -2.26%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/map-8        63.9µs ± 1%    62.8µs ± 1%   -1.72%  (p=0.008 n=5+5)
Unmarshal/HugoFrontMatter-8          10.5µs ± 1%    10.4µs ± 0%     ~     (p=0.421 n=5+5)

name                               old speed      new speed      delta
UnmarshalDataset/config-8          55.4MB/s ± 0%  56.2MB/s ± 1%   +1.35%  (p=0.008 n=5+5)
UnmarshalDataset/canada-8          35.0MB/s ± 1%  35.0MB/s ± 1%     ~     (p=1.000 n=5+5)
UnmarshalDataset/citm_catalog-8    29.1MB/s ± 0%  29.2MB/s ± 1%     ~     (p=0.548 n=5+5)
UnmarshalDataset/twitter-8         50.0MB/s ± 0%  50.4MB/s ± 0%   +0.69%  (p=0.008 n=5+5)
UnmarshalDataset/code-8            31.9MB/s ± 1%  32.5MB/s ± 0%   +1.87%  (p=0.008 n=5+5)
UnmarshalDataset/example-8         50.2MB/s ± 1%  51.2MB/s ± 0%   +1.92%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-8  25.4MB/s ± 0%  23.1MB/s ± 0%   -8.84%  (p=0.016 n=4+5)
Unmarshal/SimpleDocument/map-8     18.0MB/s ± 0%  16.7MB/s ± 1%   -7.17%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/struct-8    117MB/s ± 1%   120MB/s ± 0%   +2.31%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/map-8      82.0MB/s ± 1%  83.4MB/s ± 1%   +1.75%  (p=0.008 n=5+5)
Unmarshal/HugoFrontMatter-8        52.1MB/s ± 1%  52.3MB/s ± 0%     ~     (p=0.421 n=5+5)

name                               old alloc/op   new alloc/op   delta
UnmarshalDataset/config-8            5.92MB ± 0%    5.92MB ± 0%     ~     (p=0.056 n=5+5)
UnmarshalDataset/canada-8            84.4MB ± 0%    84.4MB ± 0%   +0.00%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-8      35.8MB ± 0%    35.8MB ± 0%   +0.01%  (p=0.008 n=5+5)
UnmarshalDataset/twitter-8           13.5MB ± 0%    13.5MB ± 0%   +0.20%  (p=0.008 n=5+5)
UnmarshalDataset/code-8              22.3MB ± 0%    22.3MB ± 0%   +0.00%  (p=0.008 n=5+5)
UnmarshalDataset/example-8            199kB ± 0%     194kB ± 0%   -2.22%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-8      629B ± 0%      805B ± 0%  +27.98%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/map-8         957B ± 0%     1133B ± 0%  +18.39%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/struct-8     20.8kB ± 0%    20.9kB ± 0%   +0.42%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/map-8        38.1kB ± 0%    38.2kB ± 0%   +0.25%  (p=0.008 n=5+5)
Unmarshal/HugoFrontMatter-8          7.38kB ± 0%    7.46kB ± 0%   +1.08%  (p=0.008 n=5+5)

name                               old allocs/op  new allocs/op  delta
UnmarshalDataset/config-8              233k ± 0%      233k ± 0%     ~     (p=1.000 n=5+5)
UnmarshalDataset/canada-8              782k ± 0%      782k ± 0%   +0.00%  (p=0.008 n=5+5)
UnmarshalDataset/citm_catalog-8        192k ± 0%      192k ± 0%   +0.01%  (p=0.008 n=5+5)
UnmarshalDataset/twitter-8            56.9k ± 0%     56.9k ± 0%   +0.08%  (p=0.008 n=5+5)
UnmarshalDataset/code-8               1.06M ± 0%     1.06M ± 0%     ~     (all equal)
UnmarshalDataset/example-8            1.36k ± 0%     1.36k ± 0%   -0.15%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-8      8.00 ± 0%      9.00 ± 0%  +12.50%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/map-8         12.0 ± 0%      13.0 ± 0%   +8.33%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/struct-8        183 ± 0%       183 ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/map-8           649 ± 0%       649 ± 0%     ~     (all equal)
Unmarshal/HugoFrontMatter-8             143 ± 0%       143 ± 0%     ~     (all equal)
```