### PR TITLE
Decode: fix maximum time offset values

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -117,7 +117,7 @@ func parseDateTime(b []byte) (time.Time, error) {
 		if err != nil {
 			return time.Time{}, err
 		}
-		if hours > 24 {
+		if hours > 23 {
 			return time.Time{}, newDecodeError(b[:1], "invalid timezone offset hours")
 		}
 
@@ -125,7 +125,7 @@ func parseDateTime(b []byte) (time.Time, error) {
 		if err != nil {
 			return time.Time{}, err
 		}
-		if minutes > 60 {
+		if minutes > 59 {
 			return time.Time{}, newDecodeError(b[:1], "invalid timezone offset minutes")
 		}
 

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2683,11 +2683,11 @@ world'`,
 		},
 		{
 			desc: `invalid zone offset hours`,
-			data: `a=0000-01-01 00:00:00+25:00`,
+			data: `a=0000-01-01 00:00:00+24:00`,
 		},
 		{
 			desc: `invalid zone offset minutes`,
-			data: `a=0000-01-01 00:00:00+00:61`,
+			data: `a=0000-01-01 00:00:00+00:60`,
 		},
 		{
 			desc: `invalid character in zone offset hours`,


### PR DESCRIPTION
According to RFC3339 section 5.6, the maximum time offset values for
hours and minutes is 23 and 59, respectively.

Found while doing differential fuzzing against toml-dart.