### PR TITLE
Encode: add comment struct tag

### DIFF
--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -21,6 +21,12 @@ func TestMarshal(t *testing.T) {
 		A interface{} `toml:",inline"`
 	}
 
+	type comments struct {
+		One   int
+		Two   int   `comment:"Before kv"`
+		Three []int `comment:"Before array"`
+	}
+
 	examples := []struct {
 		desc     string
 		v        interface{}
@@ -534,6 +540,27 @@ I = 42
 J = 42
 K = 42
 L = 2.2`,
+		},
+		{
+			desc: "comments",
+			v: struct {
+				Table comments `comment:"Before table"`
+			}{
+				Table: comments{
+					One:   1,
+					Two:   2,
+					Three: []int{1, 2, 3},
+				},
+			},
+			expected: `
+# Before table
+[Table]
+One = 1
+# Before kv
+Two = 2
+# Before array
+Three = [1, 2, 3]
+`,
 		},
 	}
 


### PR DESCRIPTION
Similar to v1, add a `comment` struct that that makes the encoder emit a comment
before the annotated element, if permitted. Unlike v1, comments are compact by
default (and cannot be changed).

Fixes #595.