### PR TITLE
Decode: check buffer length before parsing simple key

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -693,6 +693,10 @@ func (p *parser) parseKey(b []byte) (ast.Reference, []byte, error) {
 }
 
 func (p *parser) parseSimpleKey(b []byte) (raw, key, rest []byte, err error) {
+	if len(b) == 0 {
+		return nil, nil, nil, newDecodeError(b, "expected key but found none")
+	}
+
 	// simple-key = quoted-key / unquoted-key
 	// unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
 	// quoted-key = basic-string / literal-string

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2326,6 +2326,15 @@ func TestIssue710(t *testing.T) {
 	require.Equal(t, map[string]toml.LocalTime{"0": {Nanosecond: 111111111, Precision: 9}}, v2)
 }
 
+func TestIssue714(t *testing.T) {
+	var v interface{}
+	err := toml.Unmarshal([]byte("0."), &v)
+	require.Error(t, err)
+
+	err = toml.Unmarshal([]byte("0={0=0,"), &v)
+	require.Error(t, err)
+}
+
 func TestUnmarshalDecodeErrors(t *testing.T) {
 	examples := []struct {
 		desc string


### PR DESCRIPTION
Fixes #714