### PR TITLE
Decoder: rename SetStrict to DisallowUnknownFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ operations should not be shockingly slow. See [benchmarks](#benchmarks).
 the TOML document was not prevent in the target structure. This is a great way
 to check for typos. [See example in the documentation][strict].
 
-[strict]: https://pkg.go.dev/github.com/pelletier/go-toml/v2#example-Decoder.SetStrict
+[strict]: https://pkg.go.dev/github.com/pelletier/go-toml/v2#example-Decoder.DisallowUnknownFields
 
 ### Contextualized errors
 

--- a/errors.go
+++ b/errors.go
@@ -27,7 +27,7 @@ type DecodeError struct {
 // corresponding field in the target value. It contains all the missing fields
 // in Errors.
 //
-// Emitted by Decoder when SetStrict(true) was called.
+// Emitted by Decoder when DisallowUnknownFields() was called.
 type StrictMissingError struct {
 	// One error per field that could not be found.
 	Errors []DecodeError

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -1925,7 +1925,7 @@ func decoder(doc string) *toml.Decoder {
 
 func strictDecoder(doc string) *toml.Decoder {
 	d := decoder(doc)
-	d.SetStrict(true)
+	d.DisallowUnknownFields()
 	return d
 }
 

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -42,21 +42,22 @@ func NewDecoder(r io.Reader) *Decoder {
 	return &Decoder{r: r}
 }
 
-// SetStrict toggles decoding in stict mode.
+// DisallowUnknownFields causes the Decoder to return an error when the
+// destination is a struct and the input contains a key that does not match a
+// non-ignored field.
 //
-// When the decoder is in strict mode, it will record fields from the document
-// that could not be set on the target value. In that case, the decoder returns
-// a StrictMissingError that can be used to retrieve the individual errors as
-// well as generate a human readable description of the missing fields.
-func (d *Decoder) SetStrict(strict bool) *Decoder {
-	d.strict = strict
+// In that case, the Decoder returns a StrictMissingError that can be used to
+// retrieve the individual errors as well as generate a human readable
+// description of the missing fields.
+func (d *Decoder) DisallowUnknownFields() *Decoder {
+	d.strict = true
 	return d
 }
 
 // Decode the whole content of r into v.
 //
 // By default, values in the document that don't exist in the target Go value
-// are ignored. See Decoder.SetStrict() to change this behavior.
+// are ignored. See Decoder.DisallowUnknownFields() to change this behavior.
 //
 // When a TOML local date, time, or date-time is decoded into a time.Time, its
 // value is represented in time.Local timezone. Otherwise the approriate Local*

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ExampleDecoder_SetStrict() {
+func ExampleDecoder_DisallowUnknownFields() {
 	type S struct {
 		Key1 string
 		Key3 string
@@ -28,7 +28,7 @@ key3 = "value3"
 `
 	r := strings.NewReader(doc)
 	d := toml.NewDecoder(r)
-	d.SetStrict(true)
+	d.DisallowUnknownFields()
 	s := S{}
 	err := d.Decode(&s)
 
@@ -1901,7 +1901,7 @@ bar = 42
 			t.Run("strict", func(t *testing.T) {
 				r := strings.NewReader(e.input)
 				d := toml.NewDecoder(r)
-				d.SetStrict(true)
+				d.DisallowUnknownFields()
 				x := e.target
 				if x == nil {
 					x = &struct{}{}
@@ -1919,7 +1919,6 @@ bar = 42
 			t.Run("default", func(t *testing.T) {
 				r := strings.NewReader(e.input)
 				d := toml.NewDecoder(r)
-				d.SetStrict(false)
 				x := e.target
 				if x == nil {
 					x = &struct{}{}


### PR DESCRIPTION
Follow up on https://github.com/pelletier/go-toml/discussions/471#discussioncomment-554196.