### PR TITLE
Decode: use cleaned byte slice throughout parseFloat

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -309,10 +309,10 @@ func parseFloat(b []byte) (float64, error) {
 	}
 
 	start := 0
-	if b[0] == '+' || b[0] == '-' {
+	if cleaned[0] == '+' || cleaned[0] == '-' {
 		start = 1
 	}
-	if b[start] == '0' && isDigit(b[start+1]) {
+	if cleaned[start] == '0' && isDigit(cleaned[start+1]) {
 		return 0, newDecodeError(b, "float integer part cannot have leading zeroes")
 	}
 

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -279,6 +279,11 @@ func TestUnmarshal_Floats(t *testing.T) {
 			input: `1.0_e2`,
 			err:   true,
 		},
+		{
+			desc:  "leading zero in positive float",
+			input: `+0_0.0`,
+			err:   true,
+		},
 	}
 
 	type doc struct {


### PR DESCRIPTION
Fixes #734
