### PR TITLE
Decode: allow subtables to be defined later in the document

### DIFF
--- a/internal/tracker/seen_test.go
+++ b/internal/tracker/seen_test.go
@@ -1,0 +1,15 @@
+package tracker
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEntrySize(t *testing.T) {
+	// Validate no regression on the size of entry{}. This is a critical bit for
+	// performance of unmarshaling documents. Should only be increased with care
+	// and a very good reason.
+	require.LessOrEqual(t, 48, int(unsafe.Sizeof(entry{})))
+}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -546,6 +546,35 @@ func TestUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			desc: "issue 739 - table redefinition",
+			input: `
+[foo.bar.baz]
+wibble = 'wobble'
+
+[foo]
+
+[foo.bar]
+huey = 'dewey'			
+			`,
+			gen: func() test {
+				m := map[string]interface{}{}
+
+				return test{
+					target: &m,
+					expected: &map[string]interface{}{
+						`foo`: map[string]interface{}{
+							"bar": map[string]interface{}{
+								"huey": "dewey",
+								"baz": map[string]interface{}{
+									"wibble": "wobble",
+								},
+							},
+						},
+					},
+				}
+			},
+		},
+		{
 			desc: "multiline basic string",
 			input: `A = """\
 					Test"""`,


### PR DESCRIPTION
Fixes #739
