### PR TITLE
encode: fix embedded interfaces

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -600,7 +600,9 @@ func walkStruct(ctx encoderCtx, t *table, v reflect.Value) {
 
 		if k == "" {
 			if fieldType.Anonymous {
-				walkStruct(ctx, t, f)
+				if fieldType.Type.Kind() == reflect.Struct {
+					walkStruct(ctx, t, f)
+				}
 				continue
 			} else {
 				k = fieldType.Name

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -947,6 +947,22 @@ func TestIssue678(t *testing.T) {
 	require.Equal(t, cfg, cfg2)
 }
 
+func TestIssue752(t *testing.T) {
+	type Fooer interface {
+		Foo() string
+	}
+
+	type Container struct {
+		Fooer
+	}
+
+	c := Container{}
+
+	out, err := toml.Marshal(c)
+	require.NoError(t, err)
+	require.Equal(t, "", string(out))
+}
+
 func TestMarshalNestedAnonymousStructs(t *testing.T) {
 	type Embedded struct {
 		Value string `toml:"value" json:"value"`


### PR DESCRIPTION
Resolve marshaling regression when handling an embedded interface in a
struct.

Fixes #752