### PR TITLE
Fix internal entry size test

### DIFF
--- a/internal/tracker/seen_test.go
+++ b/internal/tracker/seen_test.go
@@ -11,5 +11,6 @@ func TestEntrySize(t *testing.T) {
 	// Validate no regression on the size of entry{}. This is a critical bit for
 	// performance of unmarshaling documents. Should only be increased with care
 	// and a very good reason.
-	require.LessOrEqual(t, 48, int(unsafe.Sizeof(entry{})))
+	maxExpectedEntrySize := 48
+	require.LessOrEqual(t, int(unsafe.Sizeof(entry{})), maxExpectedEntrySize)
 }


### PR DESCRIPTION
The test meant to assert that the size of entry does not grow beyond what it is today. 48 is the current size in bytes on x64. On 32-bit platform that value should be less. As written the test was doing the opposite comparison.

Unfortunately it does not seem like github actions supports multiple platforms.

Fixes #760
