### PR TITLE
Encode: fix embedded struct with explicit field name

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -1167,11 +1167,6 @@ func forEachField(t reflect.Type, path []int, do func(name string, path []int)) 
 		fieldPath := append(path, i)
 		fieldPath = fieldPath[:len(fieldPath):len(fieldPath)]
 
-		if f.Anonymous {
-			forEachField(f.Type, fieldPath, do)
-			continue
-		}
-
 		name := f.Tag.Get("toml")
 		if name == "-" {
 			continue
@@ -1180,6 +1175,12 @@ func forEachField(t reflect.Type, path []int, do func(name string, path []int)) 
 		if i := strings.IndexByte(name, ','); i >= 0 {
 			name = name[:i]
 		}
+
+		if f.Anonymous && name == "" {
+			forEachField(f.Type, fieldPath, do)
+			continue
+		}
+
 		if name == "" {
 			name = f.Name
 		}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -554,7 +554,7 @@ wibble = 'wobble'
 [foo]
 
 [foo.bar]
-huey = 'dewey'			
+huey = 'dewey'
 			`,
 			gen: func() test {
 				m := map[string]interface{}{}
@@ -2378,6 +2378,25 @@ func TestIssue714(t *testing.T) {
 
 	err = toml.Unmarshal([]byte("0={0=0,"), &v)
 	require.Error(t, err)
+}
+
+func TestIssue772(t *testing.T) {
+	type FileHandling struct {
+		FilePattern string `toml:"pattern"`
+	}
+
+	type Config struct {
+		FileHandling `toml:"filehandling"`
+	}
+
+	var defaultConfigFile = []byte(`
+		[filehandling]
+		pattern = "reach-masterdev-"`)
+
+	config := Config{}
+	err := toml.Unmarshal(defaultConfigFile, &config)
+	require.NoError(t, err)
+	require.Equal(t, "reach-masterdev-", config.FileHandling.FilePattern)
 }
 
 func TestUnmarshalDecodeErrors(t *testing.T) {


### PR DESCRIPTION
Embedded structs with explicit field names (using `toml` tag) should be unmarshalled from a table instead of inline.

Fixes #772