### PR TITLE
Encode: add bound check for uint64 > math.Int64

### DIFF
--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1102,6 +1102,19 @@ func TestLocalTime(t *testing.T) {
 	require.Equal(t, expected, string(out))
 }
 
+func TestMarshalUint64Overflow(t *testing.T) {
+	// The TOML spec only requires implementation to provide support for the
+	// int64 range. To avoid generating TOML documents that would not be
+	// supported by standard-compliant parsers, uint64 > max int64 cannot be
+	// marshaled.
+	x := map[string]interface{}{
+		"foo": uint64(math.MaxInt64) + 1,
+	}
+
+	_, err := toml.Marshal(x)
+	require.Error(t, err)
+}
+
 func ExampleMarshal() {
 	type MyConfig struct {
 		Version int


### PR DESCRIPTION
As brought up on #782, there is an asymetry between numbers go-toml can encode
and decode. Specifically, unsigned numbers larger than `math.Int64` could be
encoded but not decoded.

We considered two options: allow decoding of those numbers, or prevent those
numbers to be decoded.

Ultimately we decided to narrow the range of numbers to be encoded. The TOML
specification only requires parsers to support at least the 64 bits integer
range. Allowing larger numbers would create non-standard TOML documents, which
may not be readable (at best) by other implementations. It is a safer default to
generate documents valid by default. People who wish to deal with larger numbers
can provide a custom type implementing `encoding.TextMarshaler`.

Refs #781

cc @jmank88 