### PR TITLE
Go 1.19

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@master
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Run tests with coverage
         run: ./ci.sh coverage -d "${GITHUB_BASE_REF-HEAD}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest']
-        go: [ '1.17', '1.18' ]
+        go: [ '1.18', '1.19' ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.go }}/${{ matrix.os }}
     steps:

--- a/cmd/jsontoml/main.go
+++ b/cmd/jsontoml/main.go
@@ -1,20 +1,20 @@
 // Package jsontoml is a program that converts JSON to TOML.
 //
-// Usage
+// # Usage
 //
 // Reading from stdin:
 //
-//   cat file.json | jsontoml > file.toml
+//	cat file.json | jsontoml > file.toml
 //
 // Reading from a file:
 //
-//   jsontoml file.json > file.toml
+//	jsontoml file.json > file.toml
 //
-// Installation
+// # Installation
 //
 // Using Go:
 //
-//   go install github.com/pelletier/go-toml/v2/cmd/jsontoml@latest
+//	go install github.com/pelletier/go-toml/v2/cmd/jsontoml@latest
 package main
 
 import (

--- a/cmd/tomljson/main.go
+++ b/cmd/tomljson/main.go
@@ -1,20 +1,20 @@
 // Package tomljson is a program that converts TOML to JSON.
 //
-// Usage
+// # Usage
 //
 // Reading from stdin:
 //
-//   cat file.toml | tomljson > file.json
+//	cat file.toml | tomljson > file.json
 //
 // Reading from a file:
 //
-//   tomljson file.toml > file.json
+//	tomljson file.toml > file.json
 //
-// Installation
+// # Installation
 //
 // Using Go:
 //
-//   go install github.com/pelletier/go-toml/v2/cmd/tomljson@latest
+//	go install github.com/pelletier/go-toml/v2/cmd/tomljson@latest
 package main
 
 import (

--- a/cmd/tomll/main.go
+++ b/cmd/tomll/main.go
@@ -1,20 +1,20 @@
 // Package tomll is a linter program for TOML.
 //
-// Usage
+// # Usage
 //
 // Reading from stdin, writing to stdout:
 //
-//   cat file.toml | tomll
+//	cat file.toml | tomll
 //
 // Reading and updating a list of files in place:
 //
-//   tomll a.toml b.toml c.toml
+//	tomll a.toml b.toml c.toml
 //
-// Installation
+// # Installation
 //
 // Using Go:
 //
-//   go install github.com/pelletier/go-toml/v2/cmd/tomll@latest
+//	go install github.com/pelletier/go-toml/v2/cmd/tomll@latest
 package main
 
 import (

--- a/cmd/tomltestgen/main.go
+++ b/cmd/tomltestgen/main.go
@@ -3,7 +3,7 @@
 //
 // Within the go-toml package, run `go generate`.  Otherwise, use:
 //
-//     go run github.com/pelletier/go-toml/cmd/tomltestgen -o toml_testgen_test.go
+//	go run github.com/pelletier/go-toml/cmd/tomltestgen -o toml_testgen_test.go
 package main
 
 import (

--- a/errors.go
+++ b/errors.go
@@ -103,6 +103,7 @@ func (e *DecodeError) Key() Key {
 //
 // The function copies all bytes used in DecodeError, so that document and
 // highlight can be freely deallocated.
+//
 //nolint:funlen
 func wrapDecodeError(document []byte, de *decodeError) *DecodeError {
 	offset := danger.SubsliceOffset(document, de.highlight)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,5 +1,4 @@
-//go:build go1.18
-// +build go1.18
+//go:build go1.18 || go1.19
 
 package toml_test
 

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -11,10 +11,10 @@ import (
 //
 // For example:
 //
-// it := n.Children()
-// for it.Next() {
-// 		it.Node()
-// }
+//	it := n.Children()
+//	for it.Next() {
+//			it.Node()
+//	}
 type Iterator struct {
 	started bool
 	node    *Node

--- a/internal/imported_tests/unmarshal_imported_test.go
+++ b/internal/imported_tests/unmarshal_imported_test.go
@@ -151,6 +151,7 @@ type quotedKeyMarshalTestStruct struct {
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var quotedKeyMarshalTestData = quotedKeyMarshalTestStruct{
 	String:  "Hello",
@@ -160,6 +161,7 @@ var quotedKeyMarshalTestData = quotedKeyMarshalTestStruct{
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var quotedKeyMarshalTestToml = []byte(`"Yfloat-𝟘" = 3.5
 "Z.string-àéù" = "Hello"
@@ -272,6 +274,7 @@ var docData = testDoc{
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var mapTestDoc = testMapDoc{
 	Title: "TOML Marshal Testing",
@@ -559,10 +562,12 @@ func (c customMarshaler) MarshalTOML() ([]byte, error) {
 var customMarshalerData = customMarshaler{FirstName: "Sally", LastName: "Fields"}
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var customMarshalerToml = []byte(`Sally Fields`)
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var nestedCustomMarshalerData = customMarshalerParent{
 	Self:    customMarshaler{FirstName: "Maiku", LastName: "Suteda"},
@@ -570,6 +575,7 @@ var nestedCustomMarshalerData = customMarshalerParent{
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var nestedCustomMarshalerToml = []byte(`friends = ["Sally Fields"]
 me = "Maiku Suteda"
@@ -611,6 +617,7 @@ func TestUnmarshalTextMarshaler(t *testing.T) {
 }
 
 // TODO: Remove nolint once type and methods are used by a test
+//
 //nolint:unused
 type precedentMarshaler struct {
 	FirstName string
@@ -629,6 +636,7 @@ func (m precedentMarshaler) MarshalTOML() ([]byte, error) {
 }
 
 // TODO: Remove nolint once type and method are used by a test
+//
 //nolint:unused
 type customPointerMarshaler struct {
 	FirstName string
@@ -641,6 +649,7 @@ func (m *customPointerMarshaler) MarshalTOML() ([]byte, error) {
 }
 
 // TODO: Remove nolint once type and method are used by a test
+//
 //nolint:unused
 type textPointerMarshaler struct {
 	FirstName string
@@ -653,6 +662,7 @@ func (m *textPointerMarshaler) MarshalText() ([]byte, error) {
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var commentTestToml = []byte(`
 # it's a comment on type
@@ -690,6 +700,7 @@ type mapsTestStruct struct {
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var mapsTestData = mapsTestStruct{
 	Simple: map[string]string{
@@ -713,6 +724,7 @@ var mapsTestData = mapsTestStruct{
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var mapsTestToml = []byte(`
 [Other]
@@ -735,6 +747,7 @@ var mapsTestToml = []byte(`
 `)
 
 // TODO: Remove nolint once type is used by a test
+//
 //nolint:deadcode,unused
 type structArrayNoTag struct {
 	A struct {
@@ -744,6 +757,7 @@ type structArrayNoTag struct {
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var customTagTestToml = []byte(`
 [postgres]
@@ -758,6 +772,7 @@ var customTagTestToml = []byte(`
 `)
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var customCommentTagTestToml = []byte(`
 # db connection
@@ -771,6 +786,7 @@ var customCommentTagTestToml = []byte(`
 `)
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var customCommentedTagTestToml = []byte(`
 [postgres]
@@ -825,6 +841,7 @@ func TestUnmarshalTabInStringAndQuotedKey(t *testing.T) {
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var customMultilineTagTestToml = []byte(`int_slice = [
   1,
@@ -834,6 +851,7 @@ var customMultilineTagTestToml = []byte(`int_slice = [
 `)
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var testDocBasicToml = []byte(`
 [document]
@@ -846,12 +864,14 @@ var testDocBasicToml = []byte(`
 `)
 
 // TODO: Remove nolint once type is used by a test
+//
 //nolint:deadcode
 type testDocCustomTag struct {
 	Doc testDocBasicsCustomTag `file:"document"`
 }
 
 // TODO: Remove nolint once type is used by a test
+//
 //nolint:deadcode
 type testDocBasicsCustomTag struct {
 	Bool       bool      `file:"bool_val"`
@@ -864,6 +884,7 @@ type testDocBasicsCustomTag struct {
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,varcheck
 var testDocCustomTagData = testDocCustomTag{
 	Doc: testDocBasicsCustomTag{
@@ -966,6 +987,7 @@ func TestUnmarshalInvalidPointerKind(t *testing.T) {
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused
 type testDuration struct {
 	Nanosec   time.Duration  `toml:"nanosec"`
@@ -980,6 +1002,7 @@ type testDuration struct {
 }
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var testDurationToml = []byte(`
 nanosec = "1ns"
@@ -994,6 +1017,7 @@ a_string = "15s"
 `)
 
 // TODO: Remove nolint once var is used by a test
+//
 //nolint:deadcode,unused,varcheck
 var testDurationToml2 = []byte(`a_string = "15s"
 hour = "1h0m0s"
@@ -1007,6 +1031,7 @@ sec = "1s"
 `)
 
 // TODO: Remove nolint once type is used by a test
+//
 //nolint:deadcode,unused
 type testBadDuration struct {
 	Val time.Duration `toml:"val"`

--- a/marshaler.go
+++ b/marshaler.go
@@ -54,7 +54,7 @@ func NewEncoder(w io.Writer) *Encoder {
 // This behavior can be controlled on an individual struct field basis with the
 // inline tag:
 //
-//   MyField `toml:",inline"`
+//	MyField `toml:",inline"`
 func (enc *Encoder) SetTablesInline(inline bool) *Encoder {
 	enc.tablesInline = inline
 	return enc
@@ -65,7 +65,7 @@ func (enc *Encoder) SetTablesInline(inline bool) *Encoder {
 //
 // This behavior can be controlled on an individual struct field basis with the multiline tag:
 //
-//   MyField `multiline:"true"`
+//	MyField `multiline:"true"`
 func (enc *Encoder) SetArraysMultiline(multiline bool) *Encoder {
 	enc.arraysMultiline = multiline
 	return enc
@@ -89,7 +89,7 @@ func (enc *Encoder) SetIndentTables(indent bool) *Encoder {
 //
 // If v cannot be represented to TOML it returns an error.
 //
-// Encoding rules
+// # Encoding rules
 //
 // A top level slice containing only maps or structs is encoded as [[table
 // array]].
@@ -120,17 +120,17 @@ func (enc *Encoder) SetIndentTables(indent bool) *Encoder {
 // Tables and array tables are separated by empty lines. However, consecutive
 // subtables definitions are not. For example:
 //
-//   [top1]
+//	[top1]
 //
-//   [top2]
-//   [top2.child1]
+//	[top2]
+//	[top2.child1]
 //
-//   [[array]]
+//	[[array]]
 //
-//   [[array]]
-//   [array.child2]
+//	[[array]]
+//	[array.child2]
 //
-// Struct tags
+// # Struct tags
 //
 // The encoding of each public struct field can be customized by the format
 // string in the "toml" key of the struct field's tag. This follows

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -79,22 +79,22 @@ func (d *Decoder) DisallowUnknownFields() *Decoder {
 // strict mode and a field is missing, a `toml.StrictMissingError` is
 // returned. In any other case, this function returns a standard Go error.
 //
-// Type mapping
+// # Type mapping
 //
 // List of supported TOML types and their associated accepted Go types:
 //
-//   String           -> string
-//   Integer          -> uint*, int*, depending on size
-//   Float            -> float*, depending on size
-//   Boolean          -> bool
-//   Offset Date-Time -> time.Time
-//   Local Date-time  -> LocalDateTime, time.Time
-//   Local Date       -> LocalDate, time.Time
-//   Local Time       -> LocalTime, time.Time
-//   Array            -> slice and array, depending on elements types
-//   Table            -> map and struct
-//   Inline Table     -> same as Table
-//   Array of Tables  -> same as Array and Table
+//	String           -> string
+//	Integer          -> uint*, int*, depending on size
+//	Float            -> float*, depending on size
+//	Boolean          -> bool
+//	Offset Date-Time -> time.Time
+//	Local Date-time  -> LocalDateTime, time.Time
+//	Local Date       -> LocalDate, time.Time
+//	Local Time       -> LocalTime, time.Time
+//	Array            -> slice and array, depending on elements types
+//	Table            -> map and struct
+//	Inline Table     -> same as Table
+//	Array of Tables  -> same as Array and Table
 func (d *Decoder) Decode(v interface{}) error {
 	b, err := ioutil.ReadAll(d.r)
 	if err != nil {


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/pelletier/go-toml/v2/benchmark
cpu: AMD Ryzen 9 5950X 16-Core Processor           
name                               old time/op    new time/op    delta
UnmarshalDataset/config-2            16.7ms ± 0%    16.4ms ± 0%   -1.92%  (p=0.016 n=4+5)
UnmarshalDataset/canada-2            66.6ms ± 0%    66.9ms ± 1%     ~     (p=0.190 n=4+5)
UnmarshalDataset/citm_catalog-2      21.5ms ± 1%    22.3ms ± 0%   +3.81%  (p=0.008 n=5+5)
UnmarshalDataset/twitter-2           8.41ms ± 1%    8.55ms ± 2%     ~     (p=0.095 n=5+5)
UnmarshalDataset/code-2              74.2ms ± 0%    72.9ms ± 0%   -1.85%  (p=0.008 n=5+5)
UnmarshalDataset/example-2            126µs ± 1%     129µs ± 0%   +2.96%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-2     476ns ± 1%     481ns ± 1%   +1.10%  (p=0.032 n=5+5)
Unmarshal/SimpleDocument/map-2        672ns ± 1%     682ns ± 0%   +1.39%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/struct-2     37.5µs ± 1%    37.4µs ± 0%     ~     (p=0.222 n=5+5)
Unmarshal/ReferenceFile/map-2        57.2µs ± 0%    57.0µs ± 0%     ~     (p=0.151 n=5+5)
Unmarshal/HugoFrontMatter-2          10.1µs ± 0%    10.0µs ± 0%   -1.18%  (p=0.008 n=5+5)
Marshal/SimpleDocument/struct-2       325ns ± 0%     324ns ± 0%   -0.25%  (p=0.032 n=5+5)
Marshal/SimpleDocument/map-2          504ns ± 0%     458ns ± 0%   -9.12%  (p=0.008 n=5+5)
Marshal/ReferenceFile/struct-2       29.6µs ± 0%    27.9µs ± 0%   -5.95%  (p=0.008 n=5+5)
Marshal/ReferenceFile/map-2          39.8µs ± 1%    36.7µs ± 0%   -7.91%  (p=0.008 n=5+5)
Marshal/HugoFrontMatter-2            7.14µs ± 0%    6.71µs ± 0%   -6.11%  (p=0.008 n=5+5)
[Geo mean]                           89.8µs         88.4µs        -1.54%

name                               old speed      new speed      delta
UnmarshalDataset/config-2          62.7MB/s ± 0%  63.9MB/s ± 0%   +1.95%  (p=0.016 n=4+5)
UnmarshalDataset/canada-2          33.2MB/s ± 2%  32.9MB/s ± 1%     ~     (p=0.095 n=5+5)
UnmarshalDataset/citm_catalog-2    26.0MB/s ± 1%  25.0MB/s ± 0%   -3.68%  (p=0.008 n=5+5)
UnmarshalDataset/twitter-2         52.6MB/s ± 1%  51.7MB/s ± 2%     ~     (p=0.095 n=5+5)
UnmarshalDataset/code-2            36.2MB/s ± 0%  36.8MB/s ± 0%   +1.88%  (p=0.008 n=5+5)
UnmarshalDataset/example-2         64.5MB/s ± 1%  62.7MB/s ± 0%   -2.88%  (p=0.008 n=5+5)
Unmarshal/SimpleDocument/struct-2  23.1MB/s ± 1%  22.8MB/s ± 1%   -1.09%  (p=0.032 n=5+5)
Unmarshal/SimpleDocument/map-2     16.4MB/s ± 1%  16.1MB/s ± 0%   -1.37%  (p=0.008 n=5+5)
Unmarshal/ReferenceFile/struct-2    140MB/s ± 1%   140MB/s ± 0%     ~     (p=0.222 n=5+5)
Unmarshal/ReferenceFile/map-2      91.6MB/s ± 0%  91.9MB/s ± 0%     ~     (p=0.103 n=5+5)
Unmarshal/HugoFrontMatter-2        54.0MB/s ± 0%  54.7MB/s ± 0%   +1.20%  (p=0.008 n=5+5)
Marshal/SimpleDocument/struct-2    37.0MB/s ± 0%  37.0MB/s ± 0%   +0.25%  (p=0.032 n=5+5)
Marshal/SimpleDocument/map-2       23.8MB/s ± 0%  26.2MB/s ± 0%  +10.04%  (p=0.008 n=5+5)
Marshal/ReferenceFile/struct-2     69.5MB/s ± 0%  73.9MB/s ± 0%   +6.32%  (p=0.008 n=5+5)
Marshal/ReferenceFile/map-2        50.3MB/s ± 1%  54.7MB/s ± 0%   +8.58%  (p=0.008 n=5+5)
Marshal/HugoFrontMatter-2          73.2MB/s ± 0%  78.0MB/s ± 0%   +6.50%  (p=0.008 n=5+5)
[Geo mean]                         45.9MB/s       46.6MB/s        +1.54%

name                               old alloc/op   new alloc/op   delta
UnmarshalDataset/config-2            5.86MB ± 0%    5.86MB ± 0%     ~     (p=1.000 n=5+5)
UnmarshalDataset/canada-2            83.0MB ± 0%    83.0MB ± 0%     ~     (p=0.667 n=4+5)
UnmarshalDataset/citm_catalog-2      34.7MB ± 0%    34.7MB ± 0%     ~     (p=0.841 n=5+5)
UnmarshalDataset/twitter-2           12.7MB ± 0%    12.7MB ± 0%   -0.07%  (p=0.008 n=5+5)
UnmarshalDataset/code-2              22.2MB ± 0%    22.2MB ± 0%     ~     (p=0.968 n=5+5)
UnmarshalDataset/example-2            186kB ± 0%     186kB ± 0%   -0.01%  (p=0.024 n=5+5)
Unmarshal/SimpleDocument/struct-2      805B ± 0%      805B ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/map-2       1.13kB ± 0%    1.13kB ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/struct-2     20.9kB ± 0%    20.9kB ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/map-2        38.2kB ± 0%    38.2kB ± 0%   +0.00%  (p=0.029 n=4+4)
Unmarshal/HugoFrontMatter-2          7.44kB ± 0%    7.44kB ± 0%     ~     (all equal)
Marshal/SimpleDocument/struct-2        240B ± 0%      240B ± 0%     ~     (all equal)
Marshal/SimpleDocument/map-2           400B ± 0%      272B ± 0%  -32.00%  (p=0.008 n=5+5)
Marshal/ReferenceFile/struct-2       28.3kB ± 0%    28.3kB ± 0%     ~     (all equal)
Marshal/ReferenceFile/map-2          32.4kB ± 0%    27.9kB ± 0%  -13.82%  (p=0.008 n=5+5)
Marshal/HugoFrontMatter-2            6.45kB ± 0%    5.81kB ± 0%   -9.93%  (p=0.008 n=5+5)
[Geo mean]                           79.8kB         76.7kB        -3.92%

name                               old allocs/op  new allocs/op  delta
UnmarshalDataset/config-2              227k ± 0%      227k ± 0%     ~     (all equal)
UnmarshalDataset/canada-2              782k ± 0%      782k ± 0%     ~     (all equal)
UnmarshalDataset/citm_catalog-2        192k ± 0%      192k ± 0%     ~     (p=0.159 n=5+5)
UnmarshalDataset/twitter-2            56.9k ± 0%     56.9k ± 0%   +0.01%  (p=0.048 n=5+5)
UnmarshalDataset/code-2               1.05M ± 0%     1.05M ± 0%     ~     (all equal)
UnmarshalDataset/example-2            1.36k ± 0%     1.36k ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/struct-2      9.00 ± 0%      9.00 ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/map-2         13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/struct-2        183 ± 0%       183 ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/map-2           642 ± 0%       642 ± 0%     ~     (all equal)
Unmarshal/HugoFrontMatter-2             141 ± 0%       141 ± 0%     ~     (all equal)
Marshal/SimpleDocument/struct-2        8.00 ± 0%      8.00 ± 0%     ~     (all equal)
Marshal/SimpleDocument/map-2           10.0 ± 0%       9.0 ± 0%  -10.00%  (p=0.008 n=5+5)
Marshal/ReferenceFile/struct-2          317 ± 0%       317 ± 0%     ~     (all equal)
Marshal/ReferenceFile/map-2             464 ± 0%       429 ± 0%   -7.54%  (p=0.008 n=5+5)
Marshal/HugoFrontMatter-2              90.0 ± 0%      85.0 ± 0%   -5.56%  (p=0.008 n=5+5)
[Geo mean]                            1.12k          1.10k        -1.49%
```