### PR TITLE
Decode: error on array table mismatched type

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -344,9 +344,9 @@ func (d *decoder) handleArrayTableCollectionLast(key ast.Iterator, v reflect.Val
 		elem := v.Index(idx)
 		_, err := d.handleArrayTable(key, elem)
 		return v, err
+	default:
+		return reflect.Value{}, fmt.Errorf("toml: cannot decode array table into a %s", v.Type())
 	}
-
-	return d.handleArrayTable(key, v)
 }
 
 // When parsing an array table expression, each part of the key needs to be

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2413,6 +2413,22 @@ Host = 'main.domain.com'
 	require.Equal(t, expected, string(b))
 }
 
+func TestIssue799(t *testing.T) {
+	const testTOML = `
+# notice the double brackets
+[[test]]
+answer = 42
+`
+
+	var s struct {
+		// should be []map[string]int
+		Test map[string]int `toml:"test"`
+	}
+
+	err := toml.Unmarshal([]byte(testTOML), &s)
+	require.Error(t, err)
+}
+
 func TestUnmarshalDecodeErrors(t *testing.T) {
 	examples := []struct {
 		desc string

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1735,6 +1735,28 @@ B = "data"`,
 				}
 			},
 		},
+		{
+			desc:  "kv that points to a slice",
+			input: "a.b.c = 'foo'",
+			gen: func() test {
+				doc := map[string][]string{}
+				return test{
+					target: &doc,
+					err:    true,
+				}
+			},
+		},
+		{
+			desc:  "kv that points to a pointer to a slice",
+			input: "a.b.c = 'foo'",
+			gen: func() test {
+				doc := map[string]*[]string{}
+				return test{
+					target: &doc,
+					err:    true,
+				}
+			},
+		},
 	}
 
 	for _, e := range examples {


### PR DESCRIPTION
Prevent the decoder from continuing if it encounters a type it cannot decode an
array table into.

For example, the reported error is `toml: cannot decode array table into a map[string]int`.

Fixes #799