### PR TITLE
Add back missing build tag needed for Go 1.16 and earlier

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,4 +1,5 @@
 //go:build go1.18 || go1.19
+// +build go1.18 go1.19
 
 package toml_test
 


### PR DESCRIPTION
Per https://pkg.go.dev/cmd/go#hdr-Build_constraints:

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix. The gofmt command will add an equivalent //go:build constraint when encountering the older syntax.

Adding the missing "+build" comment, so builds on go 1.16 work.