### PR TITLE
Fix reflect.*Header in TinyGo.

### DIFF
--- a/internal/danger/danger.go
+++ b/internal/danger/danger.go
@@ -2,11 +2,10 @@ package danger
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"unsafe"
 )
-
-const maxInt = uintptr(int(^uint(0) >> 1))
 
 func SubsliceOffset(data []byte, subslice []byte) int {
 	datap := (*reflect.SliceHeader)(unsafe.Pointer(&data))
@@ -17,21 +16,19 @@ func SubsliceOffset(data []byte, subslice []byte) int {
 	}
 	offset := hlp.Data - datap.Data
 
-	if offset > maxInt {
+	if offset > math.MaxInt {
 		panic(fmt.Errorf("slice offset larger than int (%d)", offset))
 	}
 
-	intoffset := int(offset)
-
-	if intoffset > datap.Len {
-		panic(fmt.Errorf("slice offset (%d) is farther than data length (%d)", intoffset, datap.Len))
+	if sizeType(offset) > datap.Len {
+		panic(fmt.Errorf("slice offset (%d) is farther than data length (%d)", offset, datap.Len))
 	}
 
-	if intoffset+hlp.Len > datap.Len {
-		panic(fmt.Errorf("slice ends (%d+%d) is farther than data length (%d)", intoffset, hlp.Len, datap.Len))
+	if sizeType(offset)+hlp.Len > datap.Len {
+		panic(fmt.Errorf("slice ends (%d+%d) is farther than data length (%d)", offset, hlp.Len, datap.Len))
 	}
 
-	return intoffset
+	return int(offset)
 }
 
 func BytesRange(start []byte, end []byte) []byte {
@@ -46,7 +43,7 @@ func BytesRange(start []byte, end []byte) []byte {
 	}
 
 	l := startp.Len
-	endLen := int(endp.Data-startp.Data) + endp.Len
+	endLen := sizeType(endp.Data-startp.Data) + endp.Len
 	if endLen > l {
 		l = endLen
 	}

--- a/internal/danger/danger.go
+++ b/internal/danger/danger.go
@@ -2,10 +2,11 @@ package danger
 
 import (
 	"fmt"
-	"math"
 	"reflect"
 	"unsafe"
 )
+
+const maxInt = uintptr(int(^uint(0) >> 1))
 
 func SubsliceOffset(data []byte, subslice []byte) int {
 	datap := (*reflect.SliceHeader)(unsafe.Pointer(&data))
@@ -16,7 +17,7 @@ func SubsliceOffset(data []byte, subslice []byte) int {
 	}
 	offset := hlp.Data - datap.Data
 
-	if offset > math.MaxInt {
+	if offset > maxInt {
 		panic(fmt.Errorf("slice offset larger than int (%d)", offset))
 	}
 

--- a/internal/danger/sizetype.go
+++ b/internal/danger/sizetype.go
@@ -1,0 +1,5 @@
+//go:build !tinygo
+
+package danger
+
+type sizeType = int

--- a/internal/danger/sizetype.go
+++ b/internal/danger/sizetype.go
@@ -2,4 +2,5 @@
 
 package danger
 
+// https://github.com/golang/go/blob/54182ff/src/reflect/value.go#L2760
 type sizeType = int

--- a/internal/danger/sizetype_tinygo.go
+++ b/internal/danger/sizetype_tinygo.go
@@ -1,0 +1,5 @@
+//go:build tinygo
+
+package danger
+
+type sizeType = uintptr

--- a/internal/danger/sizetype_tinygo.go
+++ b/internal/danger/sizetype_tinygo.go
@@ -2,4 +2,5 @@
 
 package danger
 
+// https://github.com/tinygo-org/tinygo/blob/f0391ea/src/reflect/value.go#L773
 type sizeType = uintptr


### PR DESCRIPTION
TinyGo uses uintptr for Len and Cap in reflect.*Header, unlike gc which uses int. This commit chooses the correct type using -tags.

For unrelated reasons, compiling with TinyGo does not yet work. But this eliminates one error.
