### PR TITLE
Reduce init time allocation when declaring types used for reflect

### DIFF
--- a/types.go
+++ b/types.go
@@ -6,9 +6,9 @@ import (
 	"time"
 )
 
-var timeType = reflect.TypeOf(time.Time{})
-var textMarshalerType = reflect.TypeOf(new(encoding.TextMarshaler)).Elem()
-var textUnmarshalerType = reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()
-var mapStringInterfaceType = reflect.TypeOf(map[string]interface{}{})
-var sliceInterfaceType = reflect.TypeOf([]interface{}{})
+var timeType = reflect.TypeOf((*time.Time)(nil)).Elem()
+var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+var textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+var mapStringInterfaceType = reflect.TypeOf(map[string]interface{}(nil))
+var sliceInterfaceType = reflect.TypeOf([]interface{}(nil))
 var stringType = reflect.TypeOf("")


### PR DESCRIPTION
In declaration of types used for `reflect`, use `reflect.TypeOf((*T)).Elem()` instead of `reflect.TypeOf(T{})` to avoid init-time allocations.

See related stdlib issue: https://github.com/golang/go/issues/55973
