### PR TITLE
refactor: Use typeMismatchError rather than raw string error

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -339,13 +339,13 @@ func (d *decoder) handleArrayTableCollectionLast(key ast.Iterator, v reflect.Val
 	case reflect.Array:
 		idx := d.arrayIndex(true, v)
 		if idx >= v.Len() {
-			return v, fmt.Errorf("toml: cannot decode array table into %s at position %d", v.Type(), idx)
+			return v, fmt.Errorf("%s at position %d", d.typeMismatchError("array table", v.Type()), idx)
 		}
 		elem := v.Index(idx)
 		_, err := d.handleArrayTable(key, elem)
 		return v, err
 	default:
-		return reflect.Value{}, fmt.Errorf("toml: cannot decode array table into a %s", v.Type())
+		return reflect.Value{}, d.typeMismatchError("array table", v.Type())
 	}
 }
 
@@ -390,7 +390,7 @@ func (d *decoder) handleArrayTableCollection(key ast.Iterator, v reflect.Value) 
 	case reflect.Array:
 		idx := d.arrayIndex(false, v)
 		if idx >= v.Len() {
-			return v, fmt.Errorf("toml: cannot decode array table into %s at position %d", v.Type(), idx)
+			return v, fmt.Errorf("%s at position %d", d.typeMismatchError("array table", v.Type()), idx)
 		}
 		elem := v.Index(idx)
 		_, err := d.handleArrayTable(key, elem)


### PR DESCRIPTION
Uses the existing method to DRY up the error message generation, and decorates with position index where needed. No behaviour is changed, but it allows for further changes to make error messaging more specific.

Related to: pelletier/go-toml#806

<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->

---

Paste `benchstat` results here

```
name                                    old time/op    new time/op    delta
pkg:github.com/pelletier/go-toml/v2 goos:darwin goarch:arm64
ScanComments/10Valid-10                   24.2ns ± 2%    24.4ns ± 2%     ~     (p=0.182 n=9+10)
ScanComments/1kValid-10                   2.21µs ± 2%    2.18µs ± 1%   -1.47%  (p=0.000 n=10+10)
ScanComments/1MValid-10                   2.23ms ± 1%    2.22ms ± 0%   -0.28%  (p=0.043 n=10+9)
ScanComments/10ValidUtf8-10               15.7ns ± 0%    15.7ns ± 0%     ~     (p=0.060 n=9+10)
ScanComments/1kValidUtf8-10               2.02µs ± 2%    2.00µs ± 0%   -1.11%  (p=0.000 n=10+9)
ScanComments/1MValidUtf8-10               2.05ms ± 1%    2.05ms ± 0%   -0.35%  (p=0.000 n=10+10)
ParseLiteralStringValid/10Valid-10        24.8ns ± 0%    23.6ns ± 0%   -4.81%  (p=0.000 n=10+9)
ParseLiteralStringValid/1kValid-10        2.19µs ± 1%    2.17µs ± 1%   -0.93%  (p=0.000 n=9+10)
ParseLiteralStringValid/1MValid-10        2.24ms ± 2%    2.24ms ± 2%     ~     (p=0.796 n=10+10)
ParseLiteralStringValid/10ValidUtf8-10    15.9ns ± 0%    15.8ns ± 1%   -0.39%  (p=0.011 n=8+10)
ParseLiteralStringValid/1kValidUtf8-10    2.04µs ± 1%    2.02µs ± 1%   -0.69%  (p=0.022 n=10+10)
ParseLiteralStringValid/1MValidUtf8-10    2.07ms ± 1%    2.06ms ± 1%   -0.44%  (p=0.035 n=10+10)
ParseBasicStringWithUnicode/4-10           108ns ± 0%     109ns ± 0%   +0.86%  (p=0.000 n=9+10)
ParseBasicStringWithUnicode/8-10           192ns ± 0%     193ns ± 0%   +0.25%  (p=0.009 n=9+10)
ParseBasicStringsEasy/1-10                6.57ns ± 1%    6.54ns ± 0%     ~     (p=0.210 n=10+10)
ParseBasicStringsEasy/4-10                10.1ns ± 1%     9.9ns ± 0%   -1.51%  (p=0.000 n=10+9)
ParseBasicStringsEasy/8-10                14.5ns ± 1%    14.3ns ± 0%   -1.08%  (p=0.000 n=10+10)
ParseBasicStringsEasy/16-10               24.4ns ± 1%    24.2ns ± 0%   -0.63%  (p=0.000 n=9+9)
ParseBasicStringsEasy/21-10               32.1ns ± 0%    31.9ns ± 0%   -0.50%  (p=0.000 n=9+9)
pkg:github.com/pelletier/go-toml/v2/benchmark goos:darwin goarch:arm64
UnmarshalDataset/config-10                12.8ms ± 0%    13.0ms ± 0%   +2.00%  (p=0.000 n=10+10)
UnmarshalDataset/canada-10                54.2ms ± 1%    54.5ms ± 0%     ~     (p=0.193 n=10+7)
UnmarshalDataset/citm_catalog-10          16.7ms ± 0%    16.9ms ± 1%   +1.11%  (p=0.000 n=7+10)
UnmarshalDataset/twitter-10               7.17ms ± 2%    7.23ms ± 2%     ~     (p=0.089 n=10+10)
UnmarshalDataset/code-10                  61.7ms ± 1%    61.6ms ± 1%     ~     (p=0.165 n=10+10)
UnmarshalDataset/example-10                118µs ± 3%     117µs ± 1%   -1.39%  (p=0.010 n=10+9)
Unmarshal/SimpleDocument/struct-10         407ns ± 2%     404ns ± 1%   -0.82%  (p=0.041 n=10+10)
Unmarshal/SimpleDocument/map-10            628ns ± 6%     548ns ± 1%  -12.84%  (p=0.000 n=9+9)
Unmarshal/ReferenceFile/struct-10         34.2µs ± 4%    32.8µs ± 1%   -4.21%  (p=0.000 n=10+9)
Unmarshal/ReferenceFile/map-10            48.6µs ± 1%    46.9µs ± 0%   -3.57%  (p=0.000 n=8+9)
Unmarshal/HugoFrontMatter-10              7.93µs ± 1%    7.60µs ± 1%   -4.10%  (p=0.000 n=9+10)
Marshal/SimpleDocument/struct-10           290ns ± 2%     281ns ± 0%   -3.00%  (p=0.000 n=9+10)
Marshal/SimpleDocument/map-10              393ns ± 3%     389ns ± 1%     ~     (p=0.078 n=10+10)
Marshal/ReferenceFile/struct-10           27.9µs ± 4%    26.8µs ± 4%   -3.93%  (p=0.001 n=9+9)
Marshal/ReferenceFile/map-10             56.8µs ±223%    32.7µs ± 1%  -42.36%  (p=0.001 n=9+10)
Marshal/HugoFrontMatter-10                6.01µs ± 2%    5.99µs ± 1%     ~     (p=0.650 n=9+9)

name                                    old speed      new speed      delta
pkg:github.com/pelletier/go-toml/v2 goos:darwin goarch:arm64
ScanComments/10Valid-10                  537MB/s ± 2%   532MB/s ± 2%     ~     (p=0.182 n=9+10)
ScanComments/1kValid-10                  464MB/s ± 2%   471MB/s ± 1%   +1.48%  (p=0.000 n=10+10)
ScanComments/1MValid-10                  470MB/s ± 1%   472MB/s ± 0%   +0.29%  (p=0.037 n=10+9)
ScanComments/10ValidUtf8-10              826MB/s ± 0%   828MB/s ± 0%     ~     (p=0.065 n=9+10)
ScanComments/1kValidUtf8-10              508MB/s ± 2%   513MB/s ± 0%   +1.09%  (p=0.000 n=10+10)
ScanComments/1MValidUtf8-10              511MB/s ± 1%   512MB/s ± 0%   +0.35%  (p=0.001 n=10+10)
ParseLiteralStringValid/10Valid-10       483MB/s ± 0%   508MB/s ± 0%   +5.06%  (p=0.000 n=10+9)
ParseLiteralStringValid/1kValid-10       469MB/s ± 1%   473MB/s ± 1%   +0.95%  (p=0.000 n=9+10)
ParseLiteralStringValid/1MValid-10       468MB/s ± 2%   468MB/s ± 2%     ~     (p=0.796 n=10+10)
ParseLiteralStringValid/10ValidUtf8-10   756MB/s ± 0%   759MB/s ± 1%   +0.39%  (p=0.011 n=8+10)
ParseLiteralStringValid/1kValidUtf8-10   504MB/s ± 1%   508MB/s ± 1%   +0.69%  (p=0.023 n=10+10)
ParseLiteralStringValid/1MValidUtf8-10   506MB/s ± 1%   508MB/s ± 1%   +0.44%  (p=0.037 n=10+10)
ParseBasicStringWithUnicode/4-10         353MB/s ± 0%   350MB/s ± 0%   -0.84%  (p=0.000 n=9+10)
ParseBasicStringWithUnicode/8-10         219MB/s ± 0%   218MB/s ± 0%   -0.26%  (p=0.010 n=9+10)
ParseBasicStringsEasy/1-10               457MB/s ± 1%   458MB/s ± 0%     ~     (p=0.190 n=10+10)
ParseBasicStringsEasy/4-10               594MB/s ± 1%   603MB/s ± 0%   +1.53%  (p=0.000 n=10+9)
ParseBasicStringsEasy/8-10               692MB/s ± 1%   699MB/s ± 0%   +1.08%  (p=0.000 n=10+10)
ParseBasicStringsEasy/16-10              739MB/s ± 1%   744MB/s ± 0%   +0.63%  (p=0.000 n=9+9)
ParseBasicStringsEasy/21-10              717MB/s ± 0%   720MB/s ± 0%   +0.49%  (p=0.000 n=9+9)
pkg:github.com/pelletier/go-toml/v2/benchmark goos:darwin goarch:arm64
UnmarshalDataset/config-10              82.1MB/s ± 0%  80.4MB/s ± 0%   -1.96%  (p=0.000 n=10+10)
UnmarshalDataset/canada-10              40.6MB/s ± 1%  40.4MB/s ± 0%     ~     (p=0.184 n=10+7)
UnmarshalDataset/citm_catalog-10        33.4MB/s ± 0%  33.0MB/s ± 1%   -1.10%  (p=0.000 n=7+10)
UnmarshalDataset/twitter-10             61.7MB/s ± 2%  61.1MB/s ± 2%     ~     (p=0.085 n=10+10)
UnmarshalDataset/code-10                43.5MB/s ± 1%  43.6MB/s ± 1%     ~     (p=0.171 n=10+10)
UnmarshalDataset/example-10             68.5MB/s ± 3%  69.5MB/s ± 1%   +1.39%  (p=0.013 n=10+9)
Unmarshal/SimpleDocument/struct-10      27.0MB/s ± 2%  27.2MB/s ± 1%   +0.81%  (p=0.045 n=10+10)
Unmarshal/SimpleDocument/map-10         17.5MB/s ± 5%  20.1MB/s ± 1%  +14.66%  (p=0.000 n=9+9)
Unmarshal/ReferenceFile/struct-10        153MB/s ± 4%   160MB/s ± 1%   +4.33%  (p=0.000 n=10+9)
Unmarshal/ReferenceFile/map-10           108MB/s ± 1%   112MB/s ± 0%   +3.70%  (p=0.000 n=8+9)
Unmarshal/HugoFrontMatter-10            68.9MB/s ± 1%  71.9MB/s ± 0%   +4.36%  (p=0.000 n=9+9)
Marshal/SimpleDocument/struct-10        41.4MB/s ± 2%  42.7MB/s ± 0%   +3.08%  (p=0.000 n=9+10)
Marshal/SimpleDocument/map-10           30.5MB/s ± 3%  30.8MB/s ± 1%     ~     (p=0.072 n=10+10)
Marshal/ReferenceFile/struct-10         73.9MB/s ± 3%  76.4MB/s ± 6%   +3.38%  (p=0.010 n=9+10)
Marshal/ReferenceFile/map-10            45.6MB/s ±79%  61.3MB/s ± 1%  +34.51%  (p=0.000 n=10+10)
Marshal/HugoFrontMatter-10              87.0MB/s ± 2%  87.3MB/s ± 1%     ~     (p=0.619 n=9+9)

name                                    old alloc/op   new alloc/op   delta
pkg:github.com/pelletier/go-toml/v2 goos:darwin goarch:arm64
ScanComments/10Valid-10                    0.00B          0.00B          ~     (all equal)
ScanComments/1kValid-10                    0.00B          0.00B          ~     (all equal)
ScanComments/1MValid-10                    0.00B          0.00B          ~     (all equal)
ScanComments/10ValidUtf8-10                0.00B          0.00B          ~     (all equal)
ScanComments/1kValidUtf8-10                0.00B          0.00B          ~     (all equal)
ScanComments/1MValidUtf8-10                0.00B          0.00B          ~     (all equal)
ParseLiteralStringValid/10Valid-10         0.00B          0.00B          ~     (all equal)
ParseLiteralStringValid/1kValid-10         0.00B          0.00B          ~     (all equal)
ParseLiteralStringValid/1MValid-10         0.00B          0.00B          ~     (all equal)
ParseLiteralStringValid/10ValidUtf8-10     0.00B          0.00B          ~     (all equal)
ParseLiteralStringValid/1kValidUtf8-10     0.00B          0.00B          ~     (all equal)
ParseLiteralStringValid/1MValidUtf8-10     0.00B          0.00B          ~     (all equal)
ParseBasicStringWithUnicode/4-10           64.0B ± 0%     64.0B ± 0%     ~     (all equal)
ParseBasicStringWithUnicode/8-10           64.0B ± 0%     64.0B ± 0%     ~     (all equal)
ParseBasicStringsEasy/1-10                 0.00B          0.00B          ~     (all equal)
ParseBasicStringsEasy/4-10                 0.00B          0.00B          ~     (all equal)
ParseBasicStringsEasy/8-10                 0.00B          0.00B          ~     (all equal)
ParseBasicStringsEasy/16-10                0.00B          0.00B          ~     (all equal)
ParseBasicStringsEasy/21-10                0.00B          0.00B          ~     (all equal)
pkg:github.com/pelletier/go-toml/v2/benchmark goos:darwin goarch:arm64
UnmarshalDataset/config-10                5.86MB ± 0%    5.86MB ± 0%     ~     (p=0.912 n=10+10)
UnmarshalDataset/canada-10                83.0MB ± 0%    83.0MB ± 0%     ~     (p=0.209 n=10+10)
UnmarshalDataset/citm_catalog-10          34.7MB ± 0%    34.7MB ± 0%     ~     (p=0.075 n=10+10)
UnmarshalDataset/twitter-10               12.7MB ± 0%    12.7MB ± 0%     ~     (p=0.481 n=10+10)
UnmarshalDataset/code-10                  22.2MB ± 0%    22.2MB ± 0%     ~     (p=0.382 n=10+10)
UnmarshalDataset/example-10                186kB ± 0%     186kB ± 0%     ~     (p=0.564 n=10+10)
Unmarshal/SimpleDocument/struct-10          805B ± 0%      805B ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/map-10           1.13kB ± 0%    1.13kB ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/struct-10         20.9kB ± 0%    20.9kB ± 0%   +0.00%  (p=0.011 n=10+10)
Unmarshal/ReferenceFile/map-10            38.2kB ± 0%    38.2kB ± 0%     ~     (p=0.137 n=8+10)
Unmarshal/HugoFrontMatter-10              7.44kB ± 0%    7.44kB ± 0%     ~     (all equal)
Marshal/SimpleDocument/struct-10            240B ± 0%      240B ± 0%     ~     (all equal)
Marshal/SimpleDocument/map-10               272B ± 0%      272B ± 0%     ~     (all equal)
Marshal/ReferenceFile/struct-10           28.3kB ± 0%    28.3kB ± 0%     ~     (all equal)
Marshal/ReferenceFile/map-10              27.9kB ± 0%    27.9kB ± 0%     ~     (all equal)
Marshal/HugoFrontMatter-10                5.81kB ± 0%    5.81kB ± 0%     ~     (all equal)

name                                    old allocs/op  new allocs/op  delta
pkg:github.com/pelletier/go-toml/v2 goos:darwin goarch:arm64
ScanComments/10Valid-10                     0.00           0.00          ~     (all equal)
ScanComments/1kValid-10                     0.00           0.00          ~     (all equal)
ScanComments/1MValid-10                     0.00           0.00          ~     (all equal)
ScanComments/10ValidUtf8-10                 0.00           0.00          ~     (all equal)
ScanComments/1kValidUtf8-10                 0.00           0.00          ~     (all equal)
ScanComments/1MValidUtf8-10                 0.00           0.00          ~     (all equal)
ParseLiteralStringValid/10Valid-10          0.00           0.00          ~     (all equal)
ParseLiteralStringValid/1kValid-10          0.00           0.00          ~     (all equal)
ParseLiteralStringValid/1MValid-10          0.00           0.00          ~     (all equal)
ParseLiteralStringValid/10ValidUtf8-10      0.00           0.00          ~     (all equal)
ParseLiteralStringValid/1kValidUtf8-10      0.00           0.00          ~     (all equal)
ParseLiteralStringValid/1MValidUtf8-10      0.00           0.00          ~     (all equal)
ParseBasicStringWithUnicode/4-10            1.00 ± 0%      1.00 ± 0%     ~     (all equal)
ParseBasicStringWithUnicode/8-10            1.00 ± 0%      1.00 ± 0%     ~     (all equal)
ParseBasicStringsEasy/1-10                  0.00           0.00          ~     (all equal)
ParseBasicStringsEasy/4-10                  0.00           0.00          ~     (all equal)
ParseBasicStringsEasy/8-10                  0.00           0.00          ~     (all equal)
ParseBasicStringsEasy/16-10                 0.00           0.00          ~     (all equal)
ParseBasicStringsEasy/21-10                 0.00           0.00          ~     (all equal)
pkg:github.com/pelletier/go-toml/v2/benchmark goos:darwin goarch:arm64
UnmarshalDataset/config-10                  227k ± 0%      227k ± 0%     ~     (p=1.000 n=10+10)
UnmarshalDataset/canada-10                  782k ± 0%      782k ± 0%     ~     (all equal)
UnmarshalDataset/citm_catalog-10            192k ± 0%      192k ± 0%     ~     (p=0.294 n=10+8)
UnmarshalDataset/twitter-10                56.9k ± 0%     56.9k ± 0%     ~     (p=0.659 n=9+10)
UnmarshalDataset/code-10                   1.05M ± 0%     1.05M ± 0%     ~     (all equal)
UnmarshalDataset/example-10                1.36k ± 0%     1.36k ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/struct-10          9.00 ± 0%      9.00 ± 0%     ~     (all equal)
Unmarshal/SimpleDocument/map-10             13.0 ± 0%      13.0 ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/struct-10            183 ± 0%       183 ± 0%     ~     (all equal)
Unmarshal/ReferenceFile/map-10               642 ± 0%       642 ± 0%     ~     (all equal)
Unmarshal/HugoFrontMatter-10                 141 ± 0%       141 ± 0%     ~     (all equal)
Marshal/SimpleDocument/struct-10            8.00 ± 0%      8.00 ± 0%     ~     (all equal)
Marshal/SimpleDocument/map-10               9.00 ± 0%      9.00 ± 0%     ~     (all equal)
Marshal/ReferenceFile/struct-10              317 ± 0%       317 ± 0%     ~     (all equal)
Marshal/ReferenceFile/map-10                 429 ± 0%       429 ± 0%     ~     (all equal)
Marshal/HugoFrontMatter-10                  85.0 ± 0%      85.0 ± 0%     ~     (all equal)
```