### PR TITLE
Encode: fix inline table first key value whitespace

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -357,9 +357,9 @@ func (enc *Encoder) encodeKv(b []byte, ctx encoderCtx, options valueOptions, v r
 
 	if !ctx.inline {
 		b = enc.encodeComment(ctx.indent, options.comment, b)
+		b = enc.indent(ctx.indent, b)
 	}
 
-	b = enc.indent(ctx.indent, b)
 	b = enc.encodeKey(b, ctx.key)
 	b = append(b, " = "...)
 

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1190,6 +1190,27 @@ func TestMarshalUint64Overflow(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIndentWithInlineTable(t *testing.T) {
+	x := map[string][]map[string]string{
+		"one": []map[string]string{
+			{"0": "0"},
+			{"1": "1"},
+		},
+	}
+	expected := `one = [
+  {0 = '0'},
+  {1 = '1'}
+]
+`
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	enc.SetIndentTables(true)
+	enc.SetTablesInline(true)
+	enc.SetArraysMultiline(true)
+	require.NoError(t, enc.Encode(x))
+	assert.Equal(t, expected, buf.String())
+}
+
 func ExampleMarshal() {
 	type MyConfig struct {
 		Version int


### PR DESCRIPTION
When encoding table inline, we should not apply ident. Otherwise, the key-value will be right align.

For example, this following data:

```
x := map[string][]map[string]string{
	"one": []map[string]string{
		{"0": "0"},
		{"1": "1"},
	},
}
```

will be encoded as:

```
one = [
  {  0 = '0'},
  {  1 = '1'}
]
```

This PR makes is to be encoded as:

```
one = [
  {0 = '0'},
  {1 = '1'}
]
```