### PR TITLE
Add multi line array options

### DIFF
--- a/cmd/jsontoml/main.go
+++ b/cmd/jsontoml/main.go
@@ -41,7 +41,7 @@ func main() {
 	p.Execute()
 }
 
-func convert(r io.Reader, w io.Writer) error {
+func convert(r io.Reader, w io.Writer, o cli.Options) error {
 	var v interface{}
 
 	d := json.NewDecoder(r)

--- a/cmd/jsontoml/main_test.go
+++ b/cmd/jsontoml/main_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2/internal/cli"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +39,7 @@ a = 42.0
 
 	for _, e := range examples {
 		b := new(bytes.Buffer)
-		err := convert(strings.NewReader(e.input), b)
+		err := convert(strings.NewReader(e.input), b, cli.Options{})
 		if e.errors {
 			require.Error(t, err)
 		} else {

--- a/cmd/tomljson/main.go
+++ b/cmd/tomljson/main.go
@@ -43,7 +43,7 @@ func main() {
 	p.Execute()
 }
 
-func convert(r io.Reader, w io.Writer) error {
+func convert(r io.Reader, w io.Writer, o cli.Options) error {
 	var v interface{}
 
 	d := toml.NewDecoder(r)

--- a/cmd/tomljson/main_test.go
+++ b/cmd/tomljson/main_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2/internal/cli"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +46,7 @@ a = 42`),
 
 	for _, e := range examples {
 		b := new(bytes.Buffer)
-		err := convert(e.input, b)
+		err := convert(e.input, b, cli.Options{})
 		if e.errors {
 			require.Error(t, err)
 		} else {

--- a/cmd/tomll/main.go
+++ b/cmd/tomll/main.go
@@ -44,7 +44,7 @@ func main() {
 	p.Execute()
 }
 
-func convert(r io.Reader, w io.Writer) error {
+func convert(r io.Reader, w io.Writer, o cli.Options) error {
 	var v interface{}
 
 	d := toml.NewDecoder(r)

--- a/cmd/tomll/main.go
+++ b/cmd/tomll/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"flag"
 	"io"
 
 	"github.com/pelletier/go-toml/v2"
@@ -33,19 +34,26 @@ Reading and updating a list of files in place:
   tomll a.toml b.toml c.toml
 
 When given a list of files, tomll will modify all files in place without asking.
+
+Flags:
+-multiLineArray      sets up the linter to encode arrays with more than one element on multiple lines instead of one.
 `
 
 func main() {
+	multiLineArray := flag.Bool("multiLineArray", false, "sets up the linter to encode arrays with more than one element on multiple lines insteadof one.")
 	p := cli.Program{
 		Usage:   usage,
 		Fn:      convert,
 		Inplace: true,
+		Opts: cli.Options{"multiLineArray": multiLineArray},
 	}
 	p.Execute()
 }
 
 func convert(r io.Reader, w io.Writer, o cli.Options) error {
 	var v interface{}
+
+	multiLineArray := o["multiLineArray"].(bool)
 
 	d := toml.NewDecoder(r)
 	err := d.Decode(&v)
@@ -54,5 +62,5 @@ func convert(r io.Reader, w io.Writer, o cli.Options) error {
 	}
 
 	e := toml.NewEncoder(w)
-	return e.Encode(v)
+	return e.SetArraysMultiline(multiLineArray).Encode(v)
 }

--- a/cmd/tomll/main_test.go
+++ b/cmd/tomll/main_test.go
@@ -36,7 +36,7 @@ a = 42.0
 
 	for _, e := range examples {
 		b := new(bytes.Buffer)
-		err := convert(strings.NewReader(e.input), b, cli.Options{})
+		err := convert(strings.NewReader(e.input), b, cli.Options{"multiLineArray": false})
 		if e.errors {
 			require.Error(t, err)
 		} else {

--- a/cmd/tomll/main_test.go
+++ b/cmd/tomll/main_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2/internal/cli"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +36,7 @@ a = 42.0
 
 	for _, e := range examples {
 		b := new(bytes.Buffer)
-		err := convert(strings.NewReader(e.input), b)
+		err := convert(strings.NewReader(e.input), b, cli.Options{})
 		if e.errors {
 			require.Error(t, err)
 		} else {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,7 +12,9 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
-type ConvertFn func(r io.Reader, w io.Writer) error
+type Options map[string]interface{}
+
+type ConvertFn func(r io.Reader, w io.Writer, options Options) error
 
 type Program struct {
 	Usage string
@@ -20,6 +22,7 @@ type Program struct {
 	// Inplace allows the command to take more than one file as argument and
 	// perform convertion in place on each provided file.
 	Inplace bool
+	Opts Options
 }
 
 func (p *Program) Execute() {
@@ -58,7 +61,7 @@ func (p *Program) run(files []string, input io.Reader, output io.Writer) error {
 		defer f.Close()
 		input = f
 	}
-	return p.Fn(input, output)
+	return p.Fn(input, output, p.Opts)
 }
 
 func (p *Program) runAllFilesInPlace(files []string) error {
@@ -79,7 +82,7 @@ func (p *Program) runFileInPlace(path string) error {
 
 	out := new(bytes.Buffer)
 
-	err = p.Fn(bytes.NewReader(in), out)
+	err = p.Fn(bytes.NewReader(in), out, p.Opts)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -25,7 +25,7 @@ func TestProcessMainStdin(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	input := strings.NewReader("this is the input")
 
-	exit := processMain([]string{}, input, stdout, stderr, func(r io.Reader, w io.Writer) error {
+	exit := processMain([]string{}, input, stdout, stderr, func(r io.Reader, w io.Writer, o Options) error {
 		return nil
 	})
 
@@ -39,7 +39,7 @@ func TestProcessMainStdinErr(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	input := strings.NewReader("this is the input")
 
-	exit := processMain([]string{}, input, stdout, stderr, func(r io.Reader, w io.Writer) error {
+	exit := processMain([]string{}, input, stdout, stderr, func(r io.Reader, w io.Writer, o Options) error {
 		return fmt.Errorf("something bad")
 	})
 
@@ -53,7 +53,7 @@ func TestProcessMainStdinDecodeErr(t *testing.T) {
 	stderr := new(bytes.Buffer)
 	input := strings.NewReader("this is the input")
 
-	exit := processMain([]string{}, input, stdout, stderr, func(r io.Reader, w io.Writer) error {
+	exit := processMain([]string{}, input, stdout, stderr, func(r io.Reader, w io.Writer, o Options) error {
 		var v interface{}
 		return toml.Unmarshal([]byte(`qwe = 001`), &v)
 	})
@@ -73,7 +73,7 @@ func TestProcessMainFileExists(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 
-	exit := processMain([]string{tmpfile.Name()}, nil, stdout, stderr, func(r io.Reader, w io.Writer) error {
+	exit := processMain([]string{tmpfile.Name()}, nil, stdout, stderr, func(r io.Reader, w io.Writer, o Options) error {
 		return nil
 	})
 
@@ -86,7 +86,7 @@ func TestProcessMainFileDoesNotExist(t *testing.T) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
 
-	exit := processMain([]string{"/lets/hope/this/does/not/exist"}, nil, stdout, stderr, func(r io.Reader, w io.Writer) error {
+	exit := processMain([]string{"/lets/hope/this/does/not/exist"}, nil, stdout, stderr, func(r io.Reader, w io.Writer, o Options) error {
 		return nil
 	})
 
@@ -148,7 +148,7 @@ func TestProcessMainFilesInPlaceFailFn(t *testing.T) {
 	require.NoError(t, err)
 
 	p := Program{
-		Fn:      func(io.Reader, io.Writer) error { return fmt.Errorf("oh no") },
+		Fn:      func(io.Reader, io.Writer, Options) error { return fmt.Errorf("oh no") },
 		Inplace: true,
 	}
 
@@ -161,7 +161,7 @@ func TestProcessMainFilesInPlaceFailFn(t *testing.T) {
 	require.Equal(t, "content 1", string(v1))
 }
 
-func dummyFileFn(r io.Reader, w io.Writer) error {
+func dummyFileFn(r io.Reader, w io.Writer, o Options) error {
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hi @pelletier 👋 

It has been a while since my last PR #578 on this repo.

Well the goal here is to re add that feature in the v2 of `go-toml` and especially `tomll`

### Explanation of what this pull request does.

The goal of this PR is to add a flag to the linter that allow us to render the TOML file with multilines array (meaning one line by element)

Don't hesitate if you need more details

Cheers 😉

---

Paste `benchstat` results here
