### PR TITLE
panic unmarshaling array of tables

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -377,7 +377,11 @@ func (d *decoder) handleArrayTableCollection(key unstable.Iterator, v reflect.Va
 
 		return v, nil
 	case reflect.Slice:
-		elem := v.Index(v.Len() - 1)
+		idx := v.Len() - 1
+		if idx < 0 {
+			return v, fmt.Errorf("TODO uninitialized array table")
+		}
+		elem := v.Index(idx)
 		x, err := d.handleArrayTable(key, elem)
 		if err != nil || d.skipUntilTable {
 			return reflect.Value{}, err

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -11,9 +11,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 func ExampleDecoder_DisallowUnknownFields() {
@@ -3300,4 +3301,15 @@ func TestUnmarshalEmbedNonString(t *testing.T) {
 	err := toml.Unmarshal([]byte(`foo = 'bar'`), &d)
 	require.NoError(t, err)
 	require.Nil(t, d.Foo)
+}
+
+func TestUnmarshalArrayOfTables(t *testing.T) {
+	m := struct {
+		A []struct {
+			B struct{}
+		}
+	}{}
+	require.NotPanics(t, func() {
+		require.Error(t, toml.Unmarshal([]byte(`[[A.B]]`), &m))
+	})
 }


### PR DESCRIPTION
Towards #839
- [x] `TestUnmarshalArrayOfTables` to reproduce
- [x] Placeholder error instead of panic to 'fix' the test
- [ ] Better error? _Or_ is this actually valid, meaning e.g. the slice should be expanded instead?