### PR TITLE
Fix go 1.20 version in github actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - name: Run tests with coverage
         run: ./ci.sh coverage -d "${GITHUB_BASE_REF-HEAD}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: "1.20"
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
YAML interprets 1.20 as 1.2 without explicitely being a string.

Follow up to https://github.com/pelletier/go-toml/pull/847