### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ complete solutions exist out there.
 
 ## Versioning
 
-Go-toml follows [Semantic Versioning](http://semver.org/). The supported version
+Go-toml follows [Semantic Versioning](https://semver.org). The supported version
 of [TOML](https://github.com/toml-lang/toml) is indicated at the beginning of
 this document. The last two major versions of Go are supported
 (see [Go Release Policy](https://golang.org/doc/devel/release.html#policy)).

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,7 +18,7 @@ type Program struct {
 	Usage string
 	Fn    ConvertFn
 	// Inplace allows the command to take more than one file as argument and
-	// perform convertion in place on each provided file.
+	// perform conversion in place on each provided file.
 	Inplace bool
 }
 

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -60,7 +60,7 @@ func (d *Decoder) DisallowUnknownFields() *Decoder {
 // are ignored. See Decoder.DisallowUnknownFields() to change this behavior.
 //
 // When a TOML local date, time, or date-time is decoded into a time.Time, its
-// value is represented in time.Local timezone. Otherwise the approriate Local*
+// value is represented in time.Local timezone. Otherwise the appropriate Local*
 // structure is used. For time values, precision up to the nanosecond is
 // supported by truncating extra digits.
 //

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2742,7 +2742,7 @@ world'`,
 			data: "a = \"aaaa\xE2\x80\x00\"",
 		},
 		{
-			desc: "invalid 4rd byte of 4-byte utf8 character in string with no escape sequence",
+			desc: "invalid 4th byte of 4-byte utf8 character in string with no escape sequence",
 			data: "a = \"aaaa\xF2\x81\x81\x00\"",
 		},
 		{
@@ -2758,7 +2758,7 @@ world'`,
 			data: "a = 'aaaa\xE2\x80\x00'",
 		},
 		{
-			desc: "invalid 4rd byte of 4-byte utf8 character in literal string",
+			desc: "invalid 4th byte of 4-byte utf8 character in literal string",
 			data: "a = 'aaaa\xF2\x81\x81\x00'",
 		},
 		{

--- a/unstable/ast.go
+++ b/unstable/ast.go
@@ -58,7 +58,7 @@ func (c *Iterator) Node() *Node {
 //   - Table and ArrayTable's children represent a dotted key (same as
 //     KeyValue, but without the first node being the value).
 //
-// When relevant, Raw describes the range of bytes this node is refering to in
+// When relevant, Raw describes the range of bytes this node is referring to in
 // the input document. Use Parser.Raw() to retrieve the actual bytes.
 type Node struct {
 	Kind Kind

--- a/unstable/parser.go
+++ b/unstable/parser.go
@@ -132,12 +132,12 @@ func (p *Parser) NextExpression() bool {
 }
 
 // Expression returns a pointer to the node representing the last successfully
-// parsed expresion.
+// parsed expression.
 func (p *Parser) Expression() *Node {
 	return p.builder.NodeAt(p.ref)
 }
 
-// Error returns any error that has occured during parsing.
+// Error returns any error that has occurred during parsing.
 func (p *Parser) Error() error {
 	return p.err
 }


### PR DESCRIPTION
This PR fixes a few typos I spotted in the project. It also converts one link from `http` to `https` protocol.