### PR TITLE
Decode: fix error reporting of type mismatch on inline tables

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -746,7 +746,7 @@ func (d *decoder) unmarshalInlineTable(itable *unstable.Node, v reflect.Value) e
 		}
 		return d.unmarshalInlineTable(itable, elem)
 	default:
-		return unstable.NewParserError(itable.Data, "cannot store inline table in Go type %s", v.Kind())
+		return unstable.NewParserError(d.p.Raw(itable.Raw), "cannot store inline table in Go type %s", v.Kind())
 	}
 
 	it := itable.Children()

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2466,6 +2466,12 @@ func TestIssue807(t *testing.T) {
 	require.Equal(t, "foo", m.Name)
 }
 
+func TestIssue850(t *testing.T) {
+	data := make(map[string]string)
+	err := toml.Unmarshal([]byte("foo = {}"), &data)
+	require.Error(t, err)
+}
+
 func TestUnmarshalDecodeErrors(t *testing.T) {
 	examples := []struct {
 		desc string

--- a/unstable/parser.go
+++ b/unstable/parser.go
@@ -402,6 +402,7 @@ func (p *Parser) parseInlineTable(b []byte) (reference, []byte, error) {
 	// inline-table-keyvals = keyval [ inline-table-sep inline-table-keyvals ]
 	parent := p.builder.Push(Node{
 		Kind: InlineTable,
+		Raw:  p.Range(b[:1]),
 	})
 
 	first := true


### PR DESCRIPTION
Parser did not track the location of the faulty inline table in the document, and unmarshaler tried to the use the non-raw data field of the AST node, both resulting into a panic when generating the parser error.

Fixes #850
