### PR TITLE
fuzz: move fuzz_target from oss-fuzz

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -77,7 +77,7 @@ cover() {
 
     pushd "$dir"
     go test -covermode=atomic  -coverpkg=./... -coverprofile=coverage.out.tmp ./...
-    cat coverage.out.tmp | grep -v testsuite | grep -v tomltestgen | grep -v gotoml-test-decoder > coverage.out
+    cat coverage.out.tmp | grep -v fuzz | grep -v testsuite | grep -v tomltestgen | grep -v gotoml-test-decoder > coverage.out
     go tool cover -func=coverage.out
     popd
 

--- a/oss_fuzz.go
+++ b/oss_fuzz.go
@@ -1,0 +1,43 @@
+//go:build go1.18 || go1.19 || go1.20
+// +build go1.18 go1.19 go1.20
+
+package toml
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func FuzzToml(data []byte) int {
+	if len(data) >= 10240 {
+		return 0
+	}
+
+	if strings.Contains(string(data), "nan") {
+		return 0
+	}
+
+	var v interface{}
+	err := Unmarshal(data, &v)
+	if err != nil {
+		return 0
+	}
+
+	encoded, err := Marshal(v)
+	if err != nil {
+		return 0
+	}
+
+	var v2 interface{}
+	err = Unmarshal(encoded, &v2)
+	if err != nil {
+		panic(fmt.Sprintf("Failed round trip: %s", err))
+	}
+
+	if !reflect.DeepEqual(v, v2) {
+		panic(fmt.Sprintf("Not equal: %#+v %#+v", v, v2))
+	}
+
+	return 1
+}

--- a/oss_fuzz.go
+++ b/oss_fuzz.go
@@ -26,17 +26,17 @@ func FuzzToml(data []byte) int {
 
 	encoded, err := Marshal(v)
 	if err != nil {
-		return 0
+		panic(fmt.Sprintf("failed to marshal unmarshaled document: %s", err))
 	}
 
 	var v2 interface{}
 	err = Unmarshal(encoded, &v2)
 	if err != nil {
-		panic(fmt.Sprintf("Failed round trip: %s", err))
+		panic(fmt.Sprintf("failed round trip: %s", err))
 	}
 
 	if !reflect.DeepEqual(v, v2) {
-		panic(fmt.Sprintf("Not equal: %#+v %#+v", v, v2))
+		panic(fmt.Sprintf("not equal: %#+v %#+v", v, v2))
 	}
 
 	return 1

--- a/ossfuzz/fuzz.go
+++ b/ossfuzz/fuzz.go
@@ -1,12 +1,14 @@
 //go:build go1.18 || go1.19 || go1.20
 // +build go1.18 go1.19 go1.20
 
-package toml
+package ossfuzz
 
 import (
 	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 func FuzzToml(data []byte) int {
@@ -19,18 +21,18 @@ func FuzzToml(data []byte) int {
 	}
 
 	var v interface{}
-	err := Unmarshal(data, &v)
+	err := toml.Unmarshal(data, &v)
 	if err != nil {
 		return 0
 	}
 
-	encoded, err := Marshal(v)
+	encoded, err := toml.Marshal(v)
 	if err != nil {
 		panic(fmt.Sprintf("failed to marshal unmarshaled document: %s", err))
 	}
 
 	var v2 interface{}
-	err = Unmarshal(encoded, &v2)
+	err = toml.Unmarshal(encoded, &v2)
 	if err != nil {
 		panic(fmt.Sprintf("failed round trip: %s", err))
 	}


### PR DESCRIPTION
- This pr attempts to move `fuzz_toml` fuzz_target from oss-fuzz to go-toml.
- Its recommended by oss-fuzz to move fuzz-target upstream as this eases maintenance of fuzz_target.
- It also include check against too large input.
- Skips fuzz from coverage report.
- Adds a new ossfuzz package
