### PR TITLE
Fix UnmarshalTOML is not called when its underlying type is an array

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -1017,6 +1017,15 @@ func (d *Decoder) valueFromToml(mtype reflect.Type, tval interface{}, mval1 *ref
 		return reflect.ValueOf(nil), fmt.Errorf("Can't convert %v(%T) to trees", tval, tval)
 	case []interface{}:
 		d.visitor.visit()
+
+		// Check if pointer to value implements the Unmarshaler interface.
+		if mvalPtr := reflect.New(mtype); isCustomUnmarshaler(mvalPtr.Type()) {
+			if err := callCustomUnmarshaler(mvalPtr, tval); err != nil {
+				return reflect.ValueOf(nil), fmt.Errorf("unmarshal toml: %v", err)
+			}
+			return mvalPtr.Elem(), nil
+		}
+
 		if isOtherSequence(mtype) {
 			return d.valueFromOtherSlice(mtype, t)
 		}


### PR DESCRIPTION
This PR is for v1.

This resolves the issue where, if a type implements `toml.Unmarshaler` but it has an array as its underlying type, the `UnmarshalTOML` method won't be triggered.