### PR TITLE
Use PtrTo to not require Go 1.18

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -1027,7 +1027,7 @@ func (d *decoder) keyFromData(keyType reflect.Type, data []byte) (reflect.Value,
 		}
 		return mk, nil
 
-	case reflect.PointerTo(keyType).Implements(textUnmarshalerType):
+	case reflect.PtrTo(keyType).Implements(textUnmarshalerType):
 		mk := reflect.New(keyType)
 		if err := mk.Interface().(encoding.TextUnmarshaler).UnmarshalText(data); err != nil {
 			return reflect.Value{}, fmt.Errorf("toml: error unmarshalling key type %s from text: %w", stringType, err)


### PR DESCRIPTION
As mentioned in https://github.com/pelletier/go-toml/pull/860#issuecomment-1559758970.

`PtrTo` is the old (pre 1.18) spelling of `PointerTo`. No need to bump Go support for that.