### PR TITLE
Encode: fix support for arrays

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -273,7 +273,7 @@ func (enc *Encoder) encode(b []byte, ctx encoderCtx, v reflect.Value) ([]byte, e
 		return enc.encodeMap(b, ctx, v)
 	case reflect.Struct:
 		return enc.encodeStruct(b, ctx, v)
-	case reflect.Slice:
+	case reflect.Slice, reflect.Array:
 		return enc.encodeSlice(b, ctx, v)
 	case reflect.Interface:
 		if v.IsNil() {
@@ -930,7 +930,7 @@ func willConvertToTableOrArrayTable(ctx encoderCtx, v reflect.Value) bool {
 		return willConvertToTableOrArrayTable(ctx, v.Elem())
 	}
 
-	if t.Kind() == reflect.Slice {
+	if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
 		if v.Len() == 0 {
 			// An empty slice should be a kv = [].
 			return false

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -209,6 +209,45 @@ b-1 = 'value 3'
 `,
 		},
 		{
+			desc: "fixed size string array",
+			v: map[string][3]string{
+				"array": {"one", "two", "three"},
+			},
+			expected: `array = ['one', 'two', 'three']
+`,
+		},
+		{
+			desc: "fixed size nested string arrays",
+			v: map[string][2][2]string{
+				"array": {{"one", "two"}, {"three"}},
+			},
+			expected: `array = [['one', 'two'], ['three', '']]
+`,
+		},
+		{
+			desc: "mixed strings and fixed size nested string arrays",
+			v: map[string][]interface{}{
+				"array": {"a string", [2]string{"one", "two"}, "last"},
+			},
+			expected: `array = ['a string', ['one', 'two'], 'last']
+`,
+		},
+		{
+			desc: "fixed size array of maps",
+			v: map[string][2]map[string]string{
+				"ftop": {
+					{"map1.1": "v1.1"},
+					{"map2.1": "v2.1"},
+				},
+			},
+			expected: `[[ftop]]
+'map1.1' = 'v1.1'
+
+[[ftop]]
+'map2.1' = 'v2.1'
+`,
+		},
+		{
 			desc: "map with two keys",
 			v: map[string]string{
 				"key1": "value1",


### PR DESCRIPTION
This change allows encoding fixed size arrays. 
Current version generates error: `toml: cannot encode value of type array`.

