### PR TITLE
Decode: assign empty struct to empty defined sections

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -79,6 +79,7 @@ cover() {
     go test -covermode=atomic  -coverpkg=./... -coverprofile=coverage.out.tmp ./...
     cat coverage.out.tmp | grep -v fuzz | grep -v testsuite | grep -v tomltestgen | grep -v gotoml-test-decoder > coverage.out
     go tool cover -func=coverage.out
+    echo "Coverage profile for ${branch}: ${dir}/coverage.out" >&2
     popd
 
     if [ "${branch}" != "HEAD" ]; then

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -1170,10 +1170,10 @@ func initAndDereferencePointer(v reflect.Value) reflect.Value {
 
 // Same as reflect.Value.FieldByIndex, but creates pointers if needed.
 func fieldByIndex(v reflect.Value, path []int) reflect.Value {
-	for i, x := range path {
+	for _, x := range path {
 		v = v.Field(x)
 
-		if i < len(path)-1 && v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Ptr {
 			if v.IsNil() {
 				v.Set(reflect.New(v.Type().Elem()))
 			}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -1278,6 +1278,64 @@ B = "data"`,
 			},
 		},
 		{
+			desc: "array table into maps with pointer on last key",
+			input: `[[foo]]
+			bar = "hello"`,
+			gen: func() test {
+				type doc struct {
+					Foo **[]interface{}
+				}
+				x := &[]interface{}{
+					map[string]interface{}{
+						"bar": "hello",
+					},
+				}
+				return test{
+					target: &doc{},
+					expected: &doc{
+						Foo: &x,
+					},
+				}
+			},
+		},
+		{
+			desc: "array table into maps with pointer on intermediate key",
+			input: `[[foo.foo2]]
+			bar = "hello"`,
+			gen: func() test {
+				type doc struct {
+					Foo **map[string]interface{}
+				}
+				x := &map[string]interface{}{
+					"foo2": []interface{}{
+						map[string]interface{}{
+							"bar": "hello",
+						},
+					},
+				}
+				return test{
+					target: &doc{},
+					expected: &doc{
+						Foo: &x,
+					},
+				}
+			},
+		},
+		{
+			desc: "array table into maps with pointer on last key with invalid leaf type",
+			input: `[[foo]]
+			bar = "hello"`,
+			gen: func() test {
+				type doc struct {
+					Foo **[]map[string]int
+				}
+				return test{
+					target: &doc{},
+					err:    true,
+				}
+			},
+		},
+		{
 			desc:  "unexported struct fields are ignored",
 			input: `foo = "bar"`,
 			gen: func() test {


### PR DESCRIPTION
Fixes #878 

Not sure what the gate in the patched method was intended to do but it was preventing from creating pointers to structs correctly when a section was defined. This change ensures that `original_document == Marshal(Unmarsal(original_document)` which isn't the case without this patch.