### PR TITLE
Fix ordered encoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/pelletier/go-toml
 
 go 1.12
+
+require github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
Fix for issue #882 (Ordered encoded results is incorrect in some cases (simple type after map or complex slice)

