### PR TITLE
Decode: fix panic when parsing '0' as a float

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -318,7 +318,7 @@ func parseFloat(b []byte) (float64, error) {
 	if cleaned[0] == '+' || cleaned[0] == '-' {
 		start = 1
 	}
-	if cleaned[start] == '0' && isDigit(cleaned[start+1]) {
+	if cleaned[start] == '0' && len(cleaned) > start+1 && isDigit(cleaned[start+1]) {
 		return 0, unstable.NewParserError(b, "float integer part cannot have leading zeroes")
 	}
 

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -241,6 +241,11 @@ func TestUnmarshal_Floats(t *testing.T) {
 			expected: 0.0,
 		},
 		{
+			desc:     "float zero without decimals",
+			input:    `0`,
+			expected: 0.0,
+		},
+		{
 			desc:     "float fractional with exponent",
 			input:    `6.626e-34`,
 			expected: 6.626e-34,


### PR DESCRIPTION
Fix (#886) :  Panic when parsing '0' using parseFloat
