### PR TITLE
Decode: fix wrong indention for comments on tables

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -983,11 +983,11 @@ func (enc *Encoder) encodeSliceAsArrayTable(b []byte, ctx encoderCtx, v reflect.
 	scratch = append(scratch, "]]\n"...)
 	ctx.skipTableHeader = true
 
+	b = enc.encodeComment(ctx.indent, ctx.options.comment, b)
+
 	if enc.indentTables {
 		ctx.indent++
 	}
-
-	b = enc.encodeComment(ctx.indent, ctx.options.comment, b)
 
 	for i := 0; i < v.Len(); i++ {
 		if i != 0 {

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1208,7 +1208,7 @@ func TestMarhsalIssue888(t *testing.T) {
 	}
 
 	type Cfg struct {
-		Custom []Thing
+		Custom []Thing `comment:"custom config"`
 	}
 
 	buf := new(bytes.Buffer)
@@ -1223,7 +1223,8 @@ func TestMarhsalIssue888(t *testing.T) {
 	encoder := toml.NewEncoder(buf).SetIndentTables(true)
 	encoder.Encode(config)
 
-	expected := `[[Custom]]
+	expected := `# custom config
+[[Custom]]
   # my field A
   FieldA = 'field a 1'
   # my field B


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->

Follow up for #889, now comments for tables have an indentation of the parent