### PR TITLE
all: Replace use of deprecated io/ioutil package

### DIFF
--- a/benchmark/bench_datasets_test.go
+++ b/benchmark/bench_datasets_test.go
@@ -3,7 +3,7 @@ package benchmark_test
 import (
 	"compress/gzip"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -74,7 +74,7 @@ func fixture(tb testing.TB, path string) []byte {
 	gz, err := gzip.NewReader(f)
 	require.NoError(tb, err)
 
-	buf, err := ioutil.ReadAll(gz)
+	buf, err := io.ReadAll(gz)
 	require.NoError(tb, err)
 	return buf
 }

--- a/benchmark/benchmark_test.go
+++ b/benchmark/benchmark_test.go
@@ -2,7 +2,7 @@ package benchmark_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -59,7 +59,7 @@ func BenchmarkUnmarshal(b *testing.B) {
 	})
 
 	b.Run("ReferenceFile", func(b *testing.B) {
-		bytes, err := ioutil.ReadFile("benchmark.toml")
+		bytes, err := os.ReadFile("benchmark.toml")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -165,7 +165,7 @@ func BenchmarkMarshal(b *testing.B) {
 	})
 
 	b.Run("ReferenceFile", func(b *testing.B) {
-		bytes, err := ioutil.ReadFile("benchmark.toml")
+		bytes, err := os.ReadFile("benchmark.toml")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -344,7 +344,7 @@ type benchmarkDoc struct {
 }
 
 func TestUnmarshalReferenceFile(t *testing.T) {
-	bytes, err := ioutil.ReadFile("benchmark.toml")
+	bytes, err := os.ReadFile("benchmark.toml")
 	require.NoError(t, err)
 	d := benchmarkDoc{}
 	err = toml.Unmarshal(bytes, &d)

--- a/cmd/tomltestgen/main.go
+++ b/cmd/tomltestgen/main.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"go/format"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -72,7 +71,7 @@ func downloadTmpFile(url string) string {
 	}
 	defer resp.Body.Close()
 
-	tmpfile, err := ioutil.TempFile("", "toml-test-*.zip")
+	tmpfile, err := os.CreateTemp("", "toml-test-*.zip")
 	if err != nil {
 		panic(err)
 	}
@@ -113,7 +112,7 @@ func readFileFromZip(f *zip.File) string {
 		panic(err)
 	}
 	defer reader.Close()
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		panic(err)
 	}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -4,7 +4,7 @@
 package toml_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -13,7 +13,7 @@ import (
 )
 
 func FuzzUnmarshal(f *testing.F) {
-	file, err := ioutil.ReadFile("benchmark/benchmark.toml")
+	file, err := os.ReadFile("benchmark/benchmark.toml")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/pelletier/go-toml/v2"
@@ -72,7 +71,7 @@ func (p *Program) runAllFilesInPlace(files []string) error {
 }
 
 func (p *Program) runFileInPlace(path string) error {
-	in, err := ioutil.ReadFile(path)
+	in, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -84,5 +83,5 @@ func (p *Program) runFileInPlace(path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, out.Bytes(), 0600)
+	return os.WriteFile(path, out.Bytes(), 0600)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -64,7 +63,7 @@ func TestProcessMainStdinDecodeErr(t *testing.T) {
 }
 
 func TestProcessMainFileExists(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "example")
+	tmpfile, err := os.CreateTemp("", "example")
 	require.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 	_, err = tmpfile.Write([]byte(`some data`))
@@ -96,16 +95,14 @@ func TestProcessMainFileDoesNotExist(t *testing.T) {
 }
 
 func TestProcessMainFilesInPlace(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	path1 := path.Join(dir, "file1")
 	path2 := path.Join(dir, "file2")
 
-	err = ioutil.WriteFile(path1, []byte("content 1"), 0600)
+	err := os.WriteFile(path1, []byte("content 1"), 0600)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(path2, []byte("content 2"), 0600)
+	err = os.WriteFile(path2, []byte("content 2"), 0600)
 	require.NoError(t, err)
 
 	p := Program{
@@ -117,11 +114,11 @@ func TestProcessMainFilesInPlace(t *testing.T) {
 
 	require.Equal(t, 0, exit)
 
-	v1, err := ioutil.ReadFile(path1)
+	v1, err := os.ReadFile(path1)
 	require.NoError(t, err)
 	require.Equal(t, "1", string(v1))
 
-	v2, err := ioutil.ReadFile(path2)
+	v2, err := os.ReadFile(path2)
 	require.NoError(t, err)
 	require.Equal(t, "2", string(v2))
 }
@@ -138,13 +135,11 @@ func TestProcessMainFilesInPlaceErrRead(t *testing.T) {
 }
 
 func TestProcessMainFilesInPlaceFailFn(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	path1 := path.Join(dir, "file1")
 
-	err = ioutil.WriteFile(path1, []byte("content 1"), 0600)
+	err := os.WriteFile(path1, []byte("content 1"), 0600)
 	require.NoError(t, err)
 
 	p := Program{
@@ -156,13 +151,13 @@ func TestProcessMainFilesInPlaceFailFn(t *testing.T) {
 
 	require.Equal(t, -1, exit)
 
-	v1, err := ioutil.ReadFile(path1)
+	v1, err := os.ReadFile(path1)
 	require.NoError(t, err)
 	require.Equal(t, "content 1", string(v1))
 }
 
 func dummyFileFn(r io.Reader, w io.Writer) error {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"reflect"
 	"strings"
@@ -96,7 +95,7 @@ func (d *Decoder) DisallowUnknownFields() *Decoder {
 //	Inline Table     -> same as Table
 //	Array of Tables  -> same as Array and Table
 func (d *Decoder) Decode(v interface{}) error {
-	b, err := ioutil.ReadAll(d.r)
+	b, err := io.ReadAll(d.r)
 	if err != nil {
 		return fmt.Errorf("toml: %w", err)
 	}


### PR DESCRIPTION
As of 1.16 (which is the lowest we support) the io and os packages contain all the same functionality.

Additionally two uses of ioutil.TempDir() in tests can be replaced with the simpler t.TempDir() to automatically handle cleanup.

<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->

Explanation of what this pull request does.

More detailed description of the decisions being made and the reasons why (if
the patch is non-trivial).

---

Paste `benchstat` results here
