### PR TITLE
Test on M1 macOS

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
+        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest', 'macos-latest-xlarge' ]
         go: [ '1.20', '1.21' ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.go }}/${{ matrix.os }}


### PR DESCRIPTION
https://github.blog/changelog/2023-10-02-github-actions-apple-silicon-m1-macos-runners-are-now-available-in-public-beta/

EDIT: never mind

> only [...] GitHub Team or GitHub Enterprise Cloud plans.