### PR TITLE
Add cmd/gotoml-test-encoder

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -77,7 +77,7 @@ cover() {
 
     pushd "$dir"
     go test -covermode=atomic  -coverpkg=./... -coverprofile=coverage.out.tmp ./...
-    cat coverage.out.tmp | grep -v fuzz | grep -v testsuite | grep -v tomltestgen | grep -v gotoml-test-decoder > coverage.out
+    grep -Ev '(fuzz|testsuite|tomltestgen|gotoml-test-decoder|gotoml-test-encoder)' coverage.out.tmp > coverage.out
     go tool cover -func=coverage.out
     echo "Coverage profile for ${branch}: ${dir}/coverage.out" >&2
     popd

--- a/cmd/gotoml-test-encoder/gotoml-test-encoder.go
+++ b/cmd/gotoml-test-encoder/gotoml-test-encoder.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path"
+
+	"github.com/pelletier/go-toml/v2/internal/testsuite"
+)
+
+func main() {
+	log.SetFlags(0)
+	flag.Usage = usage
+	flag.Parse()
+	if flag.NArg() != 0 {
+		flag.Usage()
+	}
+
+	err := testsuite.EncodeStdin()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func usage() {
+	log.Printf("Usage: %s < toml-file\n", path.Base(os.Args[0]))
+	flag.PrintDefaults()
+	os.Exit(1)
+}

--- a/internal/testsuite/rm.go
+++ b/internal/testsuite/rm.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 	"time"
+
+	"github.com/pelletier/go-toml/v2"
 )
 
 // Remove JSON tags to a data structure as returned by toml-test.
@@ -76,14 +78,31 @@ func untag(typed map[string]interface{}) (interface{}, error) {
 			return nil, fmt.Errorf("untag: %w", err)
 		}
 		return f, nil
+
+		//toml.LocalDate{Year:2020, Month:12, Day:12}
 	case "datetime":
-		return parseTime(v, "2006-01-02T15:04:05.999999999Z07:00", false)
+		return time.Parse("2006-01-02T15:04:05.999999999Z07:00", v)
 	case "datetime-local":
-		return parseTime(v, "2006-01-02T15:04:05.999999999", true)
+		var t toml.LocalDateTime
+		err := t.UnmarshalText([]byte(v))
+		if err != nil {
+			return nil, fmt.Errorf("untag: %w", err)
+		}
+		return t, nil
 	case "date-local":
-		return parseTime(v, "2006-01-02", true)
+		var t toml.LocalDate
+		err := t.UnmarshalText([]byte(v))
+		if err != nil {
+			return nil, fmt.Errorf("untag: %w", err)
+		}
+		return t, nil
 	case "time-local":
-		return parseTime(v, "15:04:05.999999999", true)
+		var t toml.LocalTime
+		err := t.UnmarshalText([]byte(v))
+		if err != nil {
+			return nil, fmt.Errorf("untag: %w", err)
+		}
+		return t, nil
 	case "bool":
 		switch v {
 		case "true":

--- a/internal/testsuite/testsuite.go
+++ b/internal/testsuite/testsuite.go
@@ -48,3 +48,21 @@ func DecodeStdin() error {
 
 	return nil
 }
+
+// EncodeStdin is a helper function for the toml-test binary interface.  Tagged
+// JSON is read from STDIN and a resulting TOML representation is written to
+// STDOUT.
+func EncodeStdin() error {
+	var j interface{}
+	err := json.NewDecoder(os.Stdin).Decode(&j)
+	if err != nil {
+		return err
+	}
+
+	rm, err := rmTag(j)
+	if err != nil {
+		return fmt.Errorf("removing tags: %w", err)
+	}
+
+	return toml.NewEncoder(os.Stdout).Encode(rm)
+}


### PR DESCRIPTION
Since there was already an encoder I figured adding an encoder makes sense. Also had to fix it for local dates.

	% toml-test -encoder ./gotoml-test-encoder
	toml-test v2023-10-13 [./gotoml-test-encoder]: using embedded tests
	encoder tests: 162 passed,  0 failed