### PR TITLE
Encode: support `json.Number` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ Given the following struct, let's see how to read it and write it as TOML:
 
 ```go
 type MyConfig struct {
-      Version int
-      Name    string
-      Tags    []string
+	  Version int
+	  Name    string
+	  Tags    []string
 }
 ```
 
@@ -119,7 +119,7 @@ tags = ["go", "toml"]
 var cfg MyConfig
 err := toml.Unmarshal([]byte(doc), &cfg)
 if err != nil {
-      panic(err)
+	  panic(err)
 }
 fmt.Println("version:", cfg.Version)
 fmt.Println("name:", cfg.Name)
@@ -140,14 +140,14 @@ as a TOML document:
 
 ```go
 cfg := MyConfig{
-      Version: 2,
-      Name:    "go-toml",
-      Tags:    []string{"go", "toml"},
+	  Version: 2,
+	  Name:    "go-toml",
+	  Tags:    []string{"go", "toml"},
 }
 
 b, err := toml.Marshal(cfg)
 if err != nil {
-      panic(err)
+	  panic(err)
 }
 fmt.Println(string(b))
 
@@ -175,17 +175,17 @@ the AST level. See https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable.
 Execution time speedup compared to other Go TOML libraries:
 
 <table>
-    <thead>
-        <tr><th>Benchmark</th><th>go-toml v1</th><th>BurntSushi/toml</th></tr>
-    </thead>
-    <tbody>
-        <tr><td>Marshal/HugoFrontMatter-2</td><td>1.9x</td><td>2.2x</td></tr>
-        <tr><td>Marshal/ReferenceFile/map-2</td><td>1.7x</td><td>2.1x</td></tr>
-        <tr><td>Marshal/ReferenceFile/struct-2</td><td>2.2x</td><td>3.0x</td></tr>
-        <tr><td>Unmarshal/HugoFrontMatter-2</td><td>2.9x</td><td>2.7x</td></tr>
-        <tr><td>Unmarshal/ReferenceFile/map-2</td><td>2.6x</td><td>2.7x</td></tr>
-        <tr><td>Unmarshal/ReferenceFile/struct-2</td><td>4.6x</td><td>5.1x</td></tr>
-     </tbody>
+	<thead>
+		<tr><th>Benchmark</th><th>go-toml v1</th><th>BurntSushi/toml</th></tr>
+	</thead>
+	<tbody>
+		<tr><td>Marshal/HugoFrontMatter-2</td><td>1.9x</td><td>2.2x</td></tr>
+		<tr><td>Marshal/ReferenceFile/map-2</td><td>1.7x</td><td>2.1x</td></tr>
+		<tr><td>Marshal/ReferenceFile/struct-2</td><td>2.2x</td><td>3.0x</td></tr>
+		<tr><td>Unmarshal/HugoFrontMatter-2</td><td>2.9x</td><td>2.7x</td></tr>
+		<tr><td>Unmarshal/ReferenceFile/map-2</td><td>2.6x</td><td>2.7x</td></tr>
+		<tr><td>Unmarshal/ReferenceFile/struct-2</td><td>4.6x</td><td>5.1x</td></tr>
+	 </tbody>
 </table>
 <details><summary>See more</summary>
 <p>The table above has the results of the most common use-cases. The table below
@@ -193,22 +193,22 @@ contains the results of all benchmarks, including unrealistic ones. It is
 provided for completeness.</p>
 
 <table>
-    <thead>
-        <tr><th>Benchmark</th><th>go-toml v1</th><th>BurntSushi/toml</th></tr>
-    </thead>
-    <tbody>
-        <tr><td>Marshal/SimpleDocument/map-2</td><td>1.8x</td><td>2.7x</td></tr>
-        <tr><td>Marshal/SimpleDocument/struct-2</td><td>2.7x</td><td>3.8x</td></tr>
-        <tr><td>Unmarshal/SimpleDocument/map-2</td><td>3.8x</td><td>3.0x</td></tr>
-        <tr><td>Unmarshal/SimpleDocument/struct-2</td><td>5.6x</td><td>4.1x</td></tr>
-        <tr><td>UnmarshalDataset/example-2</td><td>3.0x</td><td>3.2x</td></tr>
-        <tr><td>UnmarshalDataset/code-2</td><td>2.3x</td><td>2.9x</td></tr>
-        <tr><td>UnmarshalDataset/twitter-2</td><td>2.6x</td><td>2.7x</td></tr>
-        <tr><td>UnmarshalDataset/citm_catalog-2</td><td>2.2x</td><td>2.3x</td></tr>
-        <tr><td>UnmarshalDataset/canada-2</td><td>1.8x</td><td>1.5x</td></tr>
-        <tr><td>UnmarshalDataset/config-2</td><td>4.1x</td><td>2.9x</td></tr>
-        <tr><td>geomean</td><td>2.7x</td><td>2.8x</td></tr>
-     </tbody>
+	<thead>
+		<tr><th>Benchmark</th><th>go-toml v1</th><th>BurntSushi/toml</th></tr>
+	</thead>
+	<tbody>
+		<tr><td>Marshal/SimpleDocument/map-2</td><td>1.8x</td><td>2.7x</td></tr>
+		<tr><td>Marshal/SimpleDocument/struct-2</td><td>2.7x</td><td>3.8x</td></tr>
+		<tr><td>Unmarshal/SimpleDocument/map-2</td><td>3.8x</td><td>3.0x</td></tr>
+		<tr><td>Unmarshal/SimpleDocument/struct-2</td><td>5.6x</td><td>4.1x</td></tr>
+		<tr><td>UnmarshalDataset/example-2</td><td>3.0x</td><td>3.2x</td></tr>
+		<tr><td>UnmarshalDataset/code-2</td><td>2.3x</td><td>2.9x</td></tr>
+		<tr><td>UnmarshalDataset/twitter-2</td><td>2.6x</td><td>2.7x</td></tr>
+		<tr><td>UnmarshalDataset/citm_catalog-2</td><td>2.2x</td><td>2.3x</td></tr>
+		<tr><td>UnmarshalDataset/canada-2</td><td>1.8x</td><td>1.5x</td></tr>
+		<tr><td>UnmarshalDataset/config-2</td><td>4.1x</td><td>2.9x</td></tr>
+		<tr><td>geomean</td><td>2.7x</td><td>2.8x</td></tr>
+	 </tbody>
 </table>
 <p>This table can be generated with <code>./ci.sh benchmark -a -html</code>.</p>
 </details>
@@ -233,24 +233,24 @@ Go-toml provides three handy command line tools:
 
  * `tomljson`: Reads a TOML file and outputs its JSON representation.
 
-    ```
-    $ go install github.com/pelletier/go-toml/v2/cmd/tomljson@latest
-    $ tomljson --help
-    ```
+	```
+	$ go install github.com/pelletier/go-toml/v2/cmd/tomljson@latest
+	$ tomljson --help
+	```
 
  * `jsontoml`: Reads a JSON file and outputs a TOML representation.
 
-    ```
-    $ go install github.com/pelletier/go-toml/v2/cmd/jsontoml@latest
-    $ jsontoml --help
-    ```
+	```
+	$ go install github.com/pelletier/go-toml/v2/cmd/jsontoml@latest
+	$ jsontoml --help
+	```
 
  * `tomll`: Lints and reformats a TOML file.
 
-    ```
-    $ go install github.com/pelletier/go-toml/v2/cmd/tomll@latest
-    $ tomll --help
-    ```
+	```
+	$ go install github.com/pelletier/go-toml/v2/cmd/tomll@latest
+	$ tomll --help
+	```
 
 ### Docker image
 
@@ -301,7 +301,7 @@ type doc struct {
 
 d := doc{
   A: inner{
-    B: "Before",
+	B: "Before",
   },
 }
 
@@ -565,10 +565,11 @@ complete solutions exist out there.
 
 ## Versioning
 
-Go-toml follows [Semantic Versioning](https://semver.org). The supported version
-of [TOML](https://github.com/toml-lang/toml) is indicated at the beginning of
-this document. The last two major versions of Go are supported
-(see [Go Release Policy](https://golang.org/doc/devel/release.html#policy)).
+Expect for parts explicitely marked otherwise, go-toml follows [Semantic
+Versioning](https://semver.org). The supported version of
+[TOML](https://github.com/toml-lang/toml) is indicated at the beginning of this
+document. The last two major versions of Go are supported (see [Go Release
+Policy](https://golang.org/doc/devel/release.html#policy)).
 
 ## License
 

--- a/cmd/jsontoml/main.go
+++ b/cmd/jsontoml/main.go
@@ -45,6 +45,7 @@ func convert(r io.Reader, w io.Writer) error {
 	var v interface{}
 
 	d := json.NewDecoder(r)
+	d.UseNumber()
 	err := d.Decode(&v)
 	if err != nil {
 		return err

--- a/cmd/jsontoml/main.go
+++ b/cmd/jsontoml/main.go
@@ -45,7 +45,6 @@ func convert(r io.Reader, w io.Writer) error {
 	var v interface{}
 
 	d := json.NewDecoder(r)
-	d.UseNumber()
 	err := d.Decode(&v)
 	if err != nil {
 		return err

--- a/cmd/jsontoml/main.go
+++ b/cmd/jsontoml/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"io"
 
 	"github.com/pelletier/go-toml/v2"
@@ -33,6 +34,10 @@ Reading from a file:
   jsontoml file.json > file.toml
 `
 
+var (
+	useNumber = flag.Bool("use-number", false, "Tells the json decoder to unmarshal numbers into json.Number type instead of float64")
+)
+
 func main() {
 	p := cli.Program{
 		Usage: usage,
@@ -45,11 +50,17 @@ func convert(r io.Reader, w io.Writer) error {
 	var v interface{}
 
 	d := json.NewDecoder(r)
+	e := toml.NewEncoder(w)
+
+	if useNumber != nil && *useNumber {
+		d.UseNumber()
+		e.SetJsonNumber(true)
+	}
+
 	err := d.Decode(&v)
 	if err != nil {
 		return err
 	}
 
-	e := toml.NewEncoder(w)
 	return e.Encode(v)
 }

--- a/cmd/jsontoml/main.go
+++ b/cmd/jsontoml/main.go
@@ -54,7 +54,7 @@ func convert(r io.Reader, w io.Writer) error {
 
 	if useNumber != nil && *useNumber {
 		d.UseNumber()
-		e.SetJsonNumber(true)
+		e.SetMarshalJsonNumbers(true)
 	}
 
 	err := d.Decode(&v)

--- a/cmd/jsontoml/main.go
+++ b/cmd/jsontoml/main.go
@@ -34,11 +34,11 @@ Reading from a file:
   jsontoml file.json > file.toml
 `
 
-var (
-	useNumber = flag.Bool("use-number", false, "Tells the json decoder to unmarshal numbers into json.Number type instead of float64")
-)
+var useJsonNumber bool
 
 func main() {
+	flag.BoolVar(&useJsonNumber, "use-json-number", false, "unmarshal numbers into `json.Number` type instead of as `float64`")
+
 	p := cli.Program{
 		Usage: usage,
 		Fn:    convert,
@@ -52,7 +52,7 @@ func convert(r io.Reader, w io.Writer) error {
 	d := json.NewDecoder(r)
 	e := toml.NewEncoder(w)
 
-	if useNumber != nil && *useNumber {
+	if useJsonNumber {
 		d.UseNumber()
 		e.SetMarshalJsonNumbers(true)
 	}

--- a/cmd/jsontoml/main_test.go
+++ b/cmd/jsontoml/main_test.go
@@ -25,7 +25,7 @@ func TestConvert(t *testing.T) {
   }
 }`,
 			expected: `[mytoml]
-a = 42.0
+a = 42
 `,
 		},
 		{

--- a/cmd/jsontoml/main_test.go
+++ b/cmd/jsontoml/main_test.go
@@ -11,11 +11,11 @@ import (
 
 func TestConvert(t *testing.T) {
 	examples := []struct {
-		name      string
-		input     string
-		expected  string
-		errors    bool
-		useNumber bool
+		name          string
+		input         string
+		expected      string
+		errors        bool
+		useJsonNumber bool
 	}{
 		{
 			name: "valid json",
@@ -30,8 +30,8 @@ a = 42.0
 `,
 		},
 		{
-			name:      "use json number",
-			useNumber: true,
+			name:          "use json number",
+			useJsonNumber: true,
 			input: `
 {
   "mytoml": {
@@ -49,13 +49,9 @@ a = 42
 		},
 	}
 
-	trueValue := true
-
 	for _, e := range examples {
 		b := new(bytes.Buffer)
-		if e.useNumber {
-			useNumber = &trueValue
-		}
+		useJsonNumber = e.useJsonNumber
 		err := convert(strings.NewReader(e.input), b)
 		if e.errors {
 			require.Error(t, err)

--- a/cmd/jsontoml/main_test.go
+++ b/cmd/jsontoml/main_test.go
@@ -11,10 +11,11 @@ import (
 
 func TestConvert(t *testing.T) {
 	examples := []struct {
-		name     string
-		input    string
-		expected string
-		errors   bool
+		name      string
+		input     string
+		expected  string
+		errors    bool
+		useNumber bool
 	}{
 		{
 			name: "valid json",
@@ -29,14 +30,32 @@ a = 42.0
 `,
 		},
 		{
+			name:      "use json number",
+			useNumber: true,
+			input: `
+{
+  "mytoml": {
+    "a": 42
+  }
+}`,
+			expected: `[mytoml]
+a = 42
+`,
+		},
+		{
 			name:   "invalid json",
 			input:  `{ foo`,
 			errors: true,
 		},
 	}
 
+	trueValue := true
+
 	for _, e := range examples {
 		b := new(bytes.Buffer)
+		if e.useNumber {
+			useNumber = &trueValue
+		}
 		err := convert(strings.NewReader(e.input), b)
 		if e.errors {
 			require.Error(t, err)

--- a/cmd/jsontoml/main_test.go
+++ b/cmd/jsontoml/main_test.go
@@ -25,7 +25,7 @@ func TestConvert(t *testing.T) {
   }
 }`,
 			expected: `[mytoml]
-a = 42
+a = 42.0
 `,
 		},
 		{

--- a/marshaler.go
+++ b/marshaler.go
@@ -3,6 +3,7 @@ package toml
 import (
 	"bytes"
 	"encoding"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -252,6 +253,16 @@ func (enc *Encoder) encode(b []byte, ctx encoderCtx, v reflect.Value) ([]byte, e
 		return append(b, x.String()...), nil
 	case LocalDateTime:
 		return append(b, x.String()...), nil
+	case json.Number:
+		if x == "" { /// Useful zero value.
+			return append(b, "0"...), nil
+		} else if v, err := x.Int64(); err == nil {
+			return enc.encode(b, ctx, reflect.ValueOf(v))
+		} else if f, err := x.Float64(); err == nil {
+			return enc.encode(b, ctx, reflect.ValueOf(f))
+		} else {
+			return nil, fmt.Errorf("toml: unable to convert %q to int64 or float64", x)
+		}
 	}
 
 	hasTextMarshaler := v.Type().Implements(textMarshalerType)

--- a/marshaler.go
+++ b/marshaler.go
@@ -89,8 +89,12 @@ func (enc *Encoder) SetIndentTables(indent bool) *Encoder {
 	return enc
 }
 
-// SetMarshalJsonNumbers forces the encoder to serialize `json.Number` as a float or integer
-// instead of relying on TextMarshaler to emit a string.
+// SetMarshalJsonNumbers forces the encoder to serialize `json.Number` as a
+// float or integer instead of relying on TextMarshaler to emit a string.
+//
+// *Unstable:* This method does not follow the compatiblity guarnatees of
+// semver. It can be changed or removed without a new major version being
+// issued.
 func (enc *Encoder) SetMarshalJsonNumbers(indent bool) *Encoder {
 	enc.marshalJsonNumbers = indent
 	return enc

--- a/marshaler.go
+++ b/marshaler.go
@@ -38,11 +38,11 @@ type Encoder struct {
 	w io.Writer
 
 	// global settings
-	tablesInline    bool
-	arraysMultiline bool
-	indentSymbol    string
-	indentTables    bool
-	jsonNumber      bool
+	tablesInline       bool
+	arraysMultiline    bool
+	indentSymbol       string
+	indentTables       bool
+	marshalJsonNumbers bool
 }
 
 // NewEncoder returns a new Encoder that writes to w.
@@ -89,10 +89,10 @@ func (enc *Encoder) SetIndentTables(indent bool) *Encoder {
 	return enc
 }
 
-// SetJsonNumber forces the encoder to serialize `json.Number` as a float or integer
+// SetMarshalJsonNumbers forces the encoder to serialize `json.Number` as a float or integer
 // instead of relying on TextMarshaler to emit a string.
-func (enc *Encoder) SetJsonNumber(indent bool) *Encoder {
-	enc.jsonNumber = indent
+func (enc *Encoder) SetMarshalJsonNumbers(indent bool) *Encoder {
+	enc.marshalJsonNumbers = indent
 	return enc
 }
 
@@ -262,7 +262,7 @@ func (enc *Encoder) encode(b []byte, ctx encoderCtx, v reflect.Value) ([]byte, e
 	case LocalDateTime:
 		return append(b, x.String()...), nil
 	case json.Number:
-		if enc.jsonNumber {
+		if enc.marshalJsonNumbers {
 			if x == "" { /// Useful zero value.
 				return append(b, "0"...), nil
 			} else if v, err := x.Int64(); err == nil {

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -682,6 +682,31 @@ L = 2.2
 `,
 		},
 		{
+			desc: "json numbers",
+			v: struct {
+				A json.Number
+				B json.Number
+				C json.Number
+				D json.Number
+				E json.Number
+				F json.Number
+			}{
+				A: "1.1",
+				B: "42e-3",
+				C: "42",
+				D: "0",
+				E: "0.0",
+				F: "",
+			},
+			expected: `A = 1.1
+B = 0.042
+C = 42
+D = 0
+E = 0.0
+F = 0
+`,
+		},
+		{
 			desc: "comments",
 			v: struct {
 				Table comments `comment:"Before table"`

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -948,7 +948,7 @@ func TestEncoderSetIndentSymbol(t *testing.T) {
 	assert.Equal(t, expected, w.String())
 }
 
-func TestEncoderSetJsonNumber(t *testing.T) {
+func TestEncoderSetMarshalJsonNumbers(t *testing.T) {
 	var w strings.Builder
 	enc := toml.NewEncoder(&w)
 	enc.SetMarshalJsonNumbers(true)

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -951,7 +951,7 @@ func TestEncoderSetIndentSymbol(t *testing.T) {
 func TestEncoderSetJsonNumber(t *testing.T) {
 	var w strings.Builder
 	enc := toml.NewEncoder(&w)
-	enc.SetJsonNumber(true)
+	enc.SetMarshalJsonNumbers(true)
 	err := enc.Encode(map[string]interface{}{
 		"A": json.Number("1.1"),
 		"B": json.Number("42e-3"),

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -682,31 +682,6 @@ L = 2.2
 `,
 		},
 		{
-			desc: "json numbers",
-			v: struct {
-				A json.Number
-				B json.Number
-				C json.Number
-				D json.Number
-				E json.Number
-				F json.Number
-			}{
-				A: "1.1",
-				B: "42e-3",
-				C: "42",
-				D: "0",
-				E: "0.0",
-				F: "",
-			},
-			expected: `A = 1.1
-B = 0.042
-C = 42
-D = 0
-E = 0.0
-F = 0
-`,
-		},
-		{
 			desc: "comments",
 			v: struct {
 				Table comments `comment:"Before table"`
@@ -969,6 +944,29 @@ func TestEncoderSetIndentSymbol(t *testing.T) {
 	require.NoError(t, err)
 	expected := `[parent]
 >>>hello = 'world'
+`
+	assert.Equal(t, expected, w.String())
+}
+
+func TestEncoderSetJsonNumber(t *testing.T) {
+	var w strings.Builder
+	enc := toml.NewEncoder(&w)
+	enc.SetJsonNumber(true)
+	err := enc.Encode(map[string]interface{}{
+		"A": json.Number("1.1"),
+		"B": json.Number("42e-3"),
+		"C": json.Number("42"),
+		"D": json.Number("0"),
+		"E": json.Number("0.0"),
+		"F": json.Number(""),
+	})
+	require.NoError(t, err)
+	expected := `A = 1.1
+B = 0.042
+C = 42
+D = 0
+E = 0.0
+F = 0
 `
 	assert.Equal(t, expected, w.String())
 }


### PR DESCRIPTION
Adds encoding support for [`json.Number`](https://pkg.go.dev/encoding/json#Number) and fixes https://github.com/pelletier/go-toml/issues/897

On a side note, I am currently porting a codebase that uses https://github.com/BurntSushi/toml and the lack of encoding support for `json.Number` type in go-toml neat library was a blocker.

---

Paste `benchstat` results here
```
✦ ❯ ./ci.sh benchmark -d v2
Executing benchmark for v2 at /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.gbbPAaT5wG
Preparing worktree (checking out 'v2')
HEAD is now at 34765b4 Fix unmarshaling of nested non-exported struct (#917)
/var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.gbbPAaT5wG ~/src/go-toml
PASS
ok      github.com/pelletier/go-toml/v2 0.524s
goos: darwin
goarch: arm64
pkg: github.com/pelletier/go-toml/v2/benchmark
BenchmarkUnmarshalDataset/config-2                    97          11903903 ns/op          88.10 MB/s     5769411 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                   100          11925088 ns/op          87.94 MB/s     5769267 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                   100          11915622 ns/op          88.01 MB/s     5769277 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    99          11900315 ns/op          88.12 MB/s     5769391 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    99          11971822 ns/op          87.60 MB/s     5769346 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                   100          12181822 ns/op          86.09 MB/s     5769320 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                   100          12227300 ns/op          85.77 MB/s     5769267 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                   100          12061128 ns/op          86.95 MB/s     5769357 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                   100          12063997 ns/op          86.93 MB/s     5769406 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                   100          12059835 ns/op          86.96 MB/s     5769332 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45043838 ns/op          48.87 MB/s    80013609 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    26          45198702 ns/op          48.70 MB/s    80013609 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          44814930 ns/op          49.12 MB/s    80013610 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          44953443 ns/op          48.97 MB/s    80013606 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    26          45302455 ns/op          48.59 MB/s    80013612 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45037880 ns/op          48.88 MB/s    80013607 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    26          44884133 ns/op          49.05 MB/s    80013612 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45058027 ns/op          48.86 MB/s    80013608 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45323782 ns/op          48.57 MB/s    80013611 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    26          45093024 ns/op          48.82 MB/s    80013612 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              91          12663785 ns/op          44.07 MB/s    34501828 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              90          13116770 ns/op          42.54 MB/s    34501832 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              91          12798680 ns/op          43.60 MB/s    34501754 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              91          12771673 ns/op          43.69 MB/s    34501898 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              88          13127312 ns/op          42.51 MB/s    34501745 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              88          12969035 ns/op          43.03 MB/s    34501803 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              91          12884934 ns/op          43.31 MB/s    34501748 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              87          12880178 ns/op          43.33 MB/s    34501914 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              85          13174064 ns/op          42.36 MB/s    34501830 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              88          13031836 ns/op          42.82 MB/s    34501887 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  220           5508132 ns/op          80.22 MB/s    12633326 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  216           5550444 ns/op          79.61 MB/s    12633192 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  208           5429029 ns/op          81.39 MB/s    12633339 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  222           5415060 ns/op          81.60 MB/s    12633134 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  220           5417146 ns/op          81.57 MB/s    12633278 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  220           5431102 ns/op          81.36 MB/s    12633779 B/op      54757 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  222           5404494 ns/op          81.76 MB/s    12632923 B/op      54754 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  222           5397776 ns/op          81.86 MB/s    12632811 B/op      54754 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  222           5402685 ns/op          81.79 MB/s    12633137 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  222           5437698 ns/op          81.26 MB/s    12633566 B/op      54757 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57018850 ns/op          47.07 MB/s    21272713 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56443510 ns/op          47.55 MB/s    21272708 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56607523 ns/op          47.41 MB/s    21272716 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56613048 ns/op          47.41 MB/s    21272720 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56461679 ns/op          47.54 MB/s    21272715 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56510048 ns/op          47.50 MB/s    21272710 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56987342 ns/op          47.10 MB/s    21272711 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56552406 ns/op          47.46 MB/s    21272713 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56843088 ns/op          47.22 MB/s    21272720 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56659192 ns/op          47.37 MB/s    21272719 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            101501 ns/op          79.80 MB/s      185113 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            101348 ns/op          79.92 MB/s      185110 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            101601 ns/op          79.72 MB/s      185111 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            101342 ns/op          79.93 MB/s      185107 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            101900 ns/op          79.49 MB/s      185105 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            101281 ns/op          79.98 MB/s      185109 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            101227 ns/op          80.02 MB/s      185110 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103397 ns/op          78.34 MB/s      185118 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            102660 ns/op          78.90 MB/s      185107 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            102328 ns/op          79.16 MB/s      185121 B/op       1305 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3697077               325.0 ns/op        33.85 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3695973               330.6 ns/op        33.27 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3688902               325.9 ns/op        33.76 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3705112               324.0 ns/op        33.95 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3692125               324.2 ns/op        33.93 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3703725               325.0 ns/op        33.84 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3703592               323.8 ns/op        33.97 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3709260               323.6 ns/op        33.99 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3695694               324.6 ns/op        33.88 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3705052               323.9 ns/op        33.96 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2617071               454.8 ns/op        24.19 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2633796               457.0 ns/op        24.07 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2623290               457.2 ns/op        24.06 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2622032               458.0 ns/op        24.02 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2633118               456.5 ns/op        24.09 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2621324               457.5 ns/op        24.04 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2641050               456.1 ns/op        24.12 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2619297               456.8 ns/op        24.08 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2629777               455.4 ns/op        24.15 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2624958               456.1 ns/op        24.12 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          41130             29183 ns/op         179.59 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          41002             29185 ns/op         179.58 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          41238             29131 ns/op         179.91 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          41224             29133 ns/op         179.90 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          41338             29146 ns/op         179.82 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          41221             29092 ns/op         180.15 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          41212             29178 ns/op         179.62 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          41218             29172 ns/op         179.66 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40947             29245 ns/op         179.21 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          41004             29542 ns/op         177.41 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27697             43163 ns/op         121.42 MB/s       37746 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27596             43183 ns/op         121.37 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27771             43180 ns/op         121.38 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27648             43180 ns/op         121.38 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27590             43176 ns/op         121.39 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27776             43212 ns/op         121.28 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27733             43269 ns/op         121.13 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27636             43142 ns/op         121.48 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27720             43237 ns/op         121.22 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27654             43214 ns/op         121.28 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              162596              7305 ns/op          74.75 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              162312              7260 ns/op          75.20 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              163777              7265 ns/op          75.16 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              163282              7261 ns/op          75.19 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              162428              7261 ns/op          75.20 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              162064              7247 ns/op          75.34 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              162523              7276 ns/op          75.04 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              163615              7350 ns/op          74.29 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              160548              7469 ns/op          73.10 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              161103              7353 ns/op          74.25 MB/s        7441 B/op        141 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4492448               264.3 ns/op        45.41 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4613572               264.7 ns/op        45.34 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4595530               262.6 ns/op        45.69 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4612095               265.8 ns/op        45.14 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4556260               263.8 ns/op        45.49 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4620241               260.1 ns/op        46.14 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4616716               259.3 ns/op        46.28 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4592475               259.1 ns/op        46.31 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4607875               259.6 ns/op        46.22 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4634221               260.0 ns/op        46.15 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3364288               355.7 ns/op        33.74 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3361501               356.3 ns/op        33.68 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3370617               356.3 ns/op        33.68 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3373314               356.0 ns/op        33.70 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3364156               356.9 ns/op        33.62 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3364855               356.7 ns/op        33.64 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3367714               357.3 ns/op        33.58 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3365958               356.1 ns/op        33.69 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3364312               356.0 ns/op        33.70 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3360133               363.8 ns/op        32.98 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54135             22101 ns/op          93.07 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54378             21997 ns/op          93.51 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54459             22032 ns/op          93.36 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54476             22058 ns/op          93.26 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54655             22077 ns/op          93.18 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54340             22038 ns/op          93.34 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54517             22041 ns/op          93.33 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54326             22067 ns/op          93.22 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54358             22088 ns/op          93.13 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54349             22028 ns/op          93.38 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41956             28359 ns/op          70.74 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42212             28496 ns/op          70.40 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41997             28555 ns/op          70.25 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42067             28267 ns/op          70.97 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41863             28563 ns/op          70.23 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42160             28559 ns/op          70.24 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41828             28346 ns/op          70.77 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42087             28253 ns/op          71.00 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42099             28362 ns/op          70.73 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42087             28316 ns/op          70.84 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                226717              5318 ns/op          98.35 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                227934              5296 ns/op          98.75 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                226472              5311 ns/op          98.47 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                226528              5278 ns/op          99.09 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                226584              5273 ns/op          99.18 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                227659              5298 ns/op          98.73 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                226174              5303 ns/op          98.62 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                227338              5294 ns/op          98.80 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                226370              5303 ns/op          98.62 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                218978              5254 ns/op          99.54 MB/s        5808 B/op         85 allocs/op
PASS
ok      github.com/pelletier/go-toml/v2/benchmark       224.029s
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-decoder [no test files]
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-encoder [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/cmd/jsontoml    0.555s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomljson    0.189s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomll       0.186s
?       github.com/pelletier/go-toml/v2/cmd/tomltestgen [no test files]
?       github.com/pelletier/go-toml/v2/internal/characters     [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/cli    0.181s
PASS
ok      github.com/pelletier/go-toml/v2/internal/danger 0.187s
PASS
ok      github.com/pelletier/go-toml/v2/internal/imported_tests 0.195s
?       github.com/pelletier/go-toml/v2/internal/testsuite      [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/tracker        0.192s
?       github.com/pelletier/go-toml/v2/ossfuzz [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/unstable        0.194s
~/src/go-toml
Executing benchmark for HEAD at /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.TJYHzgxqxP
/var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.TJYHzgxqxP ~/src/go-toml
PASS
ok      github.com/pelletier/go-toml/v2 0.185s
goos: darwin
goarch: arm64
pkg: github.com/pelletier/go-toml/v2/benchmark
BenchmarkUnmarshalDataset/config-2                    96          12133868 ns/op          86.43 MB/s     5769304 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    99          12142903 ns/op          86.36 MB/s     5769305 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    98          12245551 ns/op          85.64 MB/s     5769362 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    97          12355800 ns/op          84.87 MB/s     5769440 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    98          12375998 ns/op          84.74 MB/s     5769300 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    98          12314799 ns/op          85.16 MB/s     5769306 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    98          12275545 ns/op          85.43 MB/s     5769331 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    99          12167642 ns/op          86.19 MB/s     5769372 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    98          12182803 ns/op          86.08 MB/s     5769328 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    99          12200509 ns/op          85.95 MB/s     5769277 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/canada-2                    24          46354049 ns/op          47.49 MB/s    80013634 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46525597 ns/op          47.32 MB/s    80013611 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45739823 ns/op          48.13 MB/s    80013608 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45929038 ns/op          47.93 MB/s    80013614 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46437823 ns/op          47.40 MB/s    80013610 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45557673 ns/op          48.32 MB/s    80013625 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45878958 ns/op          47.98 MB/s    80013610 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46780493 ns/op          47.06 MB/s    80013608 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46334887 ns/op          47.51 MB/s    80013610 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45823267 ns/op          48.04 MB/s    80013612 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              84          12933381 ns/op          43.15 MB/s    34501941 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              88          12891385 ns/op          43.29 MB/s    34501916 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              88          12911011 ns/op          43.22 MB/s    34501841 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              88          12794069 ns/op          43.62 MB/s    34501896 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              87          12938909 ns/op          43.13 MB/s    34501917 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              86          12863742 ns/op          43.38 MB/s    34501907 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              87          12902833 ns/op          43.25 MB/s    34501906 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              87          13024660 ns/op          42.84 MB/s    34501951 B/op     177995 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              86          13127155 ns/op          42.51 MB/s    34502014 B/op     177995 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              86          13110762 ns/op          42.56 MB/s    34501842 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  213           5498712 ns/op          80.36 MB/s    12633108 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  218           5462576 ns/op          80.89 MB/s    12633403 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  218           5486478 ns/op          80.54 MB/s    12633033 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  217           5520530 ns/op          80.04 MB/s    12633265 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  218           5474689 ns/op          80.71 MB/s    12633144 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  218           5480585 ns/op          80.63 MB/s    12633454 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  217           5465721 ns/op          80.85 MB/s    12633157 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  217           5501835 ns/op          80.32 MB/s    12633339 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  218           5471797 ns/op          80.76 MB/s    12632905 B/op      54754 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  216           5470187 ns/op          80.78 MB/s    12632970 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56629704 ns/op          47.40 MB/s    21272712 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57010125 ns/op          47.08 MB/s    21272712 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56689671 ns/op          47.35 MB/s    21272716 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56669233 ns/op          47.36 MB/s    21272719 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56919910 ns/op          47.15 MB/s    21272714 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56715096 ns/op          47.32 MB/s    21272710 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56648990 ns/op          47.38 MB/s    21272711 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      19          56884836 ns/op          47.18 MB/s    21272705 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56724673 ns/op          47.32 MB/s    21272716 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56982858 ns/op          47.10 MB/s    21272712 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103664 ns/op          78.14 MB/s      185115 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103647 ns/op          78.15 MB/s      185100 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103342 ns/op          78.38 MB/s      185115 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            104426 ns/op          77.57 MB/s      185116 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            105346 ns/op          76.89 MB/s      185113 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            104432 ns/op          77.56 MB/s      185113 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103927 ns/op          77.94 MB/s      185114 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103459 ns/op          78.29 MB/s      185110 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103430 ns/op          78.31 MB/s      185120 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103593 ns/op          78.19 MB/s      185106 B/op       1305 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3670866               326.2 ns/op        33.72 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3685221               325.7 ns/op        33.77 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3684562               326.0 ns/op        33.75 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3682892               325.9 ns/op        33.76 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3678157               326.0 ns/op        33.74 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3688754               325.2 ns/op        33.83 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3694297               324.9 ns/op        33.86 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3694838               324.7 ns/op        33.88 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3699152               324.7 ns/op        33.87 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3698080               324.4 ns/op        33.91 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2631748               457.1 ns/op        24.06 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2634981               455.3 ns/op        24.16 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2630812               456.8 ns/op        24.08 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2611082               461.5 ns/op        23.83 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2608647               456.0 ns/op        24.12 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2634579               455.2 ns/op        24.16 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2631942               457.8 ns/op        24.03 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2635190               456.4 ns/op        24.10 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2613262               457.9 ns/op        24.02 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2628867               458.7 ns/op        23.98 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40704             29430 ns/op         178.08 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40844             29471 ns/op         177.84 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40785             29440 ns/op         178.02 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40846             29421 ns/op         178.14 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40714             29474 ns/op         177.82 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40646             29830 ns/op         175.70 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          39896             29992 ns/op         174.75 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40712             29491 ns/op         177.72 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40266             29567 ns/op         177.26 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40812             29584 ns/op         177.16 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27534             43703 ns/op         119.92 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27259             43902 ns/op         119.38 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27340             43885 ns/op         119.42 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27019             43811 ns/op         119.63 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27610             43549 ns/op         120.35 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27520             43529 ns/op         120.40 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27561             43569 ns/op         120.29 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27607             43535 ns/op         120.39 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27561             43530 ns/op         120.40 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27519             43581 ns/op         120.26 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              162886              7314 ns/op          74.65 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              164526              7310 ns/op          74.69 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              164246              7308 ns/op          74.71 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              164496              7300 ns/op          74.79 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              163742              7306 ns/op          74.74 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              164480              7318 ns/op          74.61 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              155737              7418 ns/op          73.61 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              162037              7375 ns/op          74.03 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              162555              7282 ns/op          74.98 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              164997              7301 ns/op          74.79 MB/s        7441 B/op        141 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4644256               260.2 ns/op        46.13 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4635860               261.4 ns/op        45.91 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4592764               259.2 ns/op        46.30 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4531926               262.1 ns/op        45.79 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4606725               264.0 ns/op        45.46 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4641464               259.7 ns/op        46.20 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4626997               259.0 ns/op        46.33 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4635244               259.3 ns/op        46.27 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4627328               258.6 ns/op        46.40 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4633819               258.6 ns/op        46.40 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3327164               357.3 ns/op        33.58 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3347266               357.5 ns/op        33.57 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3358297               358.1 ns/op        33.51 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3353581               357.7 ns/op        33.55 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3351692               357.6 ns/op        33.56 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3350385               358.4 ns/op        33.48 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3360358               357.9 ns/op        33.53 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3355506               357.3 ns/op        33.58 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3350373               358.5 ns/op        33.47 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3357214               357.7 ns/op        33.55 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54388             21880 ns/op          94.01 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54474             22328 ns/op          92.13 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53613             22196 ns/op          92.68 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53611             22120 ns/op          92.99 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54674             21951 ns/op          93.71 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54492             21946 ns/op          93.73 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54580             21888 ns/op          93.98 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54674             21947 ns/op          93.73 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54638             21903 ns/op          93.91 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54567             21891 ns/op          93.97 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42310             28425 ns/op          70.57 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42258             28396 ns/op          70.64 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42236             28439 ns/op          70.54 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42018             28570 ns/op          70.21 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               40818             28725 ns/op          69.83 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41812             28419 ns/op          70.59 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42207             28369 ns/op          70.71 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42294             28294 ns/op          70.90 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42217             28388 ns/op          70.66 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42284             28328 ns/op          70.81 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                226003              5297 ns/op          98.74 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                225463              5312 ns/op          98.45 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                223057              5371 ns/op          97.38 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                224347              5307 ns/op          98.55 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                227582              5313 ns/op          98.43 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                223988              5304 ns/op          98.60 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                226278              5312 ns/op          98.45 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                226306              5297 ns/op          98.74 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                227433              5300 ns/op          98.67 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                224215              5301 ns/op          98.67 MB/s        5808 B/op         85 allocs/op
PASS
ok      github.com/pelletier/go-toml/v2/benchmark       224.197s
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-decoder [no test files]
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-encoder [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/cmd/jsontoml    0.513s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomljson    0.210s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomll       0.204s
?       github.com/pelletier/go-toml/v2/cmd/tomltestgen [no test files]
?       github.com/pelletier/go-toml/v2/internal/characters     [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/cli    0.195s
PASS
ok      github.com/pelletier/go-toml/v2/internal/danger 0.188s
PASS
ok      github.com/pelletier/go-toml/v2/internal/imported_tests 0.186s
?       github.com/pelletier/go-toml/v2/internal/testsuite      [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/tracker        0.199s
?       github.com/pelletier/go-toml/v2/ossfuzz [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/unstable        0.191s
~/src/go-toml
goos: darwin
goarch: arm64
pkg: github.com/pelletier/go-toml/v2/benchmark
                                  │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.mlCwj5PYjK-v2 │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.BMJVXORRKf-HEAD │
                                  │                               sec/op                               │                    sec/op                      vs base               │
UnmarshalDataset/config-2                                                                  12.02m ± 1%                                     12.22m ± 1%  +1.72% (p=0.001 n=10)
UnmarshalDataset/canada-2                                                                  45.05m ± 1%                                     46.13m ± 1%  +2.40% (p=0.000 n=10)
UnmarshalDataset/citm_catalog-2                                                            12.93m ± 2%                                     12.92m ± 1%       ~ (p=0.971 n=10)
UnmarshalDataset/twitter-2                                                                 5.423m ± 2%                                     5.478m ± 0%  +1.01% (p=0.019 n=10)
UnmarshalDataset/code-2                                                                    56.61m ± 1%                                     56.72m ± 0%       ~ (p=0.089 n=10)
UnmarshalDataset/example-2                                                                 101.6µ ± 1%                                     103.7µ ± 1%  +2.07% (p=0.000 n=10)
Unmarshal/SimpleDocument/struct-2                                                          324.4n ± 0%                                     325.4n ± 0%       ~ (p=0.066 n=10)
Unmarshal/SimpleDocument/map-2                                                             456.6n ± 0%                                     456.9n ± 0%       ~ (p=0.541 n=10)
Unmarshal/ReferenceFile/struct-2                                                           29.18µ ± 0%                                     29.48µ ± 1%  +1.05% (p=0.000 n=10)
Unmarshal/ReferenceFile/map-2                                                              43.18µ ± 0%                                     43.58µ ± 1%  +0.91% (p=0.000 n=10)
Unmarshal/HugoFrontMatter-2                                                                7.271µ ± 1%                                     7.309µ ± 1%       ~ (p=0.119 n=10)
Marshal/SimpleDocument/struct-2                                                            261.4n ± 1%                                     259.5n ± 1%       ~ (p=0.093 n=10)
Marshal/SimpleDocument/map-2                                                               356.3n ± 0%                                     357.7n ± 0%  +0.39% (p=0.002 n=10)
Marshal/ReferenceFile/struct-2                                                             22.05µ ± 0%                                     21.95µ ± 1%       ~ (p=0.143 n=10)
Marshal/ReferenceFile/map-2                                                                28.36µ ± 1%                                     28.41µ ± 1%       ~ (p=0.436 n=10)
Marshal/HugoFrontMatter-2                                                                  5.297µ ± 0%                                     5.306µ ± 0%       ~ (p=0.060 n=10)
geomean                                                                                    64.57µ                                          64.96µ       +0.61%

                                  │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.mlCwj5PYjK-v2 │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.BMJVXORRKf-HEAD │
                                  │                                B/s                                 │                      B/s                       vs base               │
UnmarshalDataset/config-2                                                                 83.24Mi ± 1%                                    81.82Mi ± 1%  -1.70% (p=0.001 n=10)
UnmarshalDataset/canada-2                                                                 46.60Mi ± 1%                                    45.51Mi ± 1%  -2.34% (p=0.000 n=10)
UnmarshalDataset/citm_catalog-2                                                           41.17Mi ± 2%                                    41.18Mi ± 1%       ~ (p=0.929 n=10)
UnmarshalDataset/twitter-2                                                                77.71Mi ± 2%                                    76.93Mi ± 0%  -0.99% (p=0.019 n=10)
UnmarshalDataset/code-2                                                                   45.21Mi ± 1%                                    45.13Mi ± 0%       ~ (p=0.078 n=10)
UnmarshalDataset/example-2                                                                76.07Mi ± 1%                                    74.52Mi ± 1%  -2.02% (p=0.000 n=10)
Unmarshal/SimpleDocument/struct-2                                                         32.33Mi ± 0%                                    32.23Mi ± 0%       ~ (p=0.072 n=10)
Unmarshal/SimpleDocument/map-2                                                            22.97Mi ± 0%                                    22.95Mi ± 0%       ~ (p=0.446 n=10)
Unmarshal/ReferenceFile/struct-2                                                          171.3Mi ± 0%                                    169.5Mi ± 1%  -1.04% (p=0.000 n=10)
Unmarshal/ReferenceFile/map-2                                                             115.8Mi ± 0%                                    114.7Mi ± 1%  -0.91% (p=0.000 n=10)
Unmarshal/HugoFrontMatter-2                                                               71.62Mi ± 1%                                    71.24Mi ± 1%       ~ (p=0.118 n=10)
Marshal/SimpleDocument/struct-2                                                           43.79Mi ± 1%                                    44.09Mi ± 1%       ~ (p=0.102 n=10)
Marshal/SimpleDocument/map-2                                                              32.12Mi ± 0%                                    32.00Mi ± 0%  -0.39% (p=0.002 n=10)
Marshal/ReferenceFile/struct-2                                                            88.97Mi ± 0%                                    89.39Mi ± 1%       ~ (p=0.138 n=10)
Marshal/ReferenceFile/map-2                                                               67.46Mi ± 1%                                    67.34Mi ± 1%       ~ (p=0.436 n=10)
Marshal/HugoFrontMatter-2                                                                 94.17Mi ± 0%                                    94.01Mi ± 0%       ~ (p=0.060 n=10)
geomean                                                                                   60.90Mi                                         60.53Mi       -0.61%

                                  │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.mlCwj5PYjK-v2 │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.BMJVXORRKf-HEAD │
                                  │                                B/op                                │                    B/op                      vs base                 │
UnmarshalDataset/config-2                                                                 5.502Mi ± 0%                                  5.502Mi ± 0%       ~ (p=0.808 n=10)
UnmarshalDataset/canada-2                                                                 76.31Mi ± 0%                                  76.31Mi ± 0%       ~ (p=0.224 n=10)
UnmarshalDataset/citm_catalog-2                                                           32.90Mi ± 0%                                  32.90Mi ± 0%  +0.00% (p=0.002 n=10)
UnmarshalDataset/twitter-2                                                                12.05Mi ± 0%                                  12.05Mi ± 0%       ~ (p=0.645 n=10)
UnmarshalDataset/code-2                                                                   20.29Mi ± 0%                                  20.29Mi ± 0%       ~ (p=0.401 n=10)
UnmarshalDataset/example-2                                                                180.8Ki ± 0%                                  180.8Ki ± 0%       ~ (p=0.382 n=10)
Unmarshal/SimpleDocument/struct-2                                                           805.0 ± 0%                                    805.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map-2                                                            1.106Ki ± 0%                                  1.106Ki ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct-2                                                          19.99Ki ± 0%                                  19.99Ki ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map-2                                                             36.86Ki ± 0%                                  36.86Ki ± 0%       ~ (p=1.000 n=10)
Unmarshal/HugoFrontMatter-2                                                               7.267Ki ± 0%                                  7.267Ki ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct-2                                                             240.0 ± 0%                                    240.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map-2                                                                272.0 ± 0%                                    272.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct-2                                                            27.64Ki ± 0%                                  27.64Ki ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map-2                                                               27.28Ki ± 0%                                  27.28Ki ± 0%       ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter-2                                                                 5.672Ki ± 0%                                  5.672Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                   74.24Ki                                       74.24Ki       +0.00%
¹ all samples are equal

                                  │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.mlCwj5PYjK-v2 │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.BMJVXORRKf-HEAD │
                                  │                             allocs/op                              │                  allocs/op                   vs base                 │
UnmarshalDataset/config-2                                                                  219.2k ± 0%                                   219.2k ± 0%       ~ (p=1.000 n=10) ¹
UnmarshalDataset/canada-2                                                                  670.4k ± 0%                                   670.4k ± 0%       ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog-2                                                            178.0k ± 0%                                   178.0k ± 0%       ~ (p=0.474 n=10)
UnmarshalDataset/twitter-2                                                                 54.76k ± 0%                                   54.76k ± 0%       ~ (p=0.744 n=10)
UnmarshalDataset/code-2                                                                    1.001M ± 0%                                   1.001M ± 0%       ~ (p=1.000 n=10) ¹
UnmarshalDataset/example-2                                                                 1.305k ± 0%                                   1.305k ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct-2                                                           9.000 ± 0%                                    9.000 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map-2                                                              13.00 ± 0%                                    13.00 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct-2                                                            160.0 ± 0%                                    160.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map-2                                                               619.0 ± 0%                                    619.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter-2                                                                 141.0 ± 0%                                    141.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct-2                                                             8.000 ± 0%                                    8.000 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map-2                                                                9.000 ± 0%                                    9.000 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct-2                                                              317.0 ± 0%                                    317.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map-2                                                                 429.0 ± 0%                                    429.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter-2                                                                   85.00 ± 0%                                    85.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                    1.060k                                        1.060k       -0.00%
¹ all samples are equal

```