### PR TITLE
Encode: support pointers to embedded structs

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -707,6 +707,8 @@ func walkStruct(ctx encoderCtx, t *table, v reflect.Value) {
 			if fieldType.Anonymous {
 				if fieldType.Type.Kind() == reflect.Struct {
 					walkStruct(ctx, t, f)
+				} else if fieldType.Type.Kind() == reflect.Pointer && !f.IsNil() && f.Elem().Kind() == reflect.Struct {
+					walkStruct(ctx, t, f.Elem())
 				}
 				continue
 			} else {

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1304,6 +1304,38 @@ value = ''
 	require.Equal(t, expected, string(result))
 }
 
+func TestMarshalNestedAnonymousStructs_PointerEmbedded(t *testing.T) {
+	type Embedded struct {
+		Value   string  `toml:"value" json:"value"`
+		Omitted string  `toml:"omitted,omitempty"`
+		Ptr     *string `toml:"ptr"`
+	}
+
+	type Named struct {
+		Value string `toml:"value" json:"value"`
+	}
+
+	type Doc struct {
+		*Embedded
+		*Named    `toml:"named" json:"named"`
+		Anonymous struct {
+			*Embedded
+			Value *string `toml:"value" json:"value"`
+		} `toml:"anonymous,omitempty" json:"anonymous,omitempty"`
+	}
+
+	doc := &Doc{
+		Embedded: &Embedded{Value: "foo"},
+	}
+
+	expected := `value = 'foo'
+`
+
+	result, err := toml.Marshal(doc)
+	require.NoError(t, err)
+	require.Equal(t, expected, string(result))
+}
+
 func TestLocalTime(t *testing.T) {
 	v := map[string]toml.LocalTime{
 		"a": {


### PR DESCRIPTION
Current encoder implementation ignores embedded "pointer structs" like `*Base` in:

```go
type Base struct {
  Value string
}

type Upper struct {
  *Base
  Other bool
}
```

This PR adds support for encoding such types.

---

Paste `benchstat` results here
```
❯ ./ci.sh benchmark -d v2
Executing benchmark for v2 at /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.lz9CXrl1y1
Preparing worktree (checking out 'v2')
HEAD is now at 34765b4 Fix unmarshaling of nested non-exported struct (#917)
/var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.lz9CXrl1y1 ~/src/go-toml
PASS
ok      github.com/pelletier/go-toml/v2 0.528s
goos: darwin
goarch: arm64
pkg: github.com/pelletier/go-toml/v2/benchmark
BenchmarkUnmarshalDataset/config-2                    97          11982439 ns/op          87.52 MB/s     5769286 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    97          12272337 ns/op          85.45 MB/s     5769337 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    99          12510009 ns/op          83.83 MB/s     5769288 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    94          12470572 ns/op          84.09 MB/s     5769284 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    98          12163871 ns/op          86.21 MB/s     5769284 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    98          12450381 ns/op          84.23 MB/s     5769335 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    99          12229840 ns/op          85.75 MB/s     5769317 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    96          12009361 ns/op          87.32 MB/s     5769323 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    99          12095854 ns/op          86.70 MB/s     5769384 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    94          12245606 ns/op          85.64 MB/s     5769363 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/canada-2                    24          45145378 ns/op          48.76 MB/s    80013612 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    26          45888026 ns/op          47.97 MB/s    80013621 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45352332 ns/op          48.54 MB/s    80013616 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46102220 ns/op          47.75 MB/s    80013614 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45658970 ns/op          48.21 MB/s    80013614 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45740437 ns/op          48.13 MB/s    80013609 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45735265 ns/op          48.13 MB/s    80013613 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    24          45757408 ns/op          48.11 MB/s    80013610 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45353103 ns/op          48.54 MB/s    80013614 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          45812575 ns/op          48.05 MB/s    80013610 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              91          12811796 ns/op          43.56 MB/s    34501873 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              86          12939999 ns/op          43.12 MB/s    34501890 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              82          12969068 ns/op          43.03 MB/s    34501871 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              91          12733041 ns/op          43.83 MB/s    34501812 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              88          12730549 ns/op          43.83 MB/s    34502067 B/op     177995 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              87          12749193 ns/op          43.77 MB/s    34501841 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              90          12758428 ns/op          43.74 MB/s    34501937 B/op     177995 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              88          12767396 ns/op          43.71 MB/s    34501914 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              86          12788570 ns/op          43.64 MB/s    34501790 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              87          12799251 ns/op          43.60 MB/s    34501928 B/op     177995 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  223           5365354 ns/op          82.36 MB/s    12633092 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  222           5411353 ns/op          81.66 MB/s    12633504 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  222           5480490 ns/op          80.63 MB/s    12633484 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  211           5420278 ns/op          81.52 MB/s    12633566 B/op      54757 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  220           5367875 ns/op          82.32 MB/s    12632965 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  220           5380087 ns/op          82.13 MB/s    12633223 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  220           5398300 ns/op          81.86 MB/s    12632869 B/op      54754 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  220           5371905 ns/op          82.26 MB/s    12633350 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  220           5403835 ns/op          81.77 MB/s    12632980 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  220           5416546 ns/op          81.58 MB/s    12633022 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57112783 ns/op          47.00 MB/s    21272714 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56624383 ns/op          47.40 MB/s    21272710 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57701471 ns/op          46.52 MB/s    21272714 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57213358 ns/op          46.91 MB/s    21272716 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56788115 ns/op          47.26 MB/s    21272701 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          59589590 ns/op          45.04 MB/s    21272714 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      19          58964493 ns/op          45.52 MB/s    21272711 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57316360 ns/op          46.83 MB/s    21272712 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          58259781 ns/op          46.07 MB/s    21272716 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      19          57862721 ns/op          46.39 MB/s    21272706 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103696 ns/op          78.11 MB/s      185106 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            104333 ns/op          77.64 MB/s      185106 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            106048 ns/op          76.38 MB/s      185108 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            104168 ns/op          77.76 MB/s      185103 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            101861 ns/op          79.52 MB/s      185116 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            102526 ns/op          79.00 MB/s      185113 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            102820 ns/op          78.78 MB/s      185113 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            102209 ns/op          79.25 MB/s      185112 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            101721 ns/op          79.63 MB/s      185099 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            102418 ns/op          79.09 MB/s      185107 B/op       1305 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3667077               323.8 ns/op        33.97 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3681438               328.3 ns/op        33.50 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3639698               337.2 ns/op        32.62 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3341606               336.9 ns/op        32.66 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3591708               328.9 ns/op        33.44 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3538990               329.2 ns/op        33.41 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3683072               329.2 ns/op        33.42 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3687992               328.7 ns/op        33.47 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3685906               328.4 ns/op        33.49 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3689648               324.2 ns/op        33.93 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2603976               455.7 ns/op        24.14 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2613799               455.5 ns/op        24.15 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2514778               456.9 ns/op        24.08 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2625978               466.8 ns/op        23.57 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2469021               471.5 ns/op        23.33 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2461879               465.9 ns/op        23.61 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2549766               473.3 ns/op        23.24 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2558547               468.7 ns/op        23.47 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2586669               462.7 ns/op        23.77 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2574088               478.6 ns/op        22.98 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40346             29712 ns/op         176.39 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          39975             30041 ns/op         174.46 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40341             29435 ns/op         178.05 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40458             29886 ns/op         175.37 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40576             29444 ns/op         178.00 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          38845             30723 ns/op         170.59 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          38642             30299 ns/op         172.98 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          39476             29672 ns/op         176.63 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40502             29811 ns/op         175.81 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          39177             29680 ns/op         176.59 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27460             43903 ns/op         119.38 MB/s       37746 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27312             43608 ns/op         120.18 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27424             43713 ns/op         119.90 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27483             43487 ns/op         120.52 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             26817             44132 ns/op         118.76 MB/s       37746 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27376             44046 ns/op         118.99 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             26563             43518 ns/op         120.43 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27436             43481 ns/op         120.54 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27466             43872 ns/op         119.46 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27460             43639 ns/op         120.10 MB/s       37746 B/op        619 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              160964              7291 ns/op          74.88 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              160708              7329 ns/op          74.50 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              160305              7270 ns/op          75.10 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              159598              7277 ns/op          75.03 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              158874              7350 ns/op          74.28 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              161134              7505 ns/op          72.75 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              161014              7264 ns/op          75.16 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              159738              7402 ns/op          73.77 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              159980              7266 ns/op          75.15 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              160560              7279 ns/op          75.01 MB/s        7441 B/op        141 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4571703               260.0 ns/op        46.16 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4568283               259.7 ns/op        46.21 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4530682               260.1 ns/op        46.13 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4569643               261.1 ns/op        45.96 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4552030               263.1 ns/op        45.60 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4260003               267.8 ns/op        44.80 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4517004               264.7 ns/op        45.33 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4471758               262.4 ns/op        45.72 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4586739               262.2 ns/op        45.77 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4525846               267.8 ns/op        44.81 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3203388               369.1 ns/op        32.51 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3289986               361.4 ns/op        33.21 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3317054               360.9 ns/op        33.25 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3248652               360.5 ns/op        33.28 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3156919               362.8 ns/op        33.08 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3331431               360.7 ns/op        33.27 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3334716               361.3 ns/op        33.22 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3205110               364.4 ns/op        32.93 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3319612               361.7 ns/op        33.18 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3234938               358.3 ns/op        33.50 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53883             22130 ns/op          92.95 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53301             22251 ns/op          92.45 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54150             22521 ns/op          91.34 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            52431             22021 ns/op          93.41 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54318             21938 ns/op          93.76 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54172             21984 ns/op          93.57 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54258             22439 ns/op          91.67 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54174             22014 ns/op          93.44 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53950             22008 ns/op          93.47 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54164             21938 ns/op          93.76 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42097             28614 ns/op          70.11 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41721             28340 ns/op          70.78 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42102             28335 ns/op          70.80 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42100             28610 ns/op          70.12 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41784             28314 ns/op          70.85 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               40956             29226 ns/op          68.64 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41644             28792 ns/op          69.67 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               40312             28763 ns/op          69.74 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               42093             29056 ns/op          69.04 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41280             29110 ns/op          68.91 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                220893              5294 ns/op          98.80 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                223581              5302 ns/op          98.64 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                222638              5323 ns/op          98.25 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                218929              5314 ns/op          98.42 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                221955              5340 ns/op          97.95 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                221324              5309 ns/op          98.51 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                223068              5348 ns/op          97.80 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                220952              5319 ns/op          98.32 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                222098              5461 ns/op          95.76 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                210892              5324 ns/op          98.23 MB/s        5808 B/op         85 allocs/op
PASS
ok      github.com/pelletier/go-toml/v2/benchmark       223.358s
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-decoder [no test files]
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-encoder [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/cmd/jsontoml    0.507s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomljson    0.196s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomll       0.188s
?       github.com/pelletier/go-toml/v2/cmd/tomltestgen [no test files]
?       github.com/pelletier/go-toml/v2/internal/characters     [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/cli    0.191s
PASS
ok      github.com/pelletier/go-toml/v2/internal/danger 0.216s
PASS
ok      github.com/pelletier/go-toml/v2/internal/imported_tests 0.191s
?       github.com/pelletier/go-toml/v2/internal/testsuite      [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/tracker        0.189s
?       github.com/pelletier/go-toml/v2/ossfuzz [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/unstable        0.192s
~/src/go-toml
Executing benchmark for HEAD at /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.XCjFm6fgqS
/var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.XCjFm6fgqS ~/src/go-toml
PASS
ok      github.com/pelletier/go-toml/v2 0.181s
goos: darwin
goarch: arm64
pkg: github.com/pelletier/go-toml/v2/benchmark
BenchmarkUnmarshalDataset/config-2                    94          12215079 ns/op          85.85 MB/s     5769336 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    98          12233065 ns/op          85.73 MB/s     5769268 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    93          12518059 ns/op          83.77 MB/s     5769247 B/op     219176 allocs/op
BenchmarkUnmarshalDataset/config-2                    96          12290872 ns/op          85.32 MB/s     5769262 B/op     219176 allocs/op
BenchmarkUnmarshalDataset/config-2                    94          12505260 ns/op          83.86 MB/s     5769321 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    94          12454053 ns/op          84.20 MB/s     5769295 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2               92       12486758 ns/op          83.98 MB/s     5769278 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    98          12251778 ns/op          85.59 MB/s     5769339 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    93          12475004 ns/op          84.06 MB/s     5769333 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/config-2                    97          12579150 ns/op          83.37 MB/s     5769272 B/op     219177 allocs/op
BenchmarkUnmarshalDataset/canada-2                    24          46321021 ns/op          47.52 MB/s    80013611 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46709545 ns/op          47.13 MB/s    80013612 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          47516655 ns/op          46.33 MB/s    80013611 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46442672 ns/op          47.40 MB/s    80013611 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46691263 ns/op          47.15 MB/s    80013608 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46615993 ns/op          47.22 MB/s    80013610 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          47123072 ns/op          46.72 MB/s    80013609 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46198980 ns/op          47.65 MB/s    80013621 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46299112 ns/op          47.55 MB/s    80013613 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/canada-2                    25          46930393 ns/op          46.91 MB/s    80013612 B/op     670398 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              88          13048812 ns/op          42.77 MB/s    34501820 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              85          12849197 ns/op          43.43 MB/s    34501577 B/op     177993 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              85          12946564 ns/op          43.10 MB/s    34501861 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              87          13251194 ns/op          42.11 MB/s    34501792 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              81          12869434 ns/op          43.36 MB/s    34501731 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              87          13449014 ns/op          41.49 MB/s    34501795 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              86          13202654 ns/op          42.27 MB/s    34501943 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              85          13583121 ns/op          41.08 MB/s    34501843 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              85          12964994 ns/op          43.04 MB/s    34501817 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              87          13051081 ns/op          42.76 MB/s    34501898 B/op     177994 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  214           5665594 ns/op          77.99 MB/s    12632688 B/op      54754 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  211           5570707 ns/op          79.32 MB/s    12633186 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  216           5618243 ns/op          78.65 MB/s    12633156 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  212           5626446 ns/op          78.54 MB/s    12633373 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  208           5701066 ns/op          77.51 MB/s    12632942 B/op      54754 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  212           5664212 ns/op          78.01 MB/s    12633249 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  211           5586823 ns/op          79.09 MB/s    12633450 B/op      54756 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  206           5566278 ns/op          79.39 MB/s    12633555 B/op      54757 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  216           5602212 ns/op          78.88 MB/s    12633080 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/twitter-2                  216           5620079 ns/op          78.63 MB/s    12633021 B/op      54755 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57496419 ns/op          46.68 MB/s    21272713 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57389373 ns/op          46.77 MB/s    21272715 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57419865 ns/op          46.74 MB/s    21272716 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          58112221 ns/op          46.19 MB/s    21272712 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57575810 ns/op          46.62 MB/s    21272724 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56975844 ns/op          47.11 MB/s    21272716 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56976646 ns/op          47.11 MB/s    21272710 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          56950998 ns/op          47.13 MB/s    21272708 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57360048 ns/op          46.79 MB/s    21272716 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/code-2                      20          57021940 ns/op          47.07 MB/s    21272711 B/op    1000531 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103857 ns/op          77.99 MB/s      185099 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103604 ns/op          78.18 MB/s      185107 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103216 ns/op          78.48 MB/s      185117 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103577 ns/op          78.20 MB/s      185115 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103329 ns/op          78.39 MB/s      185113 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103575 ns/op          78.20 MB/s      185111 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103847 ns/op          78.00 MB/s      185102 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103936 ns/op          77.93 MB/s      185113 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103587 ns/op          78.20 MB/s      185123 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                10000            103273 ns/op          78.43 MB/s      185113 B/op       1305 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3614857               326.7 ns/op        33.67 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3648441               329.0 ns/op        33.43 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3646920               339.9 ns/op        32.36 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3597604               333.4 ns/op        32.99 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3615390               333.6 ns/op        32.98 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3619126               334.7 ns/op        32.86 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3602652               330.8 ns/op        33.25 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3610009               331.5 ns/op        33.18 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3614127               332.1 ns/op        33.12 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       3608484               329.8 ns/op        33.35 MB/s         805 B/op          9 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2571640               460.6 ns/op        23.88 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2594323               471.6 ns/op        23.33 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2600216               466.1 ns/op        23.60 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2571936               464.1 ns/op        23.70 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2589841               479.5 ns/op        22.94 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2545858               460.9 ns/op        23.86 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2513960               467.8 ns/op        23.51 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2540647               470.8 ns/op        23.36 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2505975               464.3 ns/op        23.69 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          2563617               461.9 ns/op        23.82 MB/s        1133 B/op         13 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          39271             30515 ns/op         171.75 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          38115             29933 ns/op         175.09 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          39027             30216 ns/op         173.45 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          39944             29624 ns/op         176.91 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40610             29943 ns/op         175.03 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40425             29472 ns/op         177.83 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          39306             30076 ns/op         174.26 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40052             30267 ns/op         173.16 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          39130             29946 ns/op         175.01 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          40188             30029 ns/op         174.53 MB/s       20466 B/op        160 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27208             44154 ns/op         118.70 MB/s       37746 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             26725             46069 ns/op         113.76 MB/s       37746 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27424             43567 ns/op         120.30 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27140             43842 ns/op         119.54 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27279             44445 ns/op         117.92 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27292             43576 ns/op         120.27 MB/s       37746 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27385             43864 ns/op         119.48 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27477             43738 ns/op         119.83 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             26985             43561 ns/op         120.31 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             27564             43512 ns/op         120.45 MB/s       37747 B/op        619 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              160162              7326 ns/op          74.53 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              161799              7287 ns/op          74.93 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              161838              7283 ns/op          74.97 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              160239              7373 ns/op          74.06 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              160833              7362 ns/op          74.17 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              158440              7698 ns/op          70.93 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              160459              7486 ns/op          72.93 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              146665              7448 ns/op          73.30 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              159679              7284 ns/op          74.96 MB/s        7441 B/op        141 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2              161494              7314 ns/op          74.65 MB/s        7441 B/op        141 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4519734               270.3 ns/op        44.40 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4372382               273.7 ns/op        43.84 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4510404               260.9 ns/op        46.00 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4534845               260.7 ns/op        46.04 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4552627               268.6 ns/op        44.67 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4579776               261.4 ns/op        45.90 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4563357               261.0 ns/op        45.98 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4545978               261.3 ns/op        45.93 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4579154               261.9 ns/op        45.82 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         4505708               260.8 ns/op        46.01 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3335122               356.7 ns/op        33.64 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3246798               362.2 ns/op        33.13 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3185392               358.9 ns/op        33.43 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3293178               359.7 ns/op        33.37 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3292360               364.7 ns/op        32.91 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3335294               363.8 ns/op        32.98 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3336774               359.6 ns/op        33.37 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3342489               358.8 ns/op        33.45 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3334956               357.1 ns/op        33.60 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            3351116               356.7 ns/op        33.65 MB/s         272 B/op          9 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53586             22063 ns/op          93.23 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            54171             22070 ns/op          93.20 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53832             22180 ns/op          92.74 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53809             22052 ns/op          93.28 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53667             22504 ns/op          91.40 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            52560             22171 ns/op          92.78 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53991             22226 ns/op          92.55 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53252             22477 ns/op          91.52 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53481             22195 ns/op          92.68 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            53658             22471 ns/op          91.54 MB/s       28304 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               40887             29146 ns/op          68.83 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               40678             28639 ns/op          70.04 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41655             28722 ns/op          69.84 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41545             28490 ns/op          70.41 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41911             28542 ns/op          70.28 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41539             28532 ns/op          70.31 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41890             28580 ns/op          70.19 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41653             28571 ns/op          70.21 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41754             28398 ns/op          70.64 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               41647             28457 ns/op          70.49 MB/s       27936 B/op        429 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                221420              5319 ns/op          98.33 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                220926              5343 ns/op          97.88 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                218064              5326 ns/op          98.20 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                217682              5334 ns/op          98.05 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                221473              5321 ns/op          98.29 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                219225              5340 ns/op          97.93 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                217948              5343 ns/op          97.89 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                219408              5324 ns/op          98.24 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                217279              5285 ns/op          98.97 MB/s        5808 B/op         85 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                218382              5346 ns/op          97.83 MB/s        5808 B/op         85 allocs/op
PASS
ok      github.com/pelletier/go-toml/v2/benchmark       223.994s
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-decoder [no test files]
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-encoder [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/cmd/jsontoml    0.509s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomljson    0.194s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomll       0.191s
?       github.com/pelletier/go-toml/v2/cmd/tomltestgen [no test files]
?       github.com/pelletier/go-toml/v2/internal/characters     [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/cli    0.197s
PASS
ok      github.com/pelletier/go-toml/v2/internal/danger 0.200s
PASS
ok      github.com/pelletier/go-toml/v2/internal/imported_tests 0.186s
?       github.com/pelletier/go-toml/v2/internal/testsuite      [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/tracker        0.189s
?       github.com/pelletier/go-toml/v2/ossfuzz [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/unstable        0.191s
~/src/go-toml
goos: darwin
goarch: arm64
pkg: github.com/pelletier/go-toml/v2/benchmark
                                  │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.PkmcYdvwSD-v2 │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.2sH1NCEcxF-HEAD │
                                  │                               sec/op                               │                    sec/op                      vs base               │
UnmarshalDataset/config-2                                                                  12.24m ± 2%                                     12.46m ± 2%  +1.85% (p=0.043 n=10)
UnmarshalDataset/canada-2                                                                  45.74m ± 1%                                     46.65m ± 1%  +2.00% (p=0.000 n=10)
UnmarshalDataset/citm_catalog-2                                                            12.78m ± 1%                                     13.05m ± 3%  +2.13% (p=0.000 n=10)
UnmarshalDataset/twitter-2                                                                 5.401m ± 1%                                     5.619m ± 1%  +4.04% (p=0.000 n=10)
UnmarshalDataset/code-2                                                                    57.51m ± 3%                                     57.37m ± 1%       ~ (p=0.481 n=10)
UnmarshalDataset/example-2                                                                 102.7µ ± 2%                                     103.6µ ± 0%       ~ (p=0.353 n=10)
Unmarshal/SimpleDocument/struct-2                                                          328.8n ± 2%                                     331.8n ± 1%       ~ (p=0.072 n=10)
Unmarshal/SimpleDocument/map-2                                                             466.3n ± 2%                                     465.2n ± 1%       ~ (p=0.853 n=10)
Unmarshal/ReferenceFile/struct-2                                                           29.76µ ± 2%                                     29.99µ ± 1%       ~ (p=0.280 n=10)
Unmarshal/ReferenceFile/map-2                                                              43.68µ ± 1%                                     43.79µ ± 1%       ~ (p=0.529 n=10)
Unmarshal/HugoFrontMatter-2                                                                7.285µ ± 2%                                     7.344µ ± 2%       ~ (p=0.123 n=10)
Marshal/SimpleDocument/struct-2                                                            262.3n ± 2%                                     261.4n ± 3%       ~ (p=0.780 n=10)
Marshal/SimpleDocument/map-2                                                               361.4n ± 1%                                     359.2n ± 1%       ~ (p=0.102 n=10)
Marshal/ReferenceFile/struct-2                                                             22.02µ ± 2%                                     22.19µ ± 1%       ~ (p=0.086 n=10)
Marshal/ReferenceFile/map-2                                                                28.69µ ± 1%                                     28.56µ ± 1%       ~ (p=0.481 n=10)
Marshal/HugoFrontMatter-2                                                                  5.321µ ± 1%                                     5.330µ ± 0%       ~ (p=0.403 n=10)
geomean                                                                                    65.16µ                                          65.67µ       +0.79%

                                  │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.PkmcYdvwSD-v2 │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.2sH1NCEcxF-HEAD │
                                  │                                B/s                                 │                      B/s                       vs base               │
UnmarshalDataset/config-2                                                                 81.73Mi ± 2%                                    80.23Mi ± 2%  -1.83% (p=0.043 n=10)
UnmarshalDataset/canada-2                                                                 45.90Mi ± 1%                                    45.00Mi ± 1%  -1.96% (p=0.000 n=10)
UnmarshalDataset/citm_catalog-2                                                           41.65Mi ± 1%                                    40.78Mi ± 3%  -2.08% (p=0.000 n=10)
UnmarshalDataset/twitter-2                                                                78.02Mi ± 1%                                    75.00Mi ± 1%  -3.88% (p=0.000 n=10)
UnmarshalDataset/code-2                                                                   44.51Mi ± 2%                                    44.61Mi ± 1%       ~ (p=0.469 n=10)
UnmarshalDataset/example-2                                                                75.24Mi ± 2%                                    74.58Mi ± 0%       ~ (p=0.352 n=10)
Unmarshal/SimpleDocument/struct-2                                                         31.91Mi ± 2%                                    31.61Mi ± 1%       ~ (p=0.075 n=10)
Unmarshal/SimpleDocument/map-2                                                            22.50Mi ± 2%                                    22.55Mi ± 1%       ~ (p=0.870 n=10)
Unmarshal/ReferenceFile/struct-2                                                          167.9Mi ± 2%                                    166.7Mi ± 1%       ~ (p=0.280 n=10)
Unmarshal/ReferenceFile/map-2                                                             114.4Mi ± 1%                                    114.1Mi ± 1%       ~ (p=0.529 n=10)
Unmarshal/HugoFrontMatter-2                                                               71.47Mi ± 2%                                    70.91Mi ± 2%       ~ (p=0.123 n=10)
Marshal/SimpleDocument/struct-2                                                           43.63Mi ± 2%                                    43.79Mi ± 3%       ~ (p=0.796 n=10)
Marshal/SimpleDocument/map-2                                                              31.68Mi ± 1%                                    31.85Mi ± 1%       ~ (p=0.101 n=10)
Marshal/ReferenceFile/struct-2                                                            89.10Mi ± 2%                                    88.42Mi ± 1%       ~ (p=0.086 n=10)
Marshal/ReferenceFile/map-2                                                               66.69Mi ± 1%                                    66.99Mi ± 1%       ~ (p=0.481 n=10)
Marshal/HugoFrontMatter-2                                                                 93.73Mi ± 0%                                    93.58Mi ± 0%       ~ (p=0.436 n=10)
geomean                                                                                   60.35Mi                                         59.88Mi       -0.78%

                                  │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.PkmcYdvwSD-v2 │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.2sH1NCEcxF-HEAD │
                                  │                                B/op                                │                    B/op                      vs base                 │
UnmarshalDataset/config-2                                                                 5.502Mi ± 0%                                  5.502Mi ± 0%       ~ (p=0.138 n=10)
UnmarshalDataset/canada-2                                                                 76.31Mi ± 0%                                  76.31Mi ± 0%       ~ (p=0.193 n=10)
UnmarshalDataset/citm_catalog-2                                                           32.90Mi ± 0%                                  32.90Mi ± 0%       ~ (p=0.089 n=10)
UnmarshalDataset/twitter-2                                                                12.05Mi ± 0%                                  12.05Mi ± 0%       ~ (p=0.853 n=10)
UnmarshalDataset/code-2                                                                   20.29Mi ± 0%                                  20.29Mi ± 0%       ~ (p=0.359 n=10)
UnmarshalDataset/example-2                                                                180.8Ki ± 0%                                  180.8Ki ± 0%       ~ (p=0.268 n=10)
Unmarshal/SimpleDocument/struct-2                                                           805.0 ± 0%                                    805.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map-2                                                            1.106Ki ± 0%                                  1.106Ki ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct-2                                                          19.99Ki ± 0%                                  19.99Ki ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map-2                                                             36.86Ki ± 0%                                  36.86Ki ± 0%       ~ (p=1.000 n=10)
Unmarshal/HugoFrontMatter-2                                                               7.267Ki ± 0%                                  7.267Ki ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct-2                                                             240.0 ± 0%                                    240.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map-2                                                                272.0 ± 0%                                    272.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct-2                                                            27.64Ki ± 0%                                  27.64Ki ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map-2                                                               27.28Ki ± 0%                                  27.28Ki ± 0%       ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter-2                                                                 5.672Ki ± 0%                                  5.672Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                   74.24Ki                                       74.24Ki       +0.00%
¹ all samples are equal

                                  │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.PkmcYdvwSD-v2 │ /var/folders/yw/xfw4875j6xv69_2r5v52b1yc0000gn/T/tmp.2sH1NCEcxF-HEAD │
                                  │                             allocs/op                              │                  allocs/op                   vs base                 │
UnmarshalDataset/config-2                                                                  219.2k ± 0%                                   219.2k ± 0%       ~ (p=0.474 n=10)
UnmarshalDataset/canada-2                                                                  670.4k ± 0%                                   670.4k ± 0%       ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog-2                                                            178.0k ± 0%                                   178.0k ± 0%       ~ (p=0.124 n=10)
UnmarshalDataset/twitter-2                                                                 54.76k ± 0%                                   54.76k ± 0%       ~ (p=0.667 n=10)
UnmarshalDataset/code-2                                                                    1.001M ± 0%                                   1.001M ± 0%       ~ (p=1.000 n=10) ¹
UnmarshalDataset/example-2                                                                 1.305k ± 0%                                   1.305k ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct-2                                                           9.000 ± 0%                                    9.000 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map-2                                                              13.00 ± 0%                                    13.00 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct-2                                                            160.0 ± 0%                                    160.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map-2                                                               619.0 ± 0%                                    619.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter-2                                                                 141.0 ± 0%                                    141.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct-2                                                             8.000 ± 0%                                    8.000 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map-2                                                                9.000 ± 0%                                    9.000 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct-2                                                              317.0 ± 0%                                    317.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map-2                                                                 429.0 ± 0%                                    429.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter-2                                                                   85.00 ± 0%                                    85.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                    1.060k                                        1.060k       +0.00%
¹ all samples are equal
```