### PR TITLE
Decode: fix reuse of slice for array tables

### DIFF
--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2848,6 +2848,27 @@ func TestIssue931(t *testing.T) {
 
 func TestIssue931Interface(t *testing.T) {
 	type items struct {
+		Slice interface{}
+	}
+
+	type item = map[string]interface{}
+
+	its := items{[]interface{}{item{"Name": "a"}, item{"Name": "b"}}}
+
+	b := []byte(`
+	[[Slice]]
+  Name = 'c'
+
+[[Slice]]
+  Name = 'd'
+	`)
+
+	toml.Unmarshal(b, &its)
+	require.Equal(t, items{[]interface{}{item{"Name": "c"}, item{"Name": "d"}}}, its)
+}
+
+func TestIssue931SliceInterface(t *testing.T) {
+	type items struct {
 		Slice []interface{}
 	}
 

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2846,6 +2846,32 @@ func TestIssue931(t *testing.T) {
 	require.Equal(t, items{[]item{{"c"}, {"d"}}}, its)
 }
 
+func TestIssue931Interface(t *testing.T) {
+	type items struct {
+		Slice []interface{}
+	}
+
+	type item = map[string]interface{}
+
+	its := items{
+		[]interface{}{
+			item{"Name": "a"},
+			item{"Name": "b"},
+		},
+	}
+
+	b := []byte(`
+	[[Slice]]
+  Name = 'c'
+
+[[Slice]]
+  Name = 'd'
+	`)
+
+	toml.Unmarshal(b, &its)
+	require.Equal(t, items{[]interface{}{item{"Name": "c"}, item{"Name": "d"}}}, its)
+}
+
 func TestUnmarshalDecodeErrors(t *testing.T) {
 	examples := []struct {
 		desc string

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -2823,6 +2823,29 @@ blah.a = "def"`)
 	require.Equal(t, "def", cfg.A)
 }
 
+func TestIssue931(t *testing.T) {
+	type item struct {
+		Name string
+	}
+
+	type items struct {
+		Slice []item
+	}
+
+	its := items{[]item{{"a"}, {"b"}}}
+
+	b := []byte(`
+	[[Slice]]
+  Name = 'c'
+
+[[Slice]]
+  Name = 'd'
+	`)
+
+	toml.Unmarshal(b, &its)
+	require.Equal(t, items{[]item{{"c"}, {"d"}}}, its)
+}
+
 func TestUnmarshalDecodeErrors(t *testing.T) {
 	examples := []struct {
 		desc string


### PR DESCRIPTION
When decoding into a non-empty slice, it needs to be emptied so that only the
tables contained in the document are present in the resulting value.

Arrays are not impacted because their unmarshal offset is tracked separately.

Fixes https://github.com/pelletier/go-toml/issues/931