### PR TITLE
fix(marchaler): escape runes outside the multilingual plane

### DIFF
--- a/internal/imported_tests/marshal_imported_test.go
+++ b/internal/imported_tests/marshal_imported_test.go
@@ -116,20 +116,19 @@ func TestBasicMarshalQuotedKey(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := `'Z.string-àéù' = 'Hello'
-'Yfloat-𝟘' = 3.5
+"Yfloat-𝟘" = 3.5
 
 ['Xsubdoc-àéù']
 String2 = 'One'
 
-[['W.sublist-𝟘']]
+[["W.sublist-𝟘"]]
 String2 = 'Two'
 
-[['W.sublist-𝟘']]
+[["W.sublist-𝟘"]]
 String2 = 'Three'
 `
 
-	require.Equal(t, string(expected), string(result))
-
+	require.Equal(t, expected, string(result))
 }
 
 func TestEmptyMarshal(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->

I recently switched to your amazing `toml` library and noticed it has an issue quoting strings as literal which ruines the rendering in oh-my-posh when exporting a configuration (see https://github.com/JanDeDobbeleer/oh-my-posh/issues/4750?notification_referrer_id=NT_kwDOACYJb7I5Nzc3NzUxMDkzOjI0OTI3ODM#issuecomment-1989538542).

This PR ensure we only quote strings as literal when it only contains characters inside the multilingual plane and/or emoji.

There was a V1 test that, rightfully so, fails which I also adjusted for correctness.

---

Paste `benchstat` results here (running ATM, takes a loooong time). Will post when it's done.
