### PR TITLE
Decode: unstable/Unmarshal interface

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -59,6 +59,14 @@ func (d *Decoder) DisallowUnknownFields() *Decoder {
 
 // EnableUnmarshalerInterface allows to enable unmarshaler interface.
 //
+// With this feature enabled, types implementing the unstable/Unmarshaler
+// interface can be decoded from any structure of the document. It allows types
+// that don't have a straightfoward TOML representation to provide their own
+// decoding logic.
+//
+// Currently, types can only decode from a single value. Tables and array tables
+// are not supported.
+//
 // *Unstable:* This method does not follow the compatibility guarantees of
 // semver. It can be changed or removed without a new major version being
 // issued.

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -17,12 +17,6 @@ import (
 	"github.com/pelletier/go-toml/v2/unstable"
 )
 
-// The Unmarshaler interface may be implemented by types to customize their
-// behavior when being unmarshaled from a TOML document.
-type Unmarshaler interface {
-	UnmarshalTOML(value *unstable.Node) error
-}
-
 // Unmarshal deserializes a TOML document into a Go value.
 //
 // It is a shortcut for Decoder.Decode() with the default options.
@@ -673,7 +667,7 @@ func (d *decoder) handleValue(value *unstable.Node, v reflect.Value) error {
 
 	if d.unmarshalerInterface {
 		if v.CanAddr() && v.Addr().CanInterface() {
-			if outi, ok := v.Addr().Interface().(Unmarshaler); ok {
+			if outi, ok := v.Addr().Interface().(unstable.Unmarshaler); ok {
 				return outi.UnmarshalTOML(value)
 			}
 		}

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -17,6 +17,12 @@ import (
 	"github.com/pelletier/go-toml/v2/unstable"
 )
 
+// The Unmarshaler interface may be implemented by types to customize their
+// behavior when being unmarshaled from a TOML document.
+type Unmarshaler interface {
+	UnmarshalTOML(value *unstable.Node) error
+}
+
 // Unmarshal deserializes a TOML document into a Go value.
 //
 // It is a shortcut for Decoder.Decode() with the default options.
@@ -646,6 +652,12 @@ func (d *decoder) tryTextUnmarshaler(node *unstable.Node, v reflect.Value) (bool
 func (d *decoder) handleValue(value *unstable.Node, v reflect.Value) error {
 	for v.Kind() == reflect.Ptr {
 		v = initAndDereferencePointer(v)
+	}
+
+	if v.CanAddr() && v.Addr().CanInterface() {
+		if outi, ok := v.Addr().Interface().(Unmarshaler); ok {
+			return outi.UnmarshalTOML(value)
+		}
 	}
 
 	ok, err := d.tryTextUnmarshaler(value, v)

--- a/unstable/unmarshaler.go
+++ b/unstable/unmarshaler.go
@@ -1,0 +1,7 @@
+package unstable
+
+// The Unmarshaler interface may be implemented by types to customize their
+// behavior when being unmarshaled from a TOML document.
+type Unmarshaler interface {
+	UnmarshalTOML(value *Node) error
+}


### PR DESCRIPTION
This adds the Unmarshaler interface to the v2 package. This way types that implement this interface can define the way they are unmarshalled.

Attempts to fix #873	
Supersedes #921