### PR TITLE
Encode: fix indentation when marshalling slices as array tables

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -1025,6 +1025,10 @@ func (enc *Encoder) encodeSliceAsArrayTable(b []byte, ctx encoderCtx, v reflect.
 
 	scratch = enc.commented(ctx.commented, scratch)
 
+	if enc.indentTables {
+		scratch = enc.indent(ctx.indent, scratch)
+	}
+
 	scratch = append(scratch, "[["...)
 
 	for i, k := range ctx.parentKey {

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1499,6 +1499,43 @@ func TestMarshalCommented(t *testing.T) {
 	require.Equal(t, expected, string(out))
 }
 
+func TestMarshalIndentedCustomTypeArray(t *testing.T) {
+	c := struct {
+		Nested struct {
+			NestedArray []struct {
+				Value int
+			}
+		}
+	}{
+		Nested: struct {
+			NestedArray []struct {
+				Value int
+			}
+		}{
+			NestedArray: []struct {
+				Value int
+			}{
+				{Value: 1},
+				{Value: 2},
+			},
+		},
+	}
+
+	expected := `[Nested]
+  [[Nested.NestedArray]]
+    Value = 1
+
+  [[Nested.NestedArray]]
+    Value = 2
+`
+
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	enc.SetIndentTables(true)
+	require.NoError(t, enc.Encode(c))
+	require.Equal(t, expected, buf.String())
+}
+
 func ExampleMarshal() {
 	type MyConfig struct {
 		Version int


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->

Arrays of custom types are not indented due to a missing call to `enc.indent`.
This PR fixes the issue by adding the missing call when `enc.indentTables == true`

---

Fixes https://github.com/pelletier/go-toml/issues/943
