### PR TITLE
Fix reflect.Pointer backward compatibility

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -732,7 +732,7 @@ func walkStruct(ctx encoderCtx, t *table, v reflect.Value) {
 			if fieldType.Anonymous {
 				if fieldType.Type.Kind() == reflect.Struct {
 					walkStruct(ctx, t, f)
-				} else if fieldType.Type.Kind() == reflect.Pointer && !f.IsNil() && f.Elem().Kind() == reflect.Struct {
+				} else if fieldType.Type.Kind() == reflect.Ptr && !f.IsNil() && f.Elem().Kind() == reflect.Struct {
 					walkStruct(ctx, t, f.Elem())
 				}
 				continue


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->

Explanation of what this pull request does.

```
/go/pkg/mod/github.com/pelletier/go-toml/v2@v2.2.2/marshaler.go:735:40: undefined: reflect.Pointer
```

If we want to reflect.Pointer backward compatibility. here should use reflect.Ptr.

related issue: https://github.com/pelletier/go-toml/issues/812

---

Benchmarks not needed
