### PR TITLE
Update goreleaser action to `v6` and set goreleaser binary to `v2`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
-          args: release ${{ inputs.args }} --rm-dist
+          version: '~> v2'
+          args: release ${{ inputs.args }} --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,6 +27,6 @@ jobs:
         run: go test -race ./...
   release-check:
     if: ${{ github.ref != 'refs/heads/v2' }}
-    uses: pelletier/go-toml/.github/workflows/release.yml@v2
+    uses: ./.github/workflows/release.yml
     with:
       args: --snapshot

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->

`goreleaser` recently released version 2 of the tool.
This release deprecates the `--rm-dist` flag.
Since the `version` argument of the `goreleaser/goreleaser-action` of the `release.yml` workflow was set to `latest`, the action downloaded the newer version, breaking the workflow.

This PR updates the goreleaser action to `v6` and pins the goreleaser binary version to any minor version of `v2`.
This should save the workflow from running into similar issues if gorelaser ever releases a `v3` with other breaking changes.

b2e0fda3392425cc434eb42551509347e064322e updates the `workflow.yml` workflow to use the `release.yml` from the same commit the workflow was triggered on.
This is required for the checks to pass on this PR, as it updates that very same workflow.
Otherwise it takes the workflow from the last tag on `v2`.
If this is desired behavior, I can just drop the commit before merging.
