### PR TITLE
Allow tranforming LocalTime to time.Duration

### DIFF
--- a/localtime.go
+++ b/localtime.go
@@ -50,6 +50,11 @@ type LocalTime struct {
 	Precision  int // Number of digits to display for Nanosecond.
 }
 
+// AsDuration converts d into a duration
+func (d LocalTime) AsDuration() time.Duration {
+	return time.Duration(d.Hour)*time.Hour + time.Duration(d.Minute)*time.Minute + time.Duration(d.Second)*time.Second + time.Duration(d.Nanosecond)*time.Nanosecond
+}
+
 // String returns RFC 3339 representation of d.
 // If d.Nanosecond and d.Precision are zero, the time won't have a nanosecond
 // component. If d.Nanosecond > 0 but d.Precision = 0, then the minimum number

--- a/types.go
+++ b/types.go
@@ -7,6 +7,7 @@ import (
 )
 
 var timeType = reflect.TypeOf((*time.Time)(nil)).Elem()
+var durationType = reflect.TypeOf((*time.Duration)(nil)).Elem()
 var textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
 var textUnmarshalerType = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 var mapStringInterfaceType = reflect.TypeOf(map[string]interface{}(nil))

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -852,6 +852,12 @@ func (d *decoder) unmarshalLocalTime(value *unstable.Node, v reflect.Value) erro
 		return unstable.NewParserError(rest, "extra characters at the end of a local time")
 	}
 
+	if v.Type() == durationType {
+		cast := lt.AsDuration()
+		v.Set(reflect.ValueOf(cast))
+		return nil
+	}
+
 	v.Set(reflect.ValueOf(lt))
 	return nil
 }

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -604,6 +604,20 @@ foo = "bar"`,
 			},
 		},
 		{
+			desc:  "local-time into duration",
+			input: `a = 12:08:05.666666666`,
+			gen: func() test {
+				var v map[string]time.Duration
+
+				return test{
+					target: &v,
+					expected: &map[string]time.Duration{
+						"a": 12*time.Hour + 8*time.Minute + 5*time.Second + 666666666*time.Nanosecond, //toml.LocalTime{Hour: 12, Minute: 8, Second: 5, Nanosecond: 666666666, Precision: 9},
+					},
+				}
+			},
+		},
+		{
 			desc:  "local-time missing digit",
 			input: `a = 12:08:0`,
 			gen: func() test {


### PR DESCRIPTION
Adds a function to transform LocalTime to time.Duration and does it automatically during unmarshalling.

[benchstat.txt](https://github.com/user-attachments/files/17337319/benchstat.txt)