### PR TITLE
feat: Add support for custom field tags

### DIFF
--- a/field_tag.go
+++ b/field_tag.go
@@ -1,0 +1,4 @@
+package toml
+
+// tomlFieldTag is the default field tag name when encoding and decoding TOML schema.
+const tomlFieldTag = "toml"

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1080,6 +1080,30 @@ Bad = ''
 	assert.Equal(t, expected, string(b))
 }
 
+func TestEncoderSetFieldTag(t *testing.T) {
+	type fieldTagTestType struct {
+		Hellllooo     string `json:"hello"`
+		Nnnummbbeerrr int    `json:"number"`
+	}
+
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	enc = enc.SetFieldTag("json")
+
+	input := fieldTagTestType{
+		Hellllooo:     "hi",
+		Nnnummbbeerrr: 1,
+	}
+	err := enc.Encode(input)
+	require.NoError(t, err)
+
+	expValue := `hello = 'hi'
+number = 1
+`
+
+	require.Equal(t, expValue, buf.String())
+}
+
 func TestIssue436(t *testing.T) {
 	data := []byte(`{"a": [ { "b": { "c": "d" } } ]}`)
 

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -112,6 +112,21 @@ func TestDecodeReaderError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDecoderSetFieldTag(t *testing.T) {
+	type fieldTagTestType struct {
+		A string `json:"aaa"`
+		B string `json:"bbb"`
+	}
+
+	d := toml.NewDecoder(strings.NewReader("aaa = \"foo\"\nbbb = \"bar\""))
+	d.SetFieldTag("json")
+	var output fieldTagTestType
+	err := d.Decode(&output)
+	require.NoError(t, err)
+	assert.Equal(t, "foo", output.A)
+	assert.Equal(t, "bar", output.B)
+}
+
 // nolint:funlen
 func TestUnmarshal_Integers(t *testing.T) {
 	examples := []struct {


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->
This PR allows for custom field tags to be set when doing toml encoding and decoding.  This allows for a single tag to be used for fields in structures that may be encoded/decoded to various formats.

For example, the default tag being used is `toml`. With this change, any tag may be used to encode / decode by calling the `SetFieldTag` method on the respective encoder or decoder.

---

<details>
    <summary>benchstat results</summary>

```
./ci.sh benchmark 
Executing benchmark for HEAD at /var/folders/6v/ptrk49k16l32ftg2l8x0q8j40000gn/T/tmp.Xf8M0QfP2t
/var/folders/6v/ptrk49k16l32ftg2l8x0q8j40000gn/T/tmp.Xf8M0QfP2t ~/repos/go-toml
PASS
ok      github.com/pelletier/go-toml/v2 0.390s
goos: darwin
goarch: amd64
pkg: github.com/pelletier/go-toml/v2/benchmark
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
BenchmarkUnmarshalDataset/config-2                    46          25581527 ns/op          40.99 MB/s     5717331 B/op     219171 allocs/op
BenchmarkUnmarshalDataset/config-2                    44          24805911 ns/op          42.28 MB/s     5717276 B/op     219170 allocs/op
BenchmarkUnmarshalDataset/config-2                    40          26196888 ns/op          40.03 MB/s     5717204 B/op     219170 allocs/op
BenchmarkUnmarshalDataset/config-2                    48          24087845 ns/op          43.54 MB/s     5717382 B/op     219171 allocs/op
BenchmarkUnmarshalDataset/config-2                    44          25106897 ns/op          41.77 MB/s     5717294 B/op     219170 allocs/op
BenchmarkUnmarshalDataset/config-2                    46          24516388 ns/op          42.77 MB/s     5717402 B/op     219171 allocs/op
BenchmarkUnmarshalDataset/config-2                    44          24267414 ns/op          43.21 MB/s     5717204 B/op     219170 allocs/op
BenchmarkUnmarshalDataset/config-2                    44          24128182 ns/op          43.46 MB/s     5717317 B/op     219170 allocs/op
BenchmarkUnmarshalDataset/config-2                    45          26520093 ns/op          39.54 MB/s     5717378 B/op     219171 allocs/op
BenchmarkUnmarshalDataset/config-2                    44          25406343 ns/op          41.28 MB/s     5717321 B/op     219170 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          86947869 ns/op          25.32 MB/s    79942720 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          85512687 ns/op          25.74 MB/s    79942714 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          84795672 ns/op          25.96 MB/s    79942720 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          86992259 ns/op          25.31 MB/s    79942716 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          85417552 ns/op          25.77 MB/s    79942714 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          91677092 ns/op          24.01 MB/s    79942717 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          83603982 ns/op          26.33 MB/s    79942717 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          85657434 ns/op          25.70 MB/s    79942712 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          86943153 ns/op          25.32 MB/s    79942717 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/canada-2                    12          84239837 ns/op          26.13 MB/s    79942713 B/op     670378 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              43          27634562 ns/op          20.19 MB/s    34471016 B/op     177997 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              43          27580064 ns/op          20.23 MB/s    34470906 B/op     177996 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              40          27301208 ns/op          20.44 MB/s    34471116 B/op     177997 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              43          27641434 ns/op          20.19 MB/s    34470716 B/op     177996 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              42          27351729 ns/op          20.40 MB/s    34471020 B/op     177997 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              43          27662765 ns/op          20.17 MB/s    34471071 B/op     177997 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              42          29424258 ns/op          18.97 MB/s    34471160 B/op     177997 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              34          32372782 ns/op          17.24 MB/s    34470885 B/op     177996 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              36          30425717 ns/op          18.34 MB/s    34470899 B/op     177996 allocs/op
BenchmarkUnmarshalDataset/citm_catalog-2              39          45320494 ns/op          12.31 MB/s    34470883 B/op     177995 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   84          13436292 ns/op          32.89 MB/s    12666948 B/op      54839 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   81          13341064 ns/op          33.12 MB/s    12666311 B/op      54837 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   92          12522409 ns/op          35.29 MB/s    12665277 B/op      54833 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   91          13059828 ns/op          33.84 MB/s    12666416 B/op      54837 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   85          12927284 ns/op          34.18 MB/s    12666325 B/op      54837 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   80          13657599 ns/op          32.35 MB/s    12667489 B/op      54841 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   93          12995151 ns/op          34.00 MB/s    12666302 B/op      54837 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   79          13356514 ns/op          33.08 MB/s    12666153 B/op      54836 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   79          13106220 ns/op          33.72 MB/s    12667217 B/op      54840 allocs/op
BenchmarkUnmarshalDataset/twitter-2                   85          13418967 ns/op          32.93 MB/s    12667082 B/op      54839 allocs/op
BenchmarkUnmarshalDataset/code-2                       9         120960775 ns/op          22.19 MB/s    21263264 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/code-2                       8         129373900 ns/op          20.75 MB/s    21263272 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/code-2                      10         107105378 ns/op          25.06 MB/s    21263257 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/code-2                      10         107467760 ns/op          24.98 MB/s    21263254 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/code-2                       9         113175573 ns/op          23.72 MB/s    21263262 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/code-2                       8         126063003 ns/op          21.29 MB/s    21263258 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/code-2                       8         126419236 ns/op          21.23 MB/s    21263260 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/code-2                      10         104414656 ns/op          25.71 MB/s    21263264 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/code-2                       9         114960958 ns/op          23.35 MB/s    21263271 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/code-2                       8         132648670 ns/op          20.23 MB/s    21263278 B/op    1000519 allocs/op
BenchmarkUnmarshalDataset/example-2                 4462            242619 ns/op          33.39 MB/s      186032 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                 5438            217122 ns/op          37.31 MB/s      186045 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                 5359            206948 ns/op          39.14 MB/s      186037 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                 5068            207618 ns/op          39.01 MB/s      186044 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                 5406            221938 ns/op          36.50 MB/s      186040 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                 4935            212530 ns/op          38.11 MB/s      186042 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                 5161            221445 ns/op          36.58 MB/s      186038 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                 5041            209406 ns/op          38.68 MB/s      186039 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                 5172            215266 ns/op          37.63 MB/s      186028 B/op       1305 allocs/op
BenchmarkUnmarshalDataset/example-2                 5118            212154 ns/op          38.18 MB/s      186034 B/op       1305 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1724060               745.0 ns/op        14.77 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1708629               731.6 ns/op        15.04 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1616756               719.8 ns/op        15.28 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1631566               707.0 ns/op        15.56 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1586236               699.5 ns/op        15.73 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1709610               739.9 ns/op        14.87 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1685721               692.4 ns/op        15.89 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1707644               725.5 ns/op        15.16 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1659865               706.0 ns/op        15.58 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/struct-2       1644679               711.2 ns/op        15.47 MB/s         821 B/op          8 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          1000000              1059 ns/op          10.39 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          1000000              1098 ns/op          10.02 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          1000000              1106 ns/op           9.94 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          1197184               999.6 ns/op        11.00 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          1000000              1008 ns/op          10.91 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          1211487               994.5 ns/op        11.06 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          1201645              1003 ns/op          10.97 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2           981436              1040 ns/op          10.58 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2           995486              1008 ns/op          10.92 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/SimpleDocument/map-2          1000000              1006 ns/op          10.93 MB/s        1149 B/op         12 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          22842             61005 ns/op          85.91 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          18127             63143 ns/op          83.00 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          20179             62047 ns/op          84.47 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          19843             59710 ns/op          87.77 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          20092             57243 ns/op          91.56 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          21488             56704 ns/op          92.43 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          20620             56457 ns/op          92.83 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          20510             55973 ns/op          93.63 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          22318             53399 ns/op          98.15 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/struct-2          21904             54657 ns/op          95.89 MB/s       15873 B/op        158 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             14161             82392 ns/op          63.61 MB/s       33154 B/op        617 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             14400             82628 ns/op          63.43 MB/s       33153 B/op        617 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             14053             81464 ns/op          64.34 MB/s       33154 B/op        617 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             14196             88695 ns/op          59.09 MB/s       33154 B/op        617 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             12607             83802 ns/op          62.54 MB/s       33154 B/op        617 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             14396             93166 ns/op          56.25 MB/s       33153 B/op        617 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             12976             89176 ns/op          58.77 MB/s       33153 B/op        617 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             14308             84955 ns/op          61.69 MB/s       33153 B/op        617 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             14364             82465 ns/op          63.55 MB/s       33153 B/op        617 allocs/op
BenchmarkUnmarshal/ReferenceFile/map-2             14330             81343 ns/op          64.43 MB/s       33154 B/op        617 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               79267             14265 ns/op          38.28 MB/s        7585 B/op        140 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               79904             14971 ns/op          36.47 MB/s        7585 B/op        140 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               77391             15034 ns/op          36.32 MB/s        7585 B/op        140 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               78628             15660 ns/op          34.87 MB/s        7585 B/op        140 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               75888             16577 ns/op          32.94 MB/s        7585 B/op        140 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               74547             15620 ns/op          34.95 MB/s        7584 B/op        140 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               74118             15015 ns/op          36.36 MB/s        7585 B/op        140 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               78826             14653 ns/op          37.26 MB/s        7585 B/op        140 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               78663             14337 ns/op          38.08 MB/s        7585 B/op        140 allocs/op
BenchmarkUnmarshal/HugoFrontMatter-2               78411             14544 ns/op          37.54 MB/s        7584 B/op        140 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2329410               503.5 ns/op        23.83 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2369288               502.5 ns/op        23.88 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2401080               514.0 ns/op        23.35 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2051607               502.0 ns/op        23.90 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2285988               509.6 ns/op        23.55 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2325723               516.5 ns/op        23.23 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2291912               542.7 ns/op        22.11 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2354224               511.1 ns/op        23.48 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2267322               601.5 ns/op        19.95 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/struct-2         2229643               528.0 ns/op        22.73 MB/s         240 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1875633               631.3 ns/op        19.01 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1875898               648.5 ns/op        18.50 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1701518               639.1 ns/op        18.78 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1898683               641.4 ns/op        18.71 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1810863               648.9 ns/op        18.49 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1893246               649.8 ns/op        18.47 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1711586               677.9 ns/op        17.70 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1558137               669.2 ns/op        17.93 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1731950               686.0 ns/op        17.49 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/SimpleDocument/map-2            1856368               634.2 ns/op        18.92 MB/s         248 B/op          8 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            27320             44274 ns/op          46.46 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            25524             45418 ns/op          45.29 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            27525             44873 ns/op          45.84 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            26524             44093 ns/op          46.65 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            26530             42390 ns/op          48.53 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            26530             41973 ns/op          49.01 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            28323             42005 ns/op          48.97 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            28225             41909 ns/op          49.08 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            26031             44423 ns/op          46.31 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/struct-2            27676             42605 ns/op          48.28 MB/s       28432 B/op        317 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               22256             52183 ns/op          38.44 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               21968             55371 ns/op          36.23 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               22038             55686 ns/op          36.02 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               22225             54316 ns/op          36.93 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               21784             53539 ns/op          37.47 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               21948             52575 ns/op          38.15 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               23359             50527 ns/op          39.70 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               22778             50056 ns/op          40.07 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               22821             50138 ns/op          40.01 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/ReferenceFile/map-2               23731             49928 ns/op          40.18 MB/s       24552 B/op        344 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                117015              9754 ns/op          53.62 MB/s        5392 B/op         73 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                116180              9950 ns/op          52.56 MB/s        5392 B/op         73 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                117126             10038 ns/op          52.10 MB/s        5392 B/op         73 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                111630             13597 ns/op          38.46 MB/s        5392 B/op         73 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                 98384             12533 ns/op          41.73 MB/s        5392 B/op         73 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                102813             12358 ns/op          42.32 MB/s        5392 B/op         73 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                103597             11373 ns/op          45.98 MB/s        5392 B/op         73 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                104995             10430 ns/op          50.14 MB/s        5392 B/op         73 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                104871             10617 ns/op          49.26 MB/s        5392 B/op         73 allocs/op
BenchmarkMarshal/HugoFrontMatter-2                116350              9923 ns/op          52.70 MB/s        5392 B/op         73 allocs/op
PASS
ok      github.com/pelletier/go-toml/v2/benchmark       255.666s
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-decoder [no test files]
?       github.com/pelletier/go-toml/v2/cmd/gotoml-test-encoder [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/cmd/jsontoml    0.364s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomljson    0.390s
PASS
ok      github.com/pelletier/go-toml/v2/cmd/tomll       0.386s
?       github.com/pelletier/go-toml/v2/cmd/tomltestgen [no test files]
?       github.com/pelletier/go-toml/v2/internal/characters     [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/cli    0.465s
PASS
ok      github.com/pelletier/go-toml/v2/internal/danger 0.450s
PASS
ok      github.com/pelletier/go-toml/v2/internal/imported_tests 0.502s
?       github.com/pelletier/go-toml/v2/internal/testsuite      [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/internal/tracker        0.470s
?       github.com/pelletier/go-toml/v2/ossfuzz [no test files]
PASS
ok      github.com/pelletier/go-toml/v2/unstable        0.399s
```
</details>

