### PR TITLE
feat: add text_multiline tag option for string slice

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -194,10 +194,11 @@ func (enc *Encoder) Encode(v interface{}) error {
 }
 
 type valueOptions struct {
-	multiline bool
-	omitempty bool
-	commented bool
-	comment   string
+	multiline     bool
+	omitempty     bool
+	commented     bool
+	comment       string
+	textMultiline bool
 }
 
 type encoderCtx struct {
@@ -758,10 +759,11 @@ func walkStruct(ctx encoderCtx, t *table, v reflect.Value) {
 		}
 
 		options := valueOptions{
-			multiline: opts.multiline,
-			omitempty: opts.omitempty,
-			commented: opts.commented,
-			comment:   fieldType.Tag.Get("comment"),
+			multiline:     opts.multiline,
+			omitempty:     opts.omitempty,
+			commented:     opts.commented,
+			comment:       fieldType.Tag.Get("comment"),
+			textMultiline: opts.textMultiline,
 		}
 
 		if opts.inline || !willConvertToTableOrArrayTable(ctx, f) {
@@ -817,10 +819,11 @@ func isValidName(s string) bool {
 }
 
 type tagOptions struct {
-	multiline bool
-	inline    bool
-	omitempty bool
-	commented bool
+	multiline     bool
+	inline        bool
+	omitempty     bool
+	commented     bool
+	textMultiline bool
 }
 
 func parseTag(tag string) (string, tagOptions) {
@@ -850,6 +853,8 @@ func parseTag(tag string) (string, tagOptions) {
 			opts.omitempty = true
 		case "commented":
 			opts.commented = true
+		case "text_multiline":
+			opts.textMultiline = true
 		}
 	}
 
@@ -1108,7 +1113,16 @@ func (enc *Encoder) encodeSliceAsArray(b []byte, ctx encoderCtx, v reflect.Value
 			b = enc.indent(subCtx.indent, b)
 		}
 
-		b, err = enc.encode(b, subCtx, v.Index(i))
+		elemValue := v.Index(i)
+		if elemValue.Kind() == reflect.String {
+			str := elemValue.String()
+			if strings.Contains(str, "\n") && ctx.options.textMultiline {
+				b = enc.encodeTextMultilineString(b, str, true)
+				continue
+			}
+		}
+
+		b, err = enc.encode(b, subCtx, elemValue)
 		if err != nil {
 			return nil, err
 		}
@@ -1127,6 +1141,24 @@ func (enc *Encoder) encodeSliceAsArray(b []byte, ctx encoderCtx, v reflect.Value
 func (enc *Encoder) indent(level int, b []byte) []byte {
 	for i := 0; i < level; i++ {
 		b = append(b, enc.indentSymbol...)
+	}
+
+	return b
+}
+
+func (enc *Encoder) encodeTextMultilineString(b []byte, v string, quoted bool) []byte {
+	if quoted {
+		b = append(b, `"""`...)
+	} else {
+		b = append(b, []byte{'"'}...)
+	}
+
+	b = append(b, v...)
+
+	if quoted {
+		b = append(b, `"""`...)
+	} else {
+		b = append(b, []byte{'"'}...)
 	}
 
 	return b

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1773,3 +1773,38 @@ port = 4242
 `
 	require.Equal(t, expected, string(out))
 }
+
+func TestMarshalMultilineStringArray(t *testing.T) {
+	type StringArrayExample struct {
+		TextMultilineStrings []string `toml:",multiline,text_multiline"`
+		MultilineStrings     []string `toml:",multiline"`
+		SimpleStrings        []string
+	}
+
+	example := StringArrayExample{
+		TextMultilineStrings: []string{"first\nline", "second\nline", "third", "fourth"},
+		MultilineStrings:     []string{"first\nline", "second\nline", "third", "fourth"},
+		SimpleStrings:        []string{"one", "two", "three", "four"},
+	}
+
+	out, err := toml.Marshal(example)
+	require.NoError(t, err)
+
+	expected := `TextMultilineStrings = [
+  """first
+line""",
+  """second
+line""",
+  'third',
+  'fourth'
+]
+MultilineStrings = [
+  "first\nline",
+  "second\nline",
+  'third',
+  'fourth'
+]
+SimpleStrings = ['one', 'two', 'three', 'four']
+`
+	assert.Equal(t, expected, string(out))
+}


### PR DESCRIPTION
# feat: add text_multiline tag option for string slice

- Add new text_multiline option to control string array formatting
- Update test cases to demonstrate different string array formatting options