### PR TITLE
Use reflect.Value.IsZero for omitempty checks

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -381,7 +381,7 @@ func isNil(v reflect.Value) bool {
 }
 
 func shouldOmitEmpty(options valueOptions, v reflect.Value) bool {
-	return options.omitempty && isEmptyValue(v)
+	return options.omitempty && v.IsZero()
 }
 
 func (enc *Encoder) encodeKv(b []byte, ctx encoderCtx, options valueOptions, v reflect.Value) ([]byte, error) {
@@ -416,54 +416,6 @@ func (enc *Encoder) commented(commented bool, b []byte) []byte {
 		return append(b, "# "...)
 	}
 	return b
-}
-
-func isEmptyValue(v reflect.Value) bool {
-	switch v.Kind() {
-	case reflect.Struct:
-		return isEmptyStruct(v)
-	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
-		return v.Len() == 0
-	case reflect.Bool:
-		return !v.Bool()
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
-		return v.IsNil()
-	}
-	return false
-}
-
-func isEmptyStruct(v reflect.Value) bool {
-	// TODO: merge with walkStruct and cache.
-	typ := v.Type()
-	for i := 0; i < typ.NumField(); i++ {
-		fieldType := typ.Field(i)
-
-		// only consider exported fields
-		if fieldType.PkgPath != "" {
-			continue
-		}
-
-		tag := fieldType.Tag.Get("toml")
-
-		// special field name to skip field
-		if tag == "-" {
-			continue
-		}
-
-		f := v.Field(i)
-
-		if !isEmptyValue(f) {
-			return false
-		}
-	}
-
-	return true
 }
 
 const literalQuote = '\''

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"net/netip"
 	"reflect"
 	"strings"
 	"testing"
@@ -1069,6 +1070,8 @@ func TestEncoderOmitempty(t *testing.T) {
 		Ptr     *string           `toml:",omitempty,multiline"`
 		Iface   interface{}       `toml:",omitempty,multiline"`
 		Struct  struct{}          `toml:",omitempty,multiline"`
+		Time    time.Time         `toml:",omitempty,multiline"`
+		IP      netip.Addr        `toml:",omitempty,multiline"`
 	}
 
 	d := doc{}
@@ -1077,6 +1080,25 @@ func TestEncoderOmitempty(t *testing.T) {
 	assert.NoError(t, err)
 
 	expected := ``
+
+	assert.Equal(t, expected, string(b))
+}
+
+func TestEncoderOmitemptyComparableStruct(t *testing.T) {
+	type doc struct {
+		Time time.Time  `toml:",omitempty"`
+		IP   netip.Addr `toml:",omitempty"`
+	}
+
+	d := doc{
+		Time: time.Date(2001, 2, 3, 4, 5, 6, 7, time.UTC),
+		IP:   netip.MustParseAddr("192.168.178.35"),
+	}
+
+	b, err := toml.Marshal(d)
+	assert.NoError(t, err)
+
+	expected := "Time = 2001-02-03T04:05:06.000000007Z\nIP = '192.168.178.35'\n"
 
 	assert.Equal(t, expected, string(b))
 }


### PR DESCRIPTION
Struct fields of type `time.Time` and `netip.Addr` are always omitted when using `omitempty` because the current `isEmptyValue` function can only check structs with exported fields. See #955 and #988.

Replacing the current `isEmptyValue` function with `reflect.Value.IsZero()` is a very simple and low risk fix that should make `omitempty` useful for many more types.

---

```text
goos: linux
goarch: amd64
pkg: github.com/pelletier/go-toml/v2/benchmark
cpu: Intel(R) Core(TM) Ultra 9 275HX
                                   │ old_bench_10.txt │          new_bench_10.txt          │
                                   │      sec/op      │   sec/op     vs base               │
UnmarshalDataset/config-24                11.95m ± 3%   12.28m ± 3%       ~ (p=0.105 n=10)
UnmarshalDataset/canada-24                50.90m ± 6%   46.93m ± 3%  -7.80% (p=0.002 n=10)
UnmarshalDataset/citm_catalog-24          21.77m ± 4%   21.27m ± 1%  -2.31% (p=0.035 n=10)
UnmarshalDataset/twitter-24               7.624m ± 6%   8.092m ± 4%  +6.15% (p=0.029 n=10)
UnmarshalDataset/code-24                  51.21m ± 6%   50.42m ± 4%       ~ (p=0.165 n=10)
UnmarshalDataset/example-24               111.4µ ± 3%   115.9µ ± 5%       ~ (p=0.089 n=10)
Unmarshal/SimpleDocument/struct-24        354.5n ± 3%   380.2n ± 3%  +7.25% (p=0.000 n=10)
Unmarshal/SimpleDocument/map-24           494.8n ± 4%   517.0n ± 4%  +4.50% (p=0.029 n=10)
Unmarshal/ReferenceFile/struct-24         27.74µ ± 5%   29.04µ ± 5%  +4.68% (p=0.035 n=10)
Unmarshal/ReferenceFile/map-24            42.84µ ± 5%   42.85µ ± 4%       ~ (p=0.853 n=10)
Unmarshal/HugoFrontMatter-24              7.200µ ± 3%   7.374µ ± 3%       ~ (p=0.143 n=10)
Marshal/SimpleDocument/struct-24          258.1n ± 6%   263.9n ± 3%       ~ (p=0.271 n=10)
Marshal/SimpleDocument/map-24             311.6n ± 2%   313.6n ± 3%       ~ (p=0.565 n=10)
Marshal/ReferenceFile/struct-24           21.15µ ± 3%   21.56µ ± 1%  +1.93% (p=0.011 n=10)
Marshal/ReferenceFile/map-24              25.35µ ± 4%   25.54µ ± 4%       ~ (p=0.247 n=10)
Marshal/HugoFrontMatter-24                4.782µ ± 4%   4.859µ ± 3%       ~ (p=0.224 n=10)
geomean                                   67.32µ        68.44µ       +1.65%

                                   │ old_bench_10.txt │          new_bench_10.txt           │
                                   │       B/s        │     B/s       vs base               │
UnmarshalDataset/config-24               83.70Mi ± 3%   81.45Mi ± 3%       ~ (p=0.105 n=10)
UnmarshalDataset/canada-24               41.25Mi ± 6%   44.73Mi ± 3%  +8.45% (p=0.002 n=10)
UnmarshalDataset/citm_catalog-24         24.45Mi ± 4%   25.02Mi ± 1%  +2.36% (p=0.034 n=10)
UnmarshalDataset/twitter-24              55.28Mi ± 6%   52.08Mi ± 4%  -5.80% (p=0.029 n=10)
UnmarshalDataset/code-24                 49.99Mi ± 6%   50.77Mi ± 4%       ~ (p=0.165 n=10)
UnmarshalDataset/example-24              69.36Mi ± 3%   66.66Mi ± 5%       ~ (p=0.089 n=10)
Unmarshal/SimpleDocument/struct-24       29.59Mi ± 3%   27.59Mi ± 3%  -6.75% (p=0.000 n=10)
Unmarshal/SimpleDocument/map-24          21.20Mi ± 4%   20.29Mi ± 4%  -4.30% (p=0.029 n=10)
Unmarshal/ReferenceFile/struct-24        180.2Mi ± 5%   172.1Mi ± 5%  -4.45% (p=0.035 n=10)
Unmarshal/ReferenceFile/map-24           116.7Mi ± 5%   116.7Mi ± 4%       ~ (p=0.853 n=10)
Unmarshal/HugoFrontMatter-24             72.33Mi ± 3%   70.61Mi ± 3%       ~ (p=0.143 n=10)
Marshal/SimpleDocument/struct-24         44.33Mi ± 5%   43.36Mi ± 3%       ~ (p=0.271 n=10)
Marshal/SimpleDocument/map-24            36.73Mi ± 2%   36.50Mi ± 3%       ~ (p=0.542 n=10)
Marshal/ReferenceFile/struct-24          92.75Mi ± 3%   90.99Mi ± 1%  -1.90% (p=0.009 n=10)
Marshal/ReferenceFile/map-24             75.47Mi ± 4%   74.90Mi ± 4%       ~ (p=0.247 n=10)
Marshal/HugoFrontMatter-24               104.3Mi ± 4%   102.7Mi ± 3%       ~ (p=0.247 n=10)
geomean                                  58.41Mi        57.46Mi       -1.62%
```

All the other measurements were equal.