### PR TITLE
marshal: don't escape quotes unnecessarily

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -517,12 +517,32 @@ func (enc *Encoder) encodeQuotedString(multiline bool, b []byte, v string) []byt
 		del = 0x7f
 	)
 
-	for _, r := range []byte(v) {
+	bv := []byte(v)
+	for i := 0; i < len(bv); i++ {
+		r := bv[i]
+		// for _, r := range []byte(v) {
 		switch r {
 		case '\\':
 			b = append(b, `\\`...)
 		case '"':
-			b = append(b, `\"`...)
+			if multiline {
+				// Quotation marks do not need to be quoted in multiline strings unless
+				// it contains 3 consecutive. If 3+ quotes appear, quote all of them
+				// because it's visually better
+				if i+2 > len(bv) || bv[i+1] != '"' || bv[i+2] != '"' {
+					b = append(b, r)
+				} else {
+					for {
+						b = append(b, `\"`...)
+						if i+1 == len(bv) || bv[i+1] != '"' {
+							break
+						}
+						i++
+					}
+				}
+			} else {
+				b = append(b, `\"`...)
+			}
 		case '\b':
 			b = append(b, `\b`...)
 		case '\f':

--- a/marshaler.go
+++ b/marshaler.go
@@ -520,7 +520,6 @@ func (enc *Encoder) encodeQuotedString(multiline bool, b []byte, v string) []byt
 	bv := []byte(v)
 	for i := 0; i < len(bv); i++ {
 		r := bv[i]
-		// for _, r := range []byte(v) {
 		switch r {
 		case '\\':
 			b = append(b, `\\`...)
@@ -532,13 +531,8 @@ func (enc *Encoder) encodeQuotedString(multiline bool, b []byte, v string) []byt
 				if i+2 > len(bv) || bv[i+1] != '"' || bv[i+2] != '"' {
 					b = append(b, r)
 				} else {
-					for {
-						b = append(b, `\"`...)
-						if i+1 == len(bv) || bv[i+1] != '"' {
-							break
-						}
-						i++
-					}
+					b = append(b, `\"\"\"`...)
+					i += 2
 				}
 			} else {
 				b = append(b, `\"`...)

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -390,6 +390,54 @@ world"""
 `,
 		},
 		{
+			desc: "multi-line quotation",
+			v: struct {
+				A string `toml:",multiline"`
+			}{
+				A: "hello\n\"world\"",
+			},
+			expected: `A = """
+hello
+"world""""
+`,
+		},
+		{
+			desc: "multi-line triple quotation",
+			v: struct {
+				A string `toml:",multiline"`
+			}{
+				A: "hello\n\"\"\"world\"",
+			},
+			expected: `A = """
+hello
+\"\"\"world""""
+`,
+		},
+		{
+			desc: "multi-line triple quotation",
+			v: struct {
+				A string `toml:",multiline"`
+			}{
+				A: "hello\n\"world\"\"\"",
+			},
+			expected: `A = """
+hello
+"world\"\"\""""
+`,
+		},
+		{
+			desc: "multi-line sextuple quotation",
+			v: struct {
+				A string `toml:",multiline"`
+			}{
+				A: "hello\n\"\"\"\"\"\"world\"",
+			},
+			expected: `A = """
+hello
+\"\"\"\"\"\"world""""
+`,
+		},
+		{
 			desc: "inline field",
 			v: struct {
 				A map[string]string `toml:",inline"`


### PR DESCRIPTION
Only 3 consecutive quotation marks need to be quoted. We choose to quote all quotation marks in a sequence if there are 3 or more consecutive present.

Fixes #990

---

Strictly speaking, this would break backwards compatibility if anyone was using a textual comparison of the output of Marshal (as opposed to the semantic content). Could hide it behind an additional tag/option if that seems like a concern.

I've not used benchstat before, but I think there's a slight performance penalty, but worth it for me :)

---

Results of `./ci.sh benchmark -d v2`:

```
goos: darwin
goarch: arm64
pkg: github.com/pelletier/go-toml/v2/benchmark
cpu: Apple M3 Max
                                  │ /var/folders/4x/hhbzwffd2d5c3n6z2b09b91c000_0t/T/v2.RfSXGXt4GH │ /var/folders/4x/hhbzwffd2d5c3n6z2b09b91c000_0t/T/HEAD.Cu81ZqvZ38 │
                                  │                             sec/op                             │                  sec/op                    vs base               │
UnmarshalDataset/config-2                                                              9.800m ± 1%                                 9.979m ± 0%  +1.83% (p=0.002 n=10)
UnmarshalDataset/canada-2                                                              38.80m ± 3%                                 38.32m ± 1%       ~ (p=0.123 n=10)
UnmarshalDataset/citm_catalog-2                                                        12.00m ± 2%                                 11.51m ± 1%  -4.09% (p=0.000 n=10)
UnmarshalDataset/twitter-2                                                             4.718m ± 4%                                 4.651m ± 0%  -1.43% (p=0.000 n=10)
UnmarshalDataset/code-2                                                                46.55m ± 1%                                 45.94m ± 1%  -1.32% (p=0.000 n=10)
UnmarshalDataset/example-2                                                             86.56µ ± 2%                                 86.24µ ± 0%  -0.37% (p=0.015 n=10)
Unmarshal/SimpleDocument/struct-2                                                      273.6n ± 2%                                 274.1n ± 0%       ~ (p=0.447 n=10)
Unmarshal/SimpleDocument/map-2                                                         385.2n ± 3%                                 383.6n ± 0%       ~ (p=0.315 n=10)
Unmarshal/ReferenceFile/struct-2                                                       24.67µ ± 2%                                 24.62µ ± 0%       ~ (p=0.105 n=10)
Unmarshal/ReferenceFile/map-2                                                          35.21µ ± 2%                                 35.18µ ± 0%       ~ (p=0.469 n=10)
Unmarshal/HugoFrontMatter-2                                                            5.932µ ± 1%                                 5.929µ ± 0%       ~ (p=0.644 n=10)
Marshal/SimpleDocument/struct-2                                                        203.7n ± 1%                                 205.0n ± 1%  +0.64% (p=0.011 n=10)
Marshal/SimpleDocument/map-2                                                           259.0n ± 0%                                 259.6n ± 0%       ~ (p=0.078 n=10)
Marshal/ReferenceFile/struct-2                                                         17.76µ ± 2%                                 17.66µ ± 0%  -0.52% (p=0.035 n=10)
Marshal/ReferenceFile/map-2                                                            21.55µ ± 0%                                 21.53µ ± 0%       ~ (p=0.631 n=10)
Marshal/HugoFrontMatter-2                                                              4.117µ ± 0%                                 4.112µ ± 0%       ~ (p=0.643 n=10)
geomean                                                                                53.03µ                                      52.79µ       -0.45%

                                  │ /var/folders/4x/hhbzwffd2d5c3n6z2b09b91c000_0t/T/v2.RfSXGXt4GH │ /var/folders/4x/hhbzwffd2d5c3n6z2b09b91c000_0t/T/HEAD.Cu81ZqvZ38 │
                                  │                              B/s                               │                    B/s                     vs base               │
UnmarshalDataset/config-2                                                             102.1Mi ± 1%                                100.2Mi ± 0%  -1.80% (p=0.002 n=10)
UnmarshalDataset/canada-2                                                             54.10Mi ± 3%                                54.79Mi ± 1%       ~ (p=0.110 n=10)
UnmarshalDataset/citm_catalog-2                                                       44.36Mi ± 2%                                46.25Mi ± 1%  +4.27% (p=0.000 n=10)
UnmarshalDataset/twitter-2                                                            89.32Mi ± 4%                                90.61Mi ± 0%  +1.45% (p=0.000 n=10)
UnmarshalDataset/code-2                                                               54.99Mi ± 1%                                55.72Mi ± 1%  +1.33% (p=0.000 n=10)
UnmarshalDataset/example-2                                                            89.24Mi ± 2%                                89.57Mi ± 0%  +0.37% (p=0.015 n=10)
Unmarshal/SimpleDocument/struct-2                                                     38.35Mi ± 2%                                38.29Mi ± 0%       ~ (p=0.470 n=10)
Unmarshal/SimpleDocument/map-2                                                        27.24Mi ± 3%                                27.35Mi ± 0%       ~ (p=0.305 n=10)
Unmarshal/ReferenceFile/struct-2                                                      202.6Mi ± 2%                                203.1Mi ± 0%       ~ (p=0.093 n=10)
Unmarshal/ReferenceFile/map-2                                                         142.0Mi ± 2%                                142.1Mi ± 0%       ~ (p=0.469 n=10)
Unmarshal/HugoFrontMatter-2                                                           87.79Mi ± 1%                                87.82Mi ± 0%       ~ (p=0.616 n=10)
Marshal/SimpleDocument/struct-2                                                       56.17Mi ± 1%                                55.81Mi ± 1%  -0.64% (p=0.011 n=10)
Marshal/SimpleDocument/map-2                                                          44.18Mi ± 0%                                44.08Mi ± 0%       ~ (p=0.085 n=10)
Marshal/ReferenceFile/struct-2                                                        110.5Mi ± 2%                                111.1Mi ± 0%  +0.53% (p=0.035 n=10)
Marshal/ReferenceFile/map-2                                                           88.77Mi ± 0%                                88.88Mi ± 0%       ~ (p=0.617 n=10)
Marshal/HugoFrontMatter-2                                                             121.2Mi ± 0%                                121.3Mi ± 0%       ~ (p=0.616 n=10)
geomean                                                                               74.15Mi                                     74.49Mi       +0.45%

                                  │ /var/folders/4x/hhbzwffd2d5c3n6z2b09b91c000_0t/T/v2.RfSXGXt4GH │ /var/folders/4x/hhbzwffd2d5c3n6z2b09b91c000_0t/T/HEAD.Cu81ZqvZ38 │
                                  │                              B/op                              │                  B/op                    vs base                 │
UnmarshalDataset/config-2                                                             5.452Mi ± 0%                              5.452Mi ± 0%       ~ (p=0.645 n=10)
UnmarshalDataset/canada-2                                                             76.24Mi ± 0%                              76.24Mi ± 0%       ~ (p=0.303 n=10)
UnmarshalDataset/citm_catalog-2                                                       32.87Mi ± 0%                              32.87Mi ± 0%       ~ (p=0.324 n=10)
UnmarshalDataset/twitter-2                                                            11.95Mi ± 0%                              11.95Mi ± 0%       ~ (p=0.883 n=10)
UnmarshalDataset/code-2                                                               20.28Mi ± 0%                              20.28Mi ± 0%       ~ (p=0.987 n=10)
UnmarshalDataset/example-2                                                            180.7Ki ± 0%                              180.7Ki ± 0%       ~ (p=0.204 n=10)
Unmarshal/SimpleDocument/struct-2                                                       805.0 ± 0%                                805.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map-2                                                        1.106Ki ± 0%                              1.106Ki ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct-2                                                      15.49Ki ± 0%                              15.49Ki ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map-2                                                         32.39Ki ± 0%                              32.39Ki ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter-2                                                           7.429Ki ± 0%                              7.429Ki ± 0%       ~ (p=1.000 n=10)
Marshal/SimpleDocument/struct-2                                                         232.0 ± 0%                                232.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map-2                                                            248.0 ± 0%                                248.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct-2                                                        27.05Ki ± 0%                              27.05Ki ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map-2                                                           23.98Ki ± 0%                              23.98Ki ± 0%       ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter-2                                                             5.266Ki ± 0%                              5.266Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                               70.92Ki                                   70.92Ki       -0.00%
¹ all samples are equal

                                  │ /var/folders/4x/hhbzwffd2d5c3n6z2b09b91c000_0t/T/v2.RfSXGXt4GH │ /var/folders/4x/hhbzwffd2d5c3n6z2b09b91c000_0t/T/HEAD.Cu81ZqvZ38 │
                                  │                           allocs/op                            │                allocs/op                 vs base                 │
UnmarshalDataset/config-2                                                              219.2k ± 0%                               219.2k ± 0%       ~ (p=1.000 n=10) ¹
UnmarshalDataset/canada-2                                                              670.4k ± 0%                               670.4k ± 0%       ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog-2                                                        178.0k ± 0%                               178.0k ± 0%       ~ (p=1.000 n=10)
UnmarshalDataset/twitter-2                                                             55.65k ± 0%                               55.65k ± 0%       ~ (p=1.000 n=10) ¹
UnmarshalDataset/code-2                                                                1.001M ± 0%                               1.001M ± 0%       ~ (p=1.000 n=10) ¹
UnmarshalDataset/example-2                                                             1.326k ± 0%                               1.326k ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct-2                                                       8.000 ± 0%                                8.000 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map-2                                                          12.00 ± 0%                                12.00 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct-2                                                        158.0 ± 0%                                158.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map-2                                                           619.0 ± 0%                                619.0 ± 0%       ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter-2                                                             142.0 ± 0%                                142.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct-2                                                         7.000 ± 0%                                7.000 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map-2                                                            8.000 ± 0%                                8.000 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct-2                                                          226.0 ± 0%                                226.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map-2                                                             344.0 ± 0%                                344.0 ± 0%       ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter-2                                                               73.00 ± 0%                                73.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                                                 987.5                                     987.5       +0.00%
¹ all samples are equal
```