### PR TITLE
Unwrap strict errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -78,7 +78,7 @@ func (e *DecodeError) Key() Key {
 	return e.key
 }
 
-// decodeErrorFromHighlight creates a DecodeError referencing a highlighted
+// wrapDecodeError creates a DecodeError referencing a highlighted
 // range of bytes from document.
 //
 // highlight needs to be a sub-slice of document, or this function panics.

--- a/errors.go
+++ b/errors.go
@@ -54,6 +54,17 @@ func (s *StrictMissingError) String() string {
 	return buf.String()
 }
 
+// Unwrap returns wrapped decode errors
+//
+// Implements errors.Join() interface.
+func (s *StrictMissingError) Unwrap() []error {
+	var errs []error
+	for i := range s.Errors {
+		errs = append(errs, &s.Errors[i])
+	}
+	return errs
+}
+
 type Key []string
 
 // Error returns the error message contained in the DecodeError.

--- a/errors_test.go
+++ b/errors_test.go
@@ -205,6 +205,21 @@ func TestDecodeError_Accessors(t *testing.T) {
 	assert.Equal(t, "bar", e.String())
 }
 
+func TestStrictErrorUnwrap(t *testing.T) {
+	fo := bytes.NewBufferString(`
+Missing = 1
+OtherMissing = 1
+`)
+	var out struct{}
+	err := NewDecoder(fo).DisallowUnknownFields().Decode(&out)
+	assert.Error(t, err)
+
+	strictErr := &StrictMissingError{}
+	assert.True(t, errors.As(err, &strictErr))
+
+	assert.Equal(t, 2, len(strictErr.Unwrap()))
+}
+
 func ExampleDecodeError() {
 	doc := `name = 123__456`
 


### PR DESCRIPTION
<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->

`Unwrap() error` and `Unwrap() []error` are common API implemented by standard `errors` package.

I suggest to simply implement `Unwrap() []error` on `StrictMissingError()` to ease handling of wrapped decode errors.

What do you think of this ?
