### PR TITLE
Use constant format strings with Printf-like functions

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -22,7 +22,7 @@ type Program struct {
 }
 
 func (p *Program) Execute() {
-	flag.Usage = func() { fmt.Fprintf(os.Stderr, p.Usage) }
+	flag.Usage = func() { fmt.Fprint(os.Stderr, p.Usage) }
 	flag.Parse()
 	os.Exit(p.main(flag.Args(), os.Stdin, os.Stdout, os.Stderr))
 }

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -1034,7 +1034,7 @@ func (d *decoder) unmarshalInteger(value *unstable.Node, v reflect.Value) error 
 	case reflect.Interface:
 		r = reflect.ValueOf(i)
 	default:
-		return unstable.NewParserError(d.p.Raw(value.Raw), d.typeMismatchString("integer", v.Type()))
+		return unstable.NewParserError(d.p.Raw(value.Raw), "%s", d.typeMismatchString("integer", v.Type()))
 	}
 
 	if !r.Type().AssignableTo(v.Type()) {
@@ -1053,7 +1053,7 @@ func (d *decoder) unmarshalString(value *unstable.Node, v reflect.Value) error {
 	case reflect.Interface:
 		v.Set(reflect.ValueOf(string(value.Data)))
 	default:
-		return unstable.NewParserError(d.p.Raw(value.Raw), d.typeMismatchString("string", v.Type()))
+		return unstable.NewParserError(d.p.Raw(value.Raw), "%s", d.typeMismatchString("string", v.Type()))
 	}
 
 	return nil


### PR DESCRIPTION
Recent versions of Go object to the use of non-constant variables a format strings. This commit fixes errors like this:

cli.go:26:47: non-constant format string in call to fmt.Fprintf