### PR TITLE
Windows arm build removal

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,6 @@ builds:
       - linux_riscv64
       - windows_amd64
       - windows_arm64
-      - windows_arm
       - darwin_amd64
       - darwin_arm64
   - id: tomljson
@@ -42,7 +41,6 @@ builds:
       - linux_riscv64
       - windows_amd64
       - windows_arm64
-      - windows_arm
       - darwin_amd64
       - darwin_arm64
   - id: jsontoml
@@ -62,7 +60,6 @@ builds:
       - linux_arm
       - windows_amd64
       - windows_arm64
-      - windows_arm
       - darwin_amd64
       - darwin_arm64
 universal_binaries:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!--

Thank you for your pull request!

Please read the Code changes section of the CONTRIBUTING.md file,
and make sure you have followed the instructions.

https://github.com/pelletier/go-toml/blob/v2/CONTRIBUTING.md#code-changes

-->

Removes the `windows/arm` build target from the GoReleaser configuration.

---

The `release-check` CI job in PR #1030 was failing because Go 1.26, which is used in the CI, no longer supports the `windows/arm` (32-bit) GOOS/GOARCH pair, resulting in an `unsupported GOOS/GOARCH pair windows/arm` error. The `.goreleaser.yaml` file explicitly listed `windows_arm` as a target for the `tomll`, `tomljson`, and `jsontoml` binaries. This PR removes `windows_arm` from these targets to resolve the build failure. `windows_arm64` and other `arm` targets (e.g., `linux_arm`) remain unaffected.

---

N/A (build configuration change)

---
<p><a href="https://cursor.com/agents/bc-917ef6c7-609a-4ba0-ac4b-88098d5b8e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-917ef6c7-609a-4ba0-ac4b-88098d5b8e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->