### PR TITLE
Fix parser error pointing to wrong line at EOF without trailing newline

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -259,6 +259,12 @@ func TestDecodeError_Position(t *testing.T) {
 			expectedRow: 3,
 			minCol:      5,
 		},
+		{
+			name:        "missing equals on last line without trailing newline",
+			doc:         "a = 1\nb = 2\nc",
+			expectedRow: 3,
+			minCol:      1,
+		},
 	}
 
 	for _, e := range examples {

--- a/unstable/parser.go
+++ b/unstable/parser.go
@@ -345,7 +345,7 @@ func (p *Parser) parseKeyval(b []byte) (reference, []byte, error) {
 	b = p.parseWhitespace(b)
 
 	if len(b) == 0 {
-		return invalidReference, nil, NewParserError(b, "expected = after a key, but the document ends there")
+		return invalidReference, nil, NewParserError(startB[:len(startB)-len(b)], "expected = after a key, but the document ends there")
 	}
 
 	b, err = expect('=', b)


### PR DESCRIPTION
## Summary

- Fix error highlight pointing to line 1 instead of the correct line when parsing a key missing `=` at EOF without a trailing newline (e.g., `a = 1\nb = 2\nc`)
- The root cause was `NewParserError` receiving an empty byte slice as the highlight, causing `subsliceOffset` to return 0. Now passes the consumed key bytes (`startB`) as the highlight instead.
- Add regression test for this scenario

Fixes #1032

## Error output example

Given this input (no trailing newline after `c`):
```toml
a = 1
b = 2
c
```

**Before** (error incorrectly points to line 1):
```
1| a = 1
 |  expected = after a key, but the document ends there
2| b = 2
3| c
```

**After** (error correctly points to line 3):
```
1| a = 1
2| b = 2
3| c
 | ~ expected = after a key, but the document ends there
```

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New test case `TestDecodeError_Position/missing_equals_on_last_line_without_trailing_newline` verifies error points to line 3
- [x] Manual verification confirms correct error output as shown above

https://claude.ai/code/session_01UWv8pyc8P1ktAPfHpveixj