### PR TITLE
Fix goreleaser deprecation warnings

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,39 +74,43 @@ universal_binaries:
     name_template: jsontoml
 archives:
 - id: jsontoml
-  format: tar.xz
-  builds:
+  formats:
+    - tar.xz
+  ids:
     - jsontoml
   files:
   - none*
   name_template: "{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}"
 - id: tomljson
-  format: tar.xz
-  builds:
+  formats:
+    - tar.xz
+  ids:
     - tomljson
   files:
   - none*
   name_template: "{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}"
 - id: tomll
-  format: tar.xz
-  builds:
+  formats:
+    - tar.xz
+  ids:
     - tomll
   files:
   - none*
   name_template: "{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}"
-dockers:
+dockers_v2:
   - id: tools
-    goos: linux
-    goarch: amd64
     ids:
       - jsontoml
       - tomljson
       - tomll
-    image_templates:
-      - "ghcr.io/pelletier/go-toml:latest"
-      - "ghcr.io/pelletier/go-toml:{{ .Tag }}"
-      - "ghcr.io/pelletier/go-toml:v{{ .Major }}"
-    skip_push: false
+    images:
+      - "ghcr.io/pelletier/go-toml"
+    tags:
+      - "latest"
+      - "{{ .Tag }}"
+      - "v{{ .Major }}"
+    platforms:
+      - linux/amd64
 checksum:
   name_template: 'sha256sums.txt'
 snapshot:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM scratch
 ENV PATH "$PATH:/bin"
-COPY tomll /bin/tomll
-COPY tomljson /bin/tomljson
-COPY jsontoml /bin/jsontoml
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/tomll /bin/tomll
+COPY $TARGETPLATFORM/tomljson /bin/tomljson
+COPY $TARGETPLATFORM/jsontoml /bin/jsontoml


### PR DESCRIPTION
## Summary

- **`archives.format` → `archives.formats`**: Changed from a single string to a list, per [deprecation notice](https://goreleaser.com/deprecations#archivesformat)
- **`archives.builds` → `archives.ids`**: Renamed for consistency with the rest of goreleaser, per [deprecation notice](https://goreleaser.com/deprecations#archivesbuilds)
- **`dockers` → `dockers_v2`**: Migrated to the new consolidated docker config format, per [deprecation notice](https://goreleaser.com/deprecations#dockers). Updated `Dockerfile` to use `TARGETPLATFORM` build arg as required by the new format.

## Test plan

- [ ] Run `goreleaser check` to validate the config
- [ ] Run a snapshot release (`goreleaser release --snapshot --clean`) to verify archives and docker build work correctly
- [ ] Verify no deprecation warnings appear in output

https://claude.ai/code/session_01QqkHTjwoFvsNUXtQj3RaU8