### PR TITLE
README.md: remove reference to old go versions and modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ documentation.
 import "github.com/pelletier/go-toml/v2"
 ```
 
-See [Modules](#Modules).
-
 ## Features
 
 ### Stdlib behavior

--- a/README.md
+++ b/README.md
@@ -273,20 +273,6 @@ provided for completeness.</p>
 <p>This table can be generated with <code>./ci.sh benchmark -a -html</code>.</p>
 </details>
 
-## Modules
-
-go-toml uses Go's standard modules system.
-
-Installation instructions:
-
-- Go ≥ 1.16: Nothing to do. Use the import in your code. The `go` command deals
-  with it automatically.
-- Go ≥ 1.13: `GO111MODULE=on go get github.com/pelletier/go-toml/v2`.
-
-In case of trouble: [Go Modules FAQ][mod-faq].
-
-[mod-faq]: https://github.com/golang/go/wiki/Modules#why-does-installing-a-tool-via-go-get-fail-with-error-cannot-find-main-module
-
 ## Tools
 
 Go-toml provides three handy command line tools:


### PR DESCRIPTION
go.mod requires 1.21. We're long past 1.13, so there's no point in having reference to go modules in the README.md, this is just confusing for the readers.

No code change.

