### PR TITLE
Change "missing field" to "unknown field" in strict mode errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -24,9 +24,9 @@ type DecodeError struct {
 	human string
 }
 
-// StrictMissingError occurs in a TOML document that does not have a
-// corresponding field in the target value. It contains all the missing fields
-// in Errors.
+// StrictMissingError occurs when the TOML document contains fields that do not
+// have a corresponding field in the target value. It contains all the unknown
+// fields in Errors.
 //
 // Emitted by Decoder when DisallowUnknownFields() was called.
 type StrictMissingError struct {
@@ -36,7 +36,7 @@ type StrictMissingError struct {
 
 // Error returns the canonical string for this error.
 func (s *StrictMissingError) Error() string {
-	return "strict mode: fields in the document are missing in the target struct"
+	return "strict mode: fields in the document are unknown to the target struct"
 }
 
 // String returns a human readable description of all errors.

--- a/strict.go
+++ b/strict.go
@@ -68,7 +68,7 @@ func (s *strict) MissingField(node *unstable.Node) {
 
 	s.missing = append(s.missing, unstable.ParserError{
 		Highlight: s.keyLocation(node),
-		Message:   "missing field",
+		Message:   "unknown field",
 		Key:       s.key.Key(),
 	})
 }

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -48,7 +48,7 @@ func NewDecoder(r io.Reader) *Decoder {
 //
 // In that case, the Decoder returns a StrictMissingError that can be used to
 // retrieve the individual errors as well as generate a human readable
-// description of the missing fields.
+// description of the unknown fields.
 func (d *Decoder) DisallowUnknownFields() *Decoder {
 	d.strict = true
 	return d

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -62,10 +62,10 @@ key3 = "value3"
 
 	fmt.Println(details.String())
 	// Output:
-	// strict mode: fields in the document are missing in the target struct
+	// strict mode: fields in the document are unknown to the target struct
 	// 2| key1 = "value1"
 	// 3| key2 = "value2"
-	//  | ~~~~ missing field
+	//  | ~~~~ unknown field
 	// 4| key3 = "value3"
 }
 
@@ -2387,14 +2387,14 @@ key4 = "value4"
 `,
 			expected: `2| key1 = "value1"
 3| key2 = "missing2"
- | ~~~~ missing field
+ | ~~~~ unknown field
 4| key3 = "missing3"
 5| key4 = "value4"
 ---
 2| key1 = "value1"
 3| key2 = "missing2"
 4| key3 = "missing3"
- | ~~~~ missing field
+ | ~~~~ unknown field
 5| key4 = "value4"`,
 			target: &struct {
 				Key1 string
@@ -2405,7 +2405,7 @@ key4 = "value4"
 			desc:  "multi-part key",
 			input: `a.short.key="foo"`,
 			expected: `1| a.short.key="foo"
- | ~~~~~~~~~~~ missing field`,
+ | ~~~~~~~~~~~ unknown field`,
 		},
 		{
 			desc: "missing table",


### PR DESCRIPTION
When `DisallowUnknownFields` is enabled and the TOML document contains a key
that doesn't match a struct field, the diagnostic annotation says "missing
field". This reads as though the TOML file is lacking something, when really it
contains something the decoder doesn't recognize.

This changes the user-facing message from "missing field" to "unknown field",
which is consistent with the `DisallowUnknownFields` API name and describes the
problem from the user's point of view.

The `StrictMissingError` type name is left unchanged to avoid a breaking API
change.

---

No performance-sensitive code paths are changed (string literals only), so
benchstat is not applicable.