### PR TITLE
Fix parser error position after comment lines

### DIFF
--- a/unstable/parser.go
+++ b/unstable/parser.go
@@ -3,6 +3,7 @@ package unstable
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"unicode"
 
 	"github.com/pelletier/go-toml/v2/internal/characters"
@@ -83,10 +84,18 @@ func (p *Parser) rangeOfToken(token, rest []byte) Range {
 }
 
 // subsliceOffset returns the byte offset of subslice b within p.data.
-// b must be a suffix (tail) of p.data.
+// b must share the same backing array as p.data.
 func (p *Parser) subsliceOffset(b []byte) int {
-	// b is a suffix of p.data, so its offset is len(p.data) - len(b)
-	return len(p.data) - len(b)
+	if len(b) == 0 {
+		return len(p.data)
+	}
+	dataPtr := reflect.ValueOf(p.data).Pointer()
+	subPtr := reflect.ValueOf(b).Pointer()
+	offset := int(subPtr - dataPtr)
+	if offset < 0 || offset > len(p.data) {
+		panic("subslice is not within parser input")
+	}
+	return offset
 }
 
 // Raw returns the slice corresponding to the bytes in the given range.

--- a/unstable/parser_test.go
+++ b/unstable/parser_test.go
@@ -695,3 +695,27 @@ func ExampleParser() {
 	// Expression: KeyValue
 	// value -> (Integer) 42
 }
+
+func TestParser_ErrorPositionAfterComment(t *testing.T) {
+	// Regression test for https://github.com/pelletier/go-toml/issues/1047
+	// Error position should point to the "=" at byte offset 10 (line 2, column 1),
+	// not to a wrong offset computed by assuming the highlight is a suffix of the input.
+	input := []byte("# comment\n= \"value\"")
+
+	p := Parser{}
+	p.Reset(input)
+	for p.NextExpression() {
+	}
+	err := p.Error()
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+
+	perr := err.(*ParserError)
+	r := p.Range(perr.Highlight)
+	shape := p.Shape(r)
+
+	assert.Equal(t, uint32(10), r.Offset)
+	assert.Equal(t, 2, shape.Start.Line)
+	assert.Equal(t, 1, shape.Start.Column)
+}


### PR DESCRIPTION
## Summary

Fix `unstable.Parser` reporting wrong error positions when the error occurs after a comment line.

`subsliceOffset` assumed highlight slices were always suffixes of the input, using `len(data) - len(b)` to compute the offset. After comment lines are skipped, error highlights are interior subslices, not suffixes, causing incorrect positions.

Fixes #1047

## Error position example

Given input `# comment\n= "value"`:

**Before** — `=` is at byte 10 (line 2, col 1), but reported at byte 18 (line 2, col 9)

**After** — correctly reported at byte 10 (line 2, col 1)

## Fix

Use pointer comparison via `reflect.ValueOf().Pointer()`, matching the approach already used in `errors.go`'s `subsliceOffset`.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New regression test `TestParser_ErrorPositionAfterComment` verifies correct offset and position