### PR TITLE
fix: omitempty should not treat TextMarshaler types as empty

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -449,8 +449,21 @@ func (enc *Encoder) commented(commented bool, b []byte) []byte {
 }
 
 func isEmptyValue(v reflect.Value) bool {
+	// For types that implement isZeroer (custom IsZero), defer to that.
+	if v.Type().Implements(isZeroerType) {
+		return v.Interface().(isZeroer).IsZero()
+	}
+	if v.CanAddr() && reflect.PointerTo(v.Type()).Implements(isZeroerType) {
+		return v.Addr().Interface().(isZeroer).IsZero()
+	}
+
 	switch v.Kind() {
 	case reflect.Struct:
+		// Types that implement TextMarshaler (e.g. netip.Addr) may have no
+		// exported fields. Fall back to reflect.IsZero instead of checking fields.
+		if v.Type().Implements(textMarshalerType) || reflect.PointerTo(v.Type()).Implements(textMarshalerType) {
+			return v.IsZero()
+		}
 		return isEmptyStruct(v)
 	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
 		return v.Len() == 0


### PR DESCRIPTION
Fixes #955

## Problem

Types like `netip.Addr` implement `encoding.TextMarshaler` but have no exported fields. `isEmptyValue` checks struct emptiness by iterating exported fields, so these types are always treated as empty:

```go
type Config struct {
    IP netip.Addr `toml:"ip,omitempty"`
}

// netip.MustParseAddr("192.168.1.1") → omitted! (no exported fields = "empty")
```

## Fix

1. Check `isZeroer` interface first (types with custom `IsZero()` like `time.Time`)
2. For `TextMarshaler` types, use `reflect.IsZero` instead of field-based check
3. Fall back to existing field-based check for regular structs

This ensures that `netip.Addr`, `uuid.UUID`, and other TextMarshaler types are only omitted when they are truly zero-valued.

All existing tests pass.