### PR TITLE
marshaler: respect TextMarshaler and IsZero in shouldOmitEmpty

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -390,32 +390,27 @@ func shouldOmitEmpty(options valueOptions, v reflect.Value) bool {
 		return false
 	}
 
-	// If the value implements IsZero() use it, like shouldOmitZero does.
-	// This is important for types such as netip.Addr that have no exported
-	// fields (making isEmptyStruct incorrectly report them as empty) but do
-	// implement a meaningful zero check.
-	if v.Type().Implements(isZeroerType) {
-		return v.Interface().(isZeroer).IsZero()
-	}
-	if reflect.PointerTo(v.Type()).Implements(isZeroerType) {
-		if v.CanAddr() {
-			return v.Addr().Interface().(isZeroer).IsZero()
-		}
-		pv := reflect.New(v.Type())
-		pv.Elem().Set(v)
-		return pv.Interface().(isZeroer).IsZero()
-	}
-
-	// If the value implements TextMarshaler, fall back to reflect.Value.IsZero
-	// rather than the struct-field scan in isEmptyStruct.  A struct with no
-	// exported fields (e.g. netip.Addr) would otherwise always be considered
-	// empty even when it holds a meaningful value.
+	// isEmptyValue only considers exported fields of structs, so a struct
+	// without any exported field (e.g. netip.Addr or time.Time) would always
+	// be reported as empty. For structs, prefer the type's own IsZero() method
+	// when it has one, like shouldOmitZero does, and otherwise fall back to
+	// reflect.Value.IsZero when the struct encodes itself through
+	// encoding.TextMarshaler.
 	if v.Kind() == reflect.Struct {
-		hasMarshaler := v.Type().Implements(textMarshalerType)
-		if !hasMarshaler && v.CanAddr() {
-			hasMarshaler = reflect.PointerTo(v.Type()).Implements(textMarshalerType)
+		if v.Type().Implements(isZeroerType) {
+			return v.Interface().(isZeroer).IsZero()
 		}
-		if hasMarshaler {
+		if reflect.PointerTo(v.Type()).Implements(isZeroerType) {
+			if v.CanAddr() {
+				return v.Addr().Interface().(isZeroer).IsZero()
+			}
+			// Create a temporary addressable copy to call the pointer
+			// receiver method.
+			pv := reflect.New(v.Type())
+			pv.Elem().Set(v)
+			return pv.Interface().(isZeroer).IsZero()
+		}
+		if v.Type().Implements(textMarshalerType) || (v.CanAddr() && reflect.PointerTo(v.Type()).Implements(textMarshalerType)) {
 			return v.IsZero()
 		}
 	}

--- a/marshaler.go
+++ b/marshaler.go
@@ -386,7 +386,41 @@ func isNil(v reflect.Value) bool {
 }
 
 func shouldOmitEmpty(options valueOptions, v reflect.Value) bool {
-	return options.omitempty && isEmptyValue(v)
+	if !options.omitempty {
+		return false
+	}
+
+	// If the value implements IsZero() use it, like shouldOmitZero does.
+	// This is important for types such as netip.Addr that have no exported
+	// fields (making isEmptyStruct incorrectly report them as empty) but do
+	// implement a meaningful zero check.
+	if v.Type().Implements(isZeroerType) {
+		return v.Interface().(isZeroer).IsZero()
+	}
+	if reflect.PointerTo(v.Type()).Implements(isZeroerType) {
+		if v.CanAddr() {
+			return v.Addr().Interface().(isZeroer).IsZero()
+		}
+		pv := reflect.New(v.Type())
+		pv.Elem().Set(v)
+		return pv.Interface().(isZeroer).IsZero()
+	}
+
+	// If the value implements TextMarshaler, fall back to reflect.Value.IsZero
+	// rather than the struct-field scan in isEmptyStruct.  A struct with no
+	// exported fields (e.g. netip.Addr) would otherwise always be considered
+	// empty even when it holds a meaningful value.
+	if v.Kind() == reflect.Struct {
+		hasMarshaler := v.Type().Implements(textMarshalerType)
+		if !hasMarshaler && v.CanAddr() {
+			hasMarshaler = reflect.PointerTo(v.Type()).Implements(textMarshalerType)
+		}
+		if hasMarshaler {
+			return v.IsZero()
+		}
+	}
+
+	return isEmptyValue(v)
 }
 
 func shouldOmitZero(options valueOptions, v reflect.Value) bool {

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1188,6 +1188,74 @@ func TestEncoderOmitemptyTextMarshalerZero(t *testing.T) {
 	assert.Equal(t, "", string(b))
 }
 
+// TestEncoderOmitemptyPointerTextMarshaler covers structs whose TextMarshaler
+// implementation uses a pointer receiver: the value must be addressable for
+// the marshaler to apply, in which case omitempty falls back to
+// reflect.Value.IsZero.
+func TestEncoderOmitemptyPointerTextMarshaler(t *testing.T) {
+	type doc struct {
+		V customTextMarshaler `toml:"v,omitempty"`
+	}
+
+	d := doc{V: customTextMarshaler{value: 2}}
+	b, err := toml.Marshal(&d)
+	assert.NoError(t, err)
+	assert.Equal(t, "v = '::2'\n", string(b))
+
+	d = doc{}
+	b, err = toml.Marshal(&d)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(b))
+}
+
+// TestEncoderOmitemptyCustomIsZero verifies that omitempty uses a custom
+// IsZero method when the struct provides one, like omitzero does.
+func TestEncoderOmitemptyCustomIsZero(t *testing.T) {
+	type doc struct {
+		Custom customZeroType `toml:",omitempty"`
+	}
+
+	// Value = 5 is non-empty for isEmptyStruct, but the custom IsZero
+	// returns true for values < 10, and takes precedence.
+	d := doc{Custom: customZeroType{Value: 5}}
+	b, err := toml.Marshal(d)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(b))
+
+	d = doc{Custom: customZeroType{Value: 15}}
+	b, err = toml.Marshal(d)
+	assert.NoError(t, err)
+	assert.Equal(t, "[Custom]\nValue = 15\n", string(b))
+}
+
+// TestEncoderOmitemptyCustomIsZeroPointerReceiver is the same as
+// TestEncoderOmitemptyCustomIsZero for a type implementing IsZero on its
+// pointer receiver. Marshaling the document by value exercises the
+// non-addressable code path, and by pointer the addressable one.
+func TestEncoderOmitemptyCustomIsZeroPointerReceiver(t *testing.T) {
+	type doc struct {
+		Custom customZeroPointerType `toml:",omitempty"`
+	}
+
+	d := doc{Custom: customZeroPointerType{Value: 5}}
+	b, err := toml.Marshal(d)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(b))
+
+	b, err = toml.Marshal(&d)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(b))
+
+	d = doc{Custom: customZeroPointerType{Value: 15}}
+	b, err = toml.Marshal(d)
+	assert.NoError(t, err)
+	assert.Equal(t, "[Custom]\nValue = 15\n", string(b))
+
+	b, err = toml.Marshal(&d)
+	assert.NoError(t, err)
+	assert.Equal(t, "[Custom]\nValue = 15\n", string(b))
+}
+
 func TestEncoderOmitzero(t *testing.T) {
 	type doc struct {
 		String  string            `toml:",omitzero,multiline"`

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1159,6 +1159,35 @@ func TestEncoderOmitempty(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+// TestEncoderOmitemptyTextMarshalerNonZero is a regression test for
+// https://github.com/pelletier/go-toml/issues/955.
+// A struct that implements encoding.TextMarshaler but has no exported fields
+// (e.g. netip.Addr) must not be considered "empty" by omitempty when it holds
+// a non-zero value.
+func TestEncoderOmitemptyTextMarshalerNonZero(t *testing.T) {
+	type doc struct {
+		IP netip.Addr `toml:"ip,omitempty"`
+	}
+
+	d := doc{IP: netip.MustParseAddr("192.168.178.35")}
+	b, err := toml.Marshal(d)
+	assert.NoError(t, err)
+	assert.Equal(t, "ip = '192.168.178.35'\n", string(b))
+}
+
+// TestEncoderOmitemptyTextMarshalerZero verifies that a zero netip.Addr is
+// still omitted when omitempty is set.
+func TestEncoderOmitemptyTextMarshalerZero(t *testing.T) {
+	type doc struct {
+		IP netip.Addr `toml:"ip,omitempty"`
+	}
+
+	d := doc{} // zero netip.Addr
+	b, err := toml.Marshal(d)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(b))
+}
+
 func TestEncoderOmitzero(t *testing.T) {
 	type doc struct {
 		String  string            `toml:",omitzero,multiline"`


### PR DESCRIPTION
## Summary

Fixes #955.

`isEmptyStruct` scans exported struct fields; a struct with no exported fields (e.g. `netip.Addr`) was always considered empty, so any such struct field tagged `omitempty` was always omitted even when it held a meaningful value.

### Root cause

`isEmptyStruct` iterates over exported fields. `netip.Addr` has none, so the loop exits immediately and returns `true` (empty) regardless of the addr's value.

### Fix

`shouldOmitEmpty` is updated to mirror the logic already in `shouldOmitZero`:

1. **`IsZero()` wins** — if the type (or its pointer) implements the `isZeroer` interface, use that, exactly as `shouldOmitZero` does.
2. **TextMarshaler fallback** — if the type is a struct that implements `encoding.TextMarshaler` but not `isZeroer`, fall back to `reflect.Value.IsZero()` rather than the exported-field scan.

### Before

```go
// netip.Addr{"192.168.178.35"} is silently dropped — ip key absent
```

### After

```go
// ip = '192.168.178.35'  — correctly emitted
```

## Tests

- `TestEncoderOmitemptyTextMarshalerNonZero` — non-zero `netip.Addr` with `omitempty` is emitted
- `TestEncoderOmitemptyTextMarshalerZero` — zero `netip.Addr` is still omitted
- Full `go test ./...` passes