### PR TITLE
fix: change DisallowUnknownFields error from "missing field" to "unknown field"

### DIFF
--- a/strict.go
+++ b/strict.go
@@ -68,7 +68,7 @@ func (s *strict) MissingField(node *unstable.Node) {
 
 	s.missing = append(s.missing, unstable.ParserError{
 		Highlight: s.keyLocation(node),
-		Message:   "missing field",
+		Message:   "unknown field",
 		Key:       s.key.Key(),
 	})
 }

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -65,7 +65,7 @@ key3 = "value3"
 	// strict mode: fields in the document are missing in the target struct
 	// 2| key1 = "value1"
 	// 3| key2 = "value2"
-	//  | ~~~~ missing field
+	//  | ~~~~ unknown field
 	// 4| key3 = "value3"
 }
 
@@ -2387,14 +2387,14 @@ key4 = "value4"
 `,
 			expected: `2| key1 = "value1"
 3| key2 = "missing2"
- | ~~~~ missing field
+ | ~~~~ unknown field
 4| key3 = "missing3"
 5| key4 = "value4"
 ---
 2| key1 = "value1"
 3| key2 = "missing2"
 4| key3 = "missing3"
- | ~~~~ missing field
+ | ~~~~ unknown field
 5| key4 = "value4"`,
 			target: &struct {
 				Key1 string
@@ -2405,7 +2405,7 @@ key4 = "value4"
 			desc:  "multi-part key",
 			input: `a.short.key="foo"`,
 			expected: `1| a.short.key="foo"
- | ~~~~~~~~~~~ missing field`,
+ | ~~~~~~~~~~~ unknown field`,
 		},
 		{
 			desc: "missing table",


### PR DESCRIPTION
Fixes #1049

## Problem

When `DisallowUnknownFields()` is enabled, the diagnostic annotation says:

```
1| [services.web]
2| typo_field = "value"
   | ~~~~~~~~~~ missing field
```

This is misleading — it reads as though the TOML file is *missing* something required. The field is actually *unknown* to the target struct.

## Fix

Change the error message from `"missing field"` to `"unknown field"`, consistent with the `DisallowUnknownFields` API name.

## Testing

All existing tests pass (updated test expectations to match).