### PR TITLE
Fix incorrect error positions in unstable parser Range() (#1047)

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -301,6 +301,123 @@ OtherMissing = 1
 	assert.Equal(t, 2, len(strictErr.Unwrap()))
 }
 
+func TestDecodeError_PositionAfterComments(t *testing.T) {
+	examples := []struct {
+		name        string
+		doc         string
+		expectedRow int
+		expectedCol int
+	}{
+		{
+			name:        "comment then invalid key start",
+			doc:         "# comment\n= \"value\"",
+			expectedRow: 2,
+			expectedCol: 1,
+		},
+		{
+			name:        "no comment invalid key start",
+			doc:         "= \"value\"",
+			expectedRow: 1,
+			expectedCol: 1,
+		},
+		{
+			name:        "multiple comments then error",
+			doc:         "# c1\n# c2\n= \"val\"",
+			expectedRow: 3,
+			expectedCol: 1,
+		},
+		{
+			name:        "valid line then invalid key start",
+			doc:         "a = 1\n= \"val\"",
+			expectedRow: 2,
+			expectedCol: 1,
+		},
+		{
+			name:        "blank lines then error",
+			doc:         "\n\n= \"val\"",
+			expectedRow: 3,
+			expectedCol: 1,
+		},
+		{
+			name:        "expected newline but got invalid char",
+			doc:         "a = 1 b = 2",
+			expectedRow: 1,
+			expectedCol: 7,
+		},
+	}
+
+	for _, e := range examples {
+		t.Run(e.name, func(t *testing.T) {
+			var v interface{}
+			err := Unmarshal([]byte(e.doc), &v)
+
+			var derr *DecodeError
+			if !errors.As(err, &derr) {
+				t.Fatal("error not in expected format")
+			}
+
+			row, col := derr.Position()
+			if row != e.expectedRow {
+				t.Errorf("row: got %d, want %d", row, e.expectedRow)
+			}
+			if col != e.expectedCol {
+				t.Errorf("col: got %d, want %d", col, e.expectedCol)
+			}
+		})
+	}
+}
+
+func TestErrorPositionConsistency(t *testing.T) {
+	// Verify that the unstable parser API and the public Unmarshal API
+	// report the same error positions for identical documents.
+	documents := []string{
+		"# comment\n= \"value\"",
+		"= \"value\"",
+		"# c1\n# c2\n= \"val\"",
+		"a = 1\n= \"val\"",
+		"\n\n= \"val\"",
+		"a = 1 b = 2",
+	}
+
+	for _, doc := range documents {
+		t.Run(doc, func(t *testing.T) {
+			// Get position from unstable API
+			p := unstable.Parser{}
+			p.Reset([]byte(doc))
+			for p.NextExpression() {
+			}
+			err := p.Error()
+			if err == nil {
+				t.Fatal("expected parser error")
+			}
+			perr, ok := err.(*unstable.ParserError)
+			if !ok {
+				t.Fatalf("expected *ParserError, got %T", err)
+			}
+			r := p.Range(perr.Highlight)
+			shape := p.Shape(r)
+			unstableLine := shape.Start.Line
+			unstableCol := shape.Start.Column
+
+			// Get position from public API
+			var v interface{}
+			pubErr := Unmarshal([]byte(doc), &v)
+			var derr *DecodeError
+			if !errors.As(pubErr, &derr) {
+				t.Fatal("error not in expected format")
+			}
+			pubRow, pubCol := derr.Position()
+
+			if unstableLine != pubRow {
+				t.Errorf("line mismatch: unstable=%d, public=%d", unstableLine, pubRow)
+			}
+			if unstableCol != pubCol {
+				t.Errorf("column mismatch: unstable=%d, public=%d", unstableCol, pubCol)
+			}
+		})
+	}
+}
+
 func ExampleDecodeError() {
 	doc := `name = 123__456`
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -390,8 +390,8 @@ func TestErrorPositionConsistency(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected parser error")
 			}
-			perr, ok := err.(*unstable.ParserError)
-			if !ok {
+			var perr *unstable.ParserError
+			if !errors.As(err, &perr) {
 				t.Fatalf("expected *ParserError, got %T", err)
 			}
 			r := p.Range(perr.Highlight)

--- a/unstable/parser.go
+++ b/unstable/parser.go
@@ -3,6 +3,7 @@ package unstable
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"unicode"
 
 	"github.com/pelletier/go-toml/v2/internal/characters"
@@ -83,10 +84,18 @@ func (p *Parser) rangeOfToken(token, rest []byte) Range {
 }
 
 // subsliceOffset returns the byte offset of subslice b within p.data.
-// b must be a suffix (tail) of p.data.
+// b must share the same backing array as p.data.
 func (p *Parser) subsliceOffset(b []byte) int {
-	// b is a suffix of p.data, so its offset is len(p.data) - len(b)
-	return len(p.data) - len(b)
+	if len(b) == 0 {
+		return len(p.data)
+	}
+	dataPtr := reflect.ValueOf(p.data).Pointer()
+	subPtr := reflect.ValueOf(b).Pointer()
+	offset := int(subPtr - dataPtr)
+	if offset < 0 || offset > len(p.data) {
+		panic("subslice is not within data")
+	}
+	return offset
 }
 
 // Raw returns the slice corresponding to the bytes in the given range.

--- a/unstable/parser_test.go
+++ b/unstable/parser_test.go
@@ -1,6 +1,7 @@
 package unstable
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -759,8 +760,8 @@ func TestParserErrorPosition(t *testing.T) {
 				t.Fatal("expected an error")
 			}
 
-			perr, ok := err.(*ParserError)
-			if !ok {
+			var perr *ParserError
+			if !errors.As(err, &perr) {
 				t.Fatalf("expected *ParserError, got %T", err)
 			}
 

--- a/unstable/parser_test.go
+++ b/unstable/parser_test.go
@@ -695,3 +695,87 @@ func ExampleParser() {
 	// Expression: KeyValue
 	// value -> (Integer) 42
 }
+
+func TestParserErrorPosition(t *testing.T) {
+	examples := []struct {
+		name           string
+		input          string
+		expectedOffset int
+		expectedLine   int
+		expectedColumn int
+	}{
+		{
+			name:           "comment then invalid key start",
+			input:          "# comment\n= \"value\"",
+			expectedOffset: 10,
+			expectedLine:   2,
+			expectedColumn: 1,
+		},
+		{
+			name:           "no comment invalid key start",
+			input:          "= \"value\"",
+			expectedOffset: 0,
+			expectedLine:   1,
+			expectedColumn: 1,
+		},
+		{
+			name:           "multiple comments then error",
+			input:          "# c1\n# c2\n= \"val\"",
+			expectedOffset: 10,
+			expectedLine:   3,
+			expectedColumn: 1,
+		},
+		{
+			name:           "valid line then invalid key start",
+			input:          "a = 1\n= \"val\"",
+			expectedOffset: 6,
+			expectedLine:   2,
+			expectedColumn: 1,
+		},
+		{
+			name:           "blank lines then error",
+			input:          "\n\n= \"val\"",
+			expectedOffset: 2,
+			expectedLine:   3,
+			expectedColumn: 1,
+		},
+		{
+			name:           "expected newline but got invalid char",
+			input:          "a = 1 b = 2",
+			expectedOffset: 6,
+			expectedLine:   1,
+			expectedColumn: 7,
+		},
+	}
+
+	for _, e := range examples {
+		t.Run(e.name, func(t *testing.T) {
+			p := Parser{}
+			p.Reset([]byte(e.input))
+			for p.NextExpression() {
+			}
+			err := p.Error()
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+
+			perr, ok := err.(*ParserError)
+			if !ok {
+				t.Fatalf("expected *ParserError, got %T", err)
+			}
+
+			r := p.Range(perr.Highlight)
+			shape := p.Shape(r)
+
+			if int(r.Offset) != e.expectedOffset {
+				t.Errorf("offset: got %d, want %d", r.Offset, e.expectedOffset)
+			}
+			if shape.Start.Line != e.expectedLine {
+				t.Errorf("line: got %d, want %d", shape.Start.Line, e.expectedLine)
+			}
+			if shape.Start.Column != e.expectedColumn {
+				t.Errorf("column: got %d, want %d", shape.Start.Column, e.expectedColumn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Parser.subsliceOffset() assumed its input was always a suffix of the
document, computing offset as len(data)-len(b). Error highlights from
NewParserError are arbitrary subslices (e.g. b[0:1]), not suffixes,
causing wrong offsets after comments and other consumed content.

Replace the suffix-length calculation with reflect-based pointer
arithmetic, matching the safe approach already used in errors.go.

Fixes #1047