### PR TITLE
marshaler: respect TextMarshaler and IsZero() in omitempty struct check

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -470,6 +470,29 @@ func isEmptyValue(v reflect.Value) bool {
 }
 
 func isEmptyStruct(v reflect.Value) bool {
+	// If the type has an IsZero() bool method, delegate to it.
+	// This covers types like netip.Addr that have no exported fields but carry
+	// meaningful state (e.g. a non-zero address should not be omitted).
+	if v.Type().Implements(isZeroerType) {
+		return v.MethodByName("IsZero").Call(nil)[0].Bool()
+	}
+	if v.CanAddr() && v.Addr().Type().Implements(isZeroerType) {
+		return v.Addr().MethodByName("IsZero").Call(nil)[0].Bool()
+	}
+
+	// If the type implements encoding.TextMarshaler it controls its own
+	// serialization; we cannot reliably determine emptiness from exported
+	// fields alone (which may be zero even for a non-zero value).  Treat any
+	// such value as non-empty so that omitempty only suppresses truly default
+	// zero-value instances — callers that need different behavior should
+	// implement IsZero() bool.
+	if v.Type().Implements(textMarshalerType) {
+		return false
+	}
+	if v.CanAddr() && v.Addr().Type().Implements(textMarshalerType) {
+		return false
+	}
+
 	// TODO: merge with walkStruct and cache.
 	typ := v.Type()
 	for i := 0; i < typ.NumField(); i++ {

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1159,6 +1159,34 @@ func TestEncoderOmitempty(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+// TestEncoderOmitemptyTextMarshaler checks that omitempty respects types that
+// implement encoding.TextMarshaler but have no exported fields (e.g. netip.Addr).
+// Before the fix, isEmptyStruct would return true for such types because it only
+// inspected exported fields, causing non-zero values to be silently dropped.
+func TestEncoderOmitemptyTextMarshaler(t *testing.T) {
+	type doc struct {
+		IP netip.Addr `toml:"ip,omitempty"`
+	}
+
+	t.Run("non-zero address is marshaled", func(t *testing.T) {
+		d := doc{IP: netip.MustParseAddr("192.168.178.35")}
+		b, err := toml.Marshal(d)
+		assert.NoError(t, err)
+		assert.Equal(t, "ip = '192.168.178.35'\n", string(b))
+	})
+
+	t.Run("zero address is still marshaled", func(t *testing.T) {
+		// netip.Addr has no exported IsZero method, so we cannot determine
+		// emptiness from the value alone.  For types that control their own
+		// serialization via TextMarshaler we fall back to "not empty" to avoid
+		// silently dropping values.  A zero Addr marshals to the empty string.
+		d := doc{}
+		b, err := toml.Marshal(d)
+		assert.NoError(t, err)
+		assert.Equal(t, "ip = ''\n", string(b))
+	})
+}
+
 func TestEncoderOmitzero(t *testing.T) {
 	type doc struct {
 		String  string            `toml:",omitzero,multiline"`


### PR DESCRIPTION
## Problem

Fixes #955

\`omitempty\` silently drops struct values that implement \`encoding.TextMarshaler\` but have no exported fields (e.g. \`netip.Addr\`, \`netip.Prefix\`, custom wrapper types).

Root cause: \`isEmptyStruct\` only walks **exported fields** to decide emptiness. A type like \`netip.Addr\` has no exported fields, so it always returns \`true\` → the field is skipped regardless of the actual value.

## Fix

Before the exported-field walk, \`isEmptyStruct\` now checks:

1. **\`IsZero() bool\` method** — if the type implements the \`isZeroer\` interface, delegate directly to it
2. **\`encoding.TextMarshaler\`** — if the type controls its own serialization, treat the value as non-empty

This matches the approach already used by \`shouldOmitZero\`.

## Tests

Added \`TestEncoderOmitemptyTextMarshaler\` covering \`netip.Addr\` with \`omitempty\`.