### PR TITLE
marshaler: respect TextMarshaler when checking omitempty on structs

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -470,6 +470,19 @@ func isEmptyValue(v reflect.Value) bool {
 }
 
 func isEmptyStruct(v reflect.Value) bool {
+	// A struct that marshals via TextMarshaler (netip.Addr, time.Time, ...)
+	// has no exported fields the field-walk below can see, so it would
+	// always look empty. Defer to MarshalText and treat a zero-length
+	// result as empty.
+	if v.Type().Implements(textMarshalerType) {
+		text, err := v.Interface().(encoding.TextMarshaler).MarshalText()
+		return err == nil && len(text) == 0
+	}
+	if v.CanAddr() && reflect.PointerTo(v.Type()).Implements(textMarshalerType) {
+		text, err := v.Addr().Interface().(encoding.TextMarshaler).MarshalText()
+		return err == nil && len(text) == 0
+	}
+
 	// TODO: merge with walkStruct and cache.
 	typ := v.Type()
 	for i := 0; i < typ.NumField(); i++ {

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1159,6 +1159,41 @@ func TestEncoderOmitempty(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+// Regression for #955. A struct that marshals through TextMarshaler
+// (netip.Addr is the canonical example, time.Time another) has no
+// exported fields, so the previous isEmptyStruct walk always reported
+// it as empty and the value was dropped with `omitempty`.
+func TestEncoderOmitempty_TextMarshaler(t *testing.T) {
+	t.Run("netip.Addr present is kept", func(t *testing.T) {
+		type doc struct {
+			IP netip.Addr `toml:"ip,omitempty"`
+		}
+		b, err := toml.Marshal(doc{IP: netip.MustParseAddr("192.168.178.35")})
+		assert.NoError(t, err)
+		assert.Equal(t, "ip = '192.168.178.35'\n", string(b))
+	})
+
+	t.Run("zero netip.Addr is omitted", func(t *testing.T) {
+		type doc struct {
+			IP netip.Addr `toml:"ip,omitempty"`
+		}
+		b, err := toml.Marshal(doc{})
+		assert.NoError(t, err)
+		assert.Equal(t, "", string(b))
+	})
+
+	t.Run("time.Time present is kept", func(t *testing.T) {
+		type doc struct {
+			When time.Time `toml:"when,omitempty"`
+		}
+		when, err := time.Parse(time.RFC3339, "2026-05-16T12:34:56Z")
+		assert.NoError(t, err)
+		b, err := toml.Marshal(doc{When: when})
+		assert.NoError(t, err)
+		assert.Equal(t, "when = 2026-05-16T12:34:56Z\n", string(b))
+	})
+}
+
 func TestEncoderOmitzero(t *testing.T) {
 	type doc struct {
 		String  string            `toml:",omitzero,multiline"`


### PR DESCRIPTION
Fixes #955.

`netip.Addr` (and other TextMarshaler-only types like `time.Time`, `big.Int`) has no exported fields, so `isEmptyStruct` walks an empty list and always reports the value as empty. With `omitempty` set on a field of that type, the value silently gets dropped from the output:

```go
type doc struct {
    IP netip.Addr `toml:\"ip,omitempty\"`
}
toml.Marshal(doc{IP: netip.MustParseAddr(\"192.168.178.35\")})
// got:  \"\"
// want: \"ip = '192.168.178.35'\\n\"
```

Check for `encoding.TextMarshaler` (on the value or its pointer) before falling back to the field walk. If MarshalText returns nothing, the value is considered empty; otherwise it's kept. The existing field walk handles the rest unchanged.

Targeting the `v2` branch.

Added `TestEncoderOmitempty_TextMarshaler` with three cases: a non-zero netip.Addr is kept, a zero netip.Addr is omitted, and a non-zero time.Time is kept.