### PR TITLE
unstable/kind: drop duplicate 'a' from LocalDate comment

### DIFF
--- a/unstable/kind.go
+++ b/unstable/kind.go
@@ -33,7 +33,7 @@ const (
 	Float
 	// Integer represents an integer value.
 	Integer
-	// LocalDate represents a a local date value.
+	// LocalDate represents a local date value.
 	LocalDate
 	// LocalTime represents a local time value.
 	LocalTime


### PR DESCRIPTION
Doc comment on `LocalDate` in `unstable/kind.go` reads "represents a a local date value". One-word fix.