### PR TITLE
Report quoted string requirement for unquoted values

### DIFF
--- a/unstable/parser.go
+++ b/unstable/parser.go
@@ -1221,6 +1221,10 @@ func (p *Parser) scanIntOrFloat(b []byte) (reference, []byte, error) {
 			return invalidReference, nil, NewParserError(b[i:i+1], "unexpected character 'n' while scanning for a number")
 		}
 
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') {
+			return invalidReference, nil, NewParserError(b[i:i+1], "strings must be quoted")
+		}
+
 		break
 	}
 

--- a/unstable/parser_test.go
+++ b/unstable/parser_test.go
@@ -780,3 +780,24 @@ func TestParserErrorPosition(t *testing.T) {
 		})
 	}
 }
+
+func TestUnquotedStringValueRequiresQuotes(t *testing.T) {
+	p := Parser{}
+	p.Reset([]byte(`timeout = 20s`))
+	for p.NextExpression() {
+	}
+
+	err := p.Error()
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+
+	var perr *ParserError
+	if !errors.As(err, &perr) {
+		t.Fatalf("expected *ParserError, got %T", err)
+	}
+
+	if perr.Message != "strings must be quoted" {
+		t.Fatalf("expected %q, got %q", "strings must be quoted", perr.Message)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #413

Unquoted values with alphabetic suffixes (e.g. `timeout = 20s`) were partially parsed as numbers and then failed with a misleading `expected newline` error. The parser now rejects alphabetic characters while scanning numeric values and returns `strings must be quoted`.

## Test plan

- [x] `go test ./...`
- [x] Added `TestUnquotedStringValueRequiresQuotes` for `timeout = 20s`