### PR TITLE
fix: wrap redefinition errors as DecodeError with key context

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -418,6 +418,31 @@ func TestErrorPositionConsistency(t *testing.T) {
 	}
 }
 
+func TestDecodeErrorRedefinition(t *testing.T) {
+	t.Run("duplicate top-level key", func(t *testing.T) {
+		m := map[string]interface{}{}
+		err := Unmarshal([]byte("a = 1\nb = 2\nb = 3\n"), &m)
+
+		var de *DecodeError
+		if !errors.As(err, &de) {
+			t.Fatalf("expected *DecodeError, got %T (%v)", err, err)
+		}
+		assert.Equal(t, Key{"b"}, de.Key())
+		assert.Equal(t, "toml: key b is already defined", de.Error())
+	})
+
+	t.Run("duplicate nested key", func(t *testing.T) {
+		m := map[string]interface{}{}
+		err := Unmarshal([]byte("foo.bar = 1\nfoo.bar = 2\n"), &m)
+
+		var de *DecodeError
+		if !errors.As(err, &de) {
+			t.Fatalf("expected *DecodeError, got %T (%v)", err, err)
+		}
+		assert.Equal(t, Key{"foo", "bar"}, de.Key())
+	})
+}
+
 func ExampleDecodeError() {
 	doc := `name = 123__456`
 

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -191,6 +191,30 @@ func (d *decoder) typeMismatchString(toml string, target reflect.Type) string {
 	return fmt.Sprintf("cannot decode TOML %s into a Go value of type %s", toml, target)
 }
 
+func keyFromNode(node *unstable.Node) Key {
+	it := node.Key()
+	var key Key
+	for it.Next() {
+		key = append(key, string(it.Node().Data))
+	}
+	return key
+}
+
+func (d *decoder) wrapSeenError(node *unstable.Node, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+	msg = strings.TrimPrefix(msg, "toml: ")
+
+	return wrapDecodeError(d.p.Data(), &unstable.ParserError{
+		Highlight: d.p.Raw(node.Raw),
+		Message:   msg,
+		Key:       keyFromNode(node),
+	})
+}
+
 func (d *decoder) expr() *unstable.Node {
 	return d.p.Expression()
 }
@@ -281,7 +305,7 @@ func (d *decoder) handleRootExpression(expr *unstable.Node, v reflect.Value) err
 	if !d.skipUntilTable || expr.Kind != unstable.KeyValue {
 		first, err = d.seen.CheckExpression(expr)
 		if err != nil {
-			return err
+			return d.wrapSeenError(expr, err)
 		}
 	}
 
@@ -671,7 +695,7 @@ func (d *decoder) handleKeyValues(v reflect.Value) (reflect.Value, error) {
 
 		_, err := d.seen.CheckExpression(expr)
 		if err != nil {
-			return reflect.Value{}, err
+			return reflect.Value{}, d.wrapSeenError(expr, err)
 		}
 
 		x, err := d.handleKeyValue(expr, v)
@@ -703,7 +727,7 @@ func (d *decoder) handleKeyValuesUnmarshaler(u unstable.Unmarshaler) (reflect.Va
 
 		_, err := d.seen.CheckExpression(expr)
 		if err != nil {
-			return reflect.Value{}, err
+			return reflect.Value{}, d.wrapSeenError(expr, err)
 		}
 
 		// Use the raw bytes from the original document to preserve formatting


### PR DESCRIPTION
## Summary
- Wrap `SeenTracker` errors from `CheckExpression` as `DecodeError` via `decoder.wrapSeenError`
- Attach the full TOML key path and source location to duplicate key / table redefinition errors

Fixes #668

## Test plan
- [x] `go test ./...`
- [x] Added `TestDecodeErrorRedefinition` for duplicate top-level and nested keys
- [x] `b = 2` followed by `b = 3` now returns `DecodeError` with `Key() == ["b"]` and a highlighted line