### PR TITLE
fix: support encoding.BinaryUnmarshaler during decode

### DIFF
--- a/issue1058_test.go
+++ b/issue1058_test.go
@@ -1,0 +1,43 @@
+package toml_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func TestIssue1058_UnmarshalURL(t *testing.T) {
+	type config struct {
+		Endpoint *url.URL `toml:"endpoint"`
+	}
+
+	var cfg config
+	err := toml.Unmarshal([]byte(`endpoint = "https://example.com/path"`), &cfg)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if cfg.Endpoint == nil {
+		t.Fatal("expected endpoint URL to be set")
+	}
+	if got, want := cfg.Endpoint.String(), "https://example.com/path"; got != want {
+		t.Fatalf("Endpoint = %q, want %q", got, want)
+	}
+}
+
+func TestIssue1058_UnmarshalURLValue(t *testing.T) {
+	type config struct {
+		Endpoint url.URL `toml:"endpoint"`
+	}
+
+	var cfg config
+	err := toml.Unmarshal([]byte(`endpoint = "https://example.com/"`), &cfg)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if got, want := cfg.Endpoint.String(), "https://example.com/"; got != want {
+		t.Fatalf("Endpoint = %q, want %q", got, want)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -18,6 +18,7 @@ var (
 	timeType               = reflect.TypeOf(time.Time{})
 	textMarshalerType      = reflect.TypeOf(new(encoding.TextMarshaler)).Elem()
 	textUnmarshalerType    = reflect.TypeOf(new(encoding.TextUnmarshaler)).Elem()
+	binaryUnmarshalerType  = reflect.TypeOf(new(encoding.BinaryUnmarshaler)).Elem()
 	mapStringInterfaceType = reflect.TypeOf(map[string]interface{}(nil))
 	sliceInterfaceType     = reflect.TypeOf([]interface{}(nil))
 	stringType             = reflect.TypeOf("")

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -1308,10 +1308,26 @@ func makeMapKey(kt reflect.Type, name string) (reflect.Value, error) {
 			}
 			return k, nil
 		}
+		if kt.Implements(binaryUnmarshalerType) {
+			k := reflect.New(kt.Elem())
+			err := k.Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary([]byte(name))
+			if err != nil {
+				return reflect.Value{}, fmt.Errorf("toml: error unmarshaling map key %q: %w", name, err)
+			}
+			return k, nil
+		}
 	default:
 		if reflect.PtrTo(kt).Implements(textUnmarshalerType) {
 			k := reflect.New(kt)
 			err := k.Interface().(encoding.TextUnmarshaler).UnmarshalText([]byte(name))
+			if err != nil {
+				return reflect.Value{}, fmt.Errorf("toml: error unmarshaling map key %q: %w", name, err)
+			}
+			return k.Elem(), nil
+		}
+		if reflect.PtrTo(kt).Implements(binaryUnmarshalerType) {
+			k := reflect.New(kt)
+			err := k.Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary([]byte(name))
 			if err != nil {
 				return reflect.Value{}, fmt.Errorf("toml: error unmarshaling map key %q: %w", name, err)
 			}
@@ -1705,6 +1721,12 @@ func (d *decoder) assignString(v reflect.Value, value *unstable.Node) (reflect.V
 		}
 		return v, nil
 	}
+	if ok, err := tryBinaryUnmarshaler(v, value.Data); ok {
+		if err != nil {
+			return reflect.Value{}, unstable.NewParserError(d.p.Raw(value.Raw), "%s", err)
+		}
+		return v, nil
+	}
 	return reflect.Value{}, d.typeMismatchError("string", v.Type(), d.p.Raw(value.Raw))
 }
 
@@ -1751,6 +1773,16 @@ func (d *decoder) assignInteger(v reflect.Value, value *unstable.Node) (reflect.
 func tryTextUnmarshaler(v reflect.Value, text []byte) (bool, error) {
 	if v.CanAddr() && v.Addr().Type().Implements(textUnmarshalerType) {
 		return true, v.Addr().Interface().(encoding.TextUnmarshaler).UnmarshalText(text)
+	}
+	return false, nil
+}
+
+func tryBinaryUnmarshaler(v reflect.Value, data []byte) (bool, error) {
+	if v.Type() == timeType {
+		return false, nil
+	}
+	if v.CanAddr() && v.Addr().Type().Implements(binaryUnmarshalerType) {
+		return true, v.Addr().Interface().(encoding.BinaryUnmarshaler).UnmarshalBinary(data)
 	}
 	return false, nil
 }

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -21,6 +21,11 @@ type unmarshalTextKey struct {
 	B string
 }
 
+type unmarshalBinaryKey struct {
+	A string
+	B string
+}
+
 func (k *unmarshalTextKey) UnmarshalText(text []byte) error {
 	parts := strings.Split(string(text), "-")
 	if len(parts) != 2 {
@@ -31,9 +36,25 @@ func (k *unmarshalTextKey) UnmarshalText(text []byte) error {
 	return nil
 }
 
+func (k *unmarshalBinaryKey) UnmarshalBinary(data []byte) error {
+	parts := strings.Split(string(data), "-")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid binary key: %s", data)
+	}
+	k.A = parts[0]
+	k.B = parts[1]
+	return nil
+}
+
 type unmarshalBadTextKey struct{}
 
 func (k *unmarshalBadTextKey) UnmarshalText([]byte) error {
+	return errors.New("error")
+}
+
+type unmarshalBadBinaryValue struct{}
+
+func (unmarshalBadBinaryValue) UnmarshalBinary([]byte) error {
 	return errors.New("error")
 }
 
@@ -505,6 +526,34 @@ func TestUnmarshal(t *testing.T) {
 			},
 		},
 		{
+			desc:  "kv bad binary value",
+			input: `A = "foo"`,
+			gen: func() test {
+				type doc struct {
+					A unmarshalBadBinaryValue
+				}
+
+				return test{
+					target: &doc{},
+					err:    true,
+				}
+			},
+		},
+		{
+			desc:  "kv string into time",
+			input: `A = "foo"`,
+			gen: func() test {
+				type doc struct {
+					A time.Time
+				}
+
+				return test{
+					target: &doc{},
+					err:    true,
+				}
+			},
+		},
+		{
 			desc:  "kv text key",
 			input: `a-1 = "foo"`,
 			gen: func() test {
@@ -559,6 +608,42 @@ foo = "bar"`,
 			},
 		},
 		{
+			desc:  "kv binary key",
+			input: `a-1 = "foo"`,
+			gen: func() test {
+				type doc = map[unmarshalBinaryKey]string
+
+				return test{
+					target:   &doc{},
+					expected: &doc{{A: "a", B: "1"}: "foo"},
+				}
+			},
+		},
+		{
+			desc:  "kv ptr binary key",
+			input: `a-1 = "foo"`,
+			gen: func() test {
+				type doc = map[*unmarshalBinaryKey]string
+
+				return test{
+					target:   &doc{},
+					expected: &doc{{A: "a", B: "1"}: "foo"},
+					assert: func(t *testing.T, test test) {
+						t.Helper()
+						expected := make(map[unmarshalBinaryKey]string)
+						for k, v := range *(test.expected.(*doc)) {
+							expected[*k] = v
+						}
+						got := make(map[unmarshalBinaryKey]string)
+						for k, v := range *(test.target.(*doc)) {
+							got[*k] = v
+						}
+						assert.Equal(t, expected, got)
+					},
+				}
+			},
+		},
+		{
 			desc:  "kv bad text key",
 			input: `a-1 = "foo"`,
 			gen: func() test {
@@ -587,6 +672,18 @@ foo = "bar"`,
 			input: `a = "foo"`,
 			gen: func() test {
 				type doc = map[unmarshalBadBinaryValueKey]string
+
+				return test{
+					target: &doc{},
+					err:    true,
+				}
+			},
+		},
+		{
+			desc:  "kv bad ptr binary key",
+			input: `a = "foo"`,
+			gen: func() test {
+				type doc = map[*unmarshalBadBinaryValueKey]string
 
 				return test{
 					target: &doc{},

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -37,6 +37,12 @@ func (k *unmarshalBadTextKey) UnmarshalText([]byte) error {
 	return errors.New("error")
 }
 
+type unmarshalBadBinaryValueKey struct{}
+
+func (unmarshalBadBinaryValueKey) UnmarshalBinary([]byte) error {
+	return errors.New("error")
+}
+
 func ExampleDecoder_DisallowUnknownFields() {
 	type S struct {
 		Key1 string
@@ -569,6 +575,18 @@ foo = "bar"`,
 			input: `a-1 = "foo"`,
 			gen: func() test {
 				type doc = map[*unmarshalBadTextKey]string
+
+				return test{
+					target: &doc{},
+					err:    true,
+				}
+			},
+		},
+		{
+			desc:  "kv bad binary value key",
+			input: `a = "foo"`,
+			gen: func() test {
+				type doc = map[unmarshalBadBinaryValueKey]string
 
 				return test{
 					target: &doc{},


### PR DESCRIPTION
## Summary

Fixes #1058

Some stdlib types such as `*url.URL` implement `encoding.BinaryUnmarshaler` but not `encoding.TextUnmarshaler`. Decoding into those types previously failed with a string type mismatch.

This adds `BinaryUnmarshaler` support for scalar values (after the existing `TextUnmarshaler` path) and for map keys.

## Test plan

- [x] Added `TestIssue1058_UnmarshalURL` and `TestIssue1058_UnmarshalURLValue`
- [x] `go test ./...`

Made with [Cursor](https://cursor.com)