### PR TITLE
Contextualize redefinition errors as DecodeError

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -418,6 +418,119 @@ func TestErrorPositionConsistency(t *testing.T) {
 	}
 }
 
+// TestDecodeErrorRedefinition checks that errors raised by the duplicate-key
+// tracker are reported as DecodeError, carrying the key path and a position
+// pointing at the offending key (see issue #668).
+func TestDecodeErrorRedefinition(t *testing.T) {
+	examples := []struct {
+		desc  string
+		doc   string
+		msg   string
+		key   Key
+		row   int
+		col   int
+		human string
+	}{
+		{
+			desc: "duplicate key",
+			doc:  "a = 1\nb = 2\nb = 3\n",
+			msg:  "toml: key b is already defined",
+			key:  Key{"b"},
+			row:  3,
+			col:  1,
+			human: `
+1| a = 1
+2| b = 2
+3| b = 3
+ | ~ key b is already defined`,
+		},
+		{
+			desc: "duplicate dotted key",
+			doc:  "foo.bar = 1\nfoo.bar = 2\n",
+			msg:  "toml: key bar is already defined",
+			key:  Key{"foo", "bar"},
+			row:  2,
+			col:  1,
+			human: `
+1| foo.bar = 1
+2| foo.bar = 2
+ | ~~~~~~~ key bar is already defined`,
+		},
+		{
+			desc: "redefined table",
+			doc:  "[a]\nx = 1\n[a]\ny = 2\n",
+			msg:  "toml: table a already exists",
+			key:  Key{"a"},
+			row:  3,
+			col:  2,
+		},
+		{
+			desc: "duplicate key in table body",
+			doc:  "[a]\nx = 1\nx = 2\n",
+			msg:  "toml: key x is already defined",
+			key:  Key{"x"},
+			row:  3,
+			col:  1,
+		},
+		{
+			desc: "redefined nested table",
+			doc:  "[a.b]\n[a.b]\n",
+			msg:  "toml: table b already exists",
+			key:  Key{"a", "b"},
+			row:  2,
+			col:  2,
+		},
+		{
+			desc: "table over value",
+			doc:  "a = 1\n[a]\n",
+			msg:  "toml: key a should be a table, not a value",
+			key:  Key{"a"},
+			row:  2,
+			col:  2,
+		},
+		{
+			desc: "array table over table",
+			doc:  "[t]\n[[t]]\n",
+			msg:  "toml: key t already exists as a table, but should be an array table",
+			key:  Key{"t"},
+			row:  2,
+			col:  3,
+		},
+		{
+			desc: "duplicate key in inline table",
+			doc:  "a = { b = 1, b = 2 }\n",
+			msg:  "toml: key b is already defined",
+			key:  Key{"a"},
+			row:  1,
+			col:  1,
+		},
+	}
+
+	for _, e := range examples {
+		t.Run(e.desc, func(t *testing.T) {
+			m := map[string]interface{}{}
+			err := Unmarshal([]byte(e.doc), &m)
+
+			var de *DecodeError
+			if !errors.As(err, &de) {
+				t.Fatalf("expected *DecodeError, got %T (%v)", err, err)
+			}
+
+			assert.Equal(t, e.msg, de.Error())
+			assert.Equal(t, e.key, de.Key())
+
+			row, col := de.Position()
+			if row != e.row || col != e.col {
+				t.Errorf("position = (%d, %d), want (%d, %d)", row, col, e.row, e.col)
+			}
+
+			if e.human != "" {
+				assert.Equal(t, e.human[1:], de.String())
+			}
+		})
+	}
+}
+
 func ExampleDecodeError() {
 	doc := `name = 123__456`
 

--- a/internal/tracker/seen.go
+++ b/internal/tracker/seen.go
@@ -265,7 +265,7 @@ func (s *SeenTracker) checkArrayTable(node *unstable.Node) (bool, error) {
 	} else {
 		kind := s.entries[idx].kind
 		if kind != arrayTableKind {
-			return false, fmt.Errorf("toml: key %s already exists as a %s,  but should be an array table", kind, string(k))
+			return false, fmt.Errorf("toml: key %s already exists as a %s, but should be an array table", string(k), kind)
 		}
 		s.clear(idx)
 	}

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -199,6 +199,45 @@ func (d *decoder) newParserError(highlight []byte, format string, args ...interf
 	}
 }
 
+// wrapSeenError turns an error returned by SeenTracker.CheckExpression into a
+// ParserError carrying the position and key of the offending expression, so
+// that it is reported as a DecodeError with context (see issue #668).
+//
+// The highlight spans the expression's key. Unlike Node.Raw, key nodes always
+// carry a Raw range, so this works for tables and array tables too (whose own
+// Raw range is not set by the parser).
+func (d *decoder) wrapSeenError(node *unstable.Node, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var key Key
+	var start, end unstable.Range
+	it := node.Key()
+	for it.Next() {
+		n := it.Node()
+		key = append(key, string(n.Data))
+		if len(key) == 1 {
+			start = n.Raw
+		}
+		end = n.Raw
+	}
+
+	var highlight []byte
+	if len(key) > 0 {
+		highlight = d.p.Raw(unstable.Range{
+			Offset: start.Offset,
+			Length: end.Offset + end.Length - start.Offset,
+		})
+	}
+
+	return &unstable.ParserError{
+		Highlight: highlight,
+		Message:   strings.TrimPrefix(err.Error(), "toml: "),
+		Key:       key,
+	}
+}
+
 func (d *decoder) expr() *unstable.Node {
 	return d.p.Expression()
 }
@@ -289,7 +328,7 @@ func (d *decoder) handleRootExpression(expr *unstable.Node, v reflect.Value) err
 	if !d.skipUntilTable || expr.Kind != unstable.KeyValue {
 		first, err = d.seen.CheckExpression(expr)
 		if err != nil {
-			return err
+			return d.wrapSeenError(expr, err)
 		}
 	}
 
@@ -679,7 +718,7 @@ func (d *decoder) handleKeyValues(v reflect.Value) (reflect.Value, error) {
 
 		_, err := d.seen.CheckExpression(expr)
 		if err != nil {
-			return reflect.Value{}, err
+			return reflect.Value{}, d.wrapSeenError(expr, err)
 		}
 
 		x, err := d.handleKeyValue(expr, v)
@@ -711,7 +750,7 @@ func (d *decoder) handleKeyValuesUnmarshaler(u unstable.Unmarshaler) (reflect.Va
 
 		_, err := d.seen.CheckExpression(expr)
 		if err != nil {
-			return reflect.Value{}, err
+			return reflect.Value{}, d.wrapSeenError(expr, err)
 		}
 
 		// Use the raw bytes from the original document to preserve formatting


### PR DESCRIPTION
## Summary

Fixes #668.

Duplicate-key and table-redefinition errors raised by `SeenTracker` were returned as bare errors with no position or key:

```
toml: key b is already defined
```

They are now wrapped into a `DecodeError` that carries the **key path** and a **highlight pointing at the offending key**:

```
toml: key b is already defined
1| a = 1
2| b = 2
3| b = 3
 | ~ key b is already defined
```

`errors.As(err, &de)` now yields a `*DecodeError` whose `Key()` and `Position()` are populated.

## Approach

This builds on the approach proposed in #1065 (wrap the `SeenTracker` error at the `CheckExpression` call sites), but fixes the highlight so it works for **all** expression kinds:

- The original PR used `node.Raw` as the highlight. The parser only sets `Raw` on `KeyValue` nodes — `Table`/`ArrayTable` nodes have no `Raw` range — so table redefinitions (the issue's motivating `[a]` case) ended up highlighting an empty range at line 1, column 1.
- `Key` nodes **always** carry a `Raw` range (set in `parseKey`), so the highlight here spans the key nodes from first to last. This points precisely at the offending key for key-values, dotted keys, tables, and array tables alike.

The wrapped error is returned as a `*unstable.ParserError`, which the existing `FromParser` path already converts to a `DecodeError` via `wrapDecodeError` — no new conversion logic.

Also fixes the swapped format arguments and a stray double space in the `key ... already exists as a ... but should be an array table` message (it previously printed the kind and key in the wrong order).

## Known limitation

For a duplicate inside an *inline* table (`a = { b = 1, b = 2 }`), the highlight points at the outer key `a` and `Key()` returns `["a"]`, while the message still names `b`. The inner offending node isn't surfaced by the tracker. This is still a strict improvement over the previous context-free error; surfacing the inner node would require a larger change to `SeenTracker`.

## Test plan

- [x] `go test ./...`
- [x] Added `TestDecodeErrorRedefinition` covering duplicate keys, dotted keys, table/nested-table redefinition, table-over-value, array-table-over-table, table-body duplicates, and inline-table duplicates — asserting `Error()`, `Key()`, `Position()`, and the rendered highlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)