### PR TITLE
ci: fix release Docker attestations + enable manual tag re-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,18 @@ on:
         default: ""
         required: false
         type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag) to release, e.g. v2.4.0. Leave empty to use the triggering ref."
+        default: ""
+        required: false
+        type: string
+      args:
+        description: "Extra arguments to pass goreleaser"
+        default: ""
+        required: false
+        type: string
 
 jobs:
   release:
@@ -19,6 +31,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ inputs.ref }}
       - name: Set up Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.26"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:


### PR DESCRIPTION
## Problem

The v2.4.0 release failed at the Docker step:

```
ERROR: failed to build: Attestation is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

The `dockers` → `dockers_v2` migration changed the build path. `dockers_v2` defaults to `sbom: 'true'`, so GoReleaser now runs `docker buildx build ... --attest=type=sbom`. The default GitHub Actions buildx builder uses the plain `docker` driver, which can't produce attestations. As a result `v2.4.0` published as a Go module (via the tag) but never got its release binaries or ghcr image.

## Changes

1. **Add `docker/setup-buildx-action@v3`** before the GoReleaser step. It provisions a builder on the `docker-container` driver, which supports attestations, so the SBOM is preserved.

2. **Add a `workflow_dispatch` trigger with an optional `ref` input.** The checkout step now uses `ref: ${{ inputs.ref }}`. An empty value (normal tag push / `workflow_call`) keeps the existing behavior of checking out the triggering ref. Dispatching manually with a `ref` lets us re-release an existing tag **without moving it**.

## Backfilling v2.4.0 (after merge)

The `v2.4.0` tag is immutable (already on the Go proxy), so we re-release it instead of re-tagging:

1. Merge this PR into `v2`.
2. Actions → **release** → **Run workflow**, run from branch **`v2`** (uses the fixed workflow) with input **`ref: v2.4.0`** (GoReleaser releases that tag).
3. GoReleaser creates the `v2.4.0` GitHub release (draft, per config) and pushes the ghcr image. Publish the draft.

Note: with attestations enabled, the single-arch `linux/amd64` image is published as an OCI image index (manifest with attached SBOM) rather than a plain image. `docker pull` works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
