### PR TITLE
fix multiline string, array indentation, and omitempty behavior

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -868,10 +868,41 @@ func isEmptyValue(v reflect.Value) bool {
 	case reflect.Ptr, reflect.Interface:
 		return v.IsNil()
 	case reflect.Struct:
-		return v.IsZero()
+		// Structs that encode as a scalar value (time.Time, the local
+		// date/time types, or any TextMarshaler) are empty only when they
+		// equal their zero value; their fields are typically unexported, so
+		// recursing into them would be meaningless.
+		if encPropsForType(v.Type()).isValue {
+			return v.IsZero()
+		}
+		// Plain structs encode as tables and are empty when every field that
+		// would be encoded is itself empty. This matches the recursive rule
+		// used before the encoder rewrite and, in particular, treats a
+		// non-nil but empty map or slice as empty (reflect.Value.IsZero does
+		// not, which would otherwise emit an empty table header).
+		return isEmptyStruct(v)
 	default:
 		return false
 	}
+}
+
+// isEmptyStruct reports whether all of a table-valued struct's encodable
+// fields are empty per isEmptyValue. It mirrors the field selection done by
+// collectStructEntries (embedded flattening, shadowing, and "-" skips) so the
+// emptiness decision matches what would actually be encoded.
+func isEmptyStruct(v reflect.Value) bool {
+	plan := encPlanForType(v.Type())
+	for i := range plan.fields {
+		fv, ok := fieldByIndexSkipNil(v, plan.fields[i].index)
+		if !ok {
+			// A nil embedded pointer along the path contributes nothing.
+			continue
+		}
+		if !isEmptyValue(fv) {
+			return false
+		}
+	}
+	return true
 }
 
 // isZeroValue implements the omitzero rules: the type's own IsZero() when

--- a/marshaler.go
+++ b/marshaler.go
@@ -164,8 +164,10 @@ func (enc *Encoder) SetMarshalJSONNumbers(indent bool) *Encoder {
 // may be empty in order to provide options without overriding the default
 // name.
 //
-// The "multiline" option emits strings as quoted multi-line TOML strings. It
-// has no effect on fields that would not be encoded as strings.
+// The "multiline" option emits strings as quoted multi-line TOML strings, and
+// arrays with one element per line. For strings, it only takes effect when the
+// value contains a newline; single-line values are emitted as regular strings.
+// It has no effect on fields that would not be encoded as strings or arrays.
 //
 // The "inline" option turns fields that would be emitted as tables into
 // inline tables instead. It has no effect on other fields.
@@ -533,8 +535,18 @@ func (e *encoderState) encodeKeyValue(ent entry, commented bool, indent int) err
 	e.buf = e.appendKey(e.buf, ent.key)
 	e.buf = append(e.buf, " = "...)
 
+	// When tables are not indented, the key is emitted at column zero
+	// regardless of its nesting depth. Value continuation lines (most
+	// notably the elements of a multiline array) must line up with that key,
+	// so the value indentation starts from zero as well rather than from the
+	// table nesting depth.
+	valueIndent := indent
+	if !e.indentTables {
+		valueIndent = 0
+	}
+
 	var err error
-	e.buf, err = e.appendValue(e.buf, ent.value, ent.options, indent)
+	e.buf, err = e.appendValue(e.buf, ent.value, ent.options, valueIndent)
 	if err != nil {
 		return err
 	}
@@ -951,10 +963,15 @@ func (e *encoderState) appendValue(b []byte, v reflect.Value, opts valueOptions,
 		}
 		return e.appendValue(b, v.Elem(), opts, indent)
 	case reflect.String:
-		if opts.multiline {
-			return e.appendMultilineString(b, v.String()), nil
+		s := v.String()
+		// The "multiline" option only takes effect when the string actually
+		// contains a newline. Wrapping a single-line value such as "2" in a
+		// """...""" block adds noise without improving readability, so it is
+		// emitted as a regular single-line string instead.
+		if opts.multiline && strings.IndexByte(s, '\n') >= 0 {
+			return e.appendMultilineString(b, s), nil
 		}
-		return e.appendString(b, v.String()), nil
+		return e.appendString(b, s), nil
 	case reflect.Bool:
 		if v.Bool() {
 			return append(b, "true"...), nil

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -1174,6 +1174,57 @@ func TestEncoderOmitempty(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+func TestEncoderOmitemptyNonNilEmptyCollections(t *testing.T) {
+	// Regression for #1075: a struct whose only non-zero fields are non-nil
+	// but empty maps/slices (as produced by some YAML decoders/cloners) must
+	// be treated as empty by omitempty, so no empty table header is emitted.
+	// reflect.Value.IsZero would report such a struct as non-zero.
+	type base struct {
+		Rules map[string]string `toml:"rules,omitempty"`
+	}
+	type nested struct {
+		base
+		Overrides []string `toml:"overrides,omitempty"`
+	}
+	type group struct {
+		Nested nested `toml:"nested,omitempty"`
+	}
+	type doc struct {
+		Group group  `toml:"group,omitempty"`
+		Keep  string `toml:"keep,omitempty"`
+	}
+
+	d := doc{
+		Group: group{Nested: nested{
+			base:      base{Rules: map[string]string{}},
+			Overrides: []string{},
+		}},
+		Keep: "x",
+	}
+
+	b, err := toml.Marshal(d)
+	assert.NoError(t, err)
+	assert.Equal(t, "keep = 'x'\n", string(b))
+}
+
+func TestEncoderOmitemptyScalarStructStillEmittedWhenSet(t *testing.T) {
+	// A struct that encodes as a scalar (here, via a TextMarshaler) must keep
+	// the zero-value-based emptiness check: non-zero values are still emitted,
+	// zero values are omitted.
+	type doc struct {
+		When time.Time `toml:"when,omitempty"`
+		Keep string    `toml:"keep,omitempty"`
+	}
+
+	zero, err := toml.Marshal(doc{Keep: "x"})
+	assert.NoError(t, err)
+	assert.Equal(t, "keep = 'x'\n", string(zero))
+
+	set, err := toml.Marshal(doc{When: time.Date(2026, 6, 22, 0, 0, 0, 0, time.UTC), Keep: "x"})
+	assert.NoError(t, err)
+	assert.Equal(t, "when = 2026-06-22T00:00:00Z\nkeep = 'x'\n", string(set))
+}
+
 func TestEncoderOmitzero(t *testing.T) {
 	type doc struct {
 		String  string            `toml:",omitzero,multiline"`

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -441,6 +441,21 @@ hello
 `,
 		},
 		{
+			// Regression for #1075: the multiline option must not wrap a
+			// single-line value in a """...""" block.
+			desc: "multi-line option ignored without newline",
+			v: struct {
+				A string `toml:",multiline"`
+				B string `toml:",multiline"`
+			}{
+				A: "2",
+				B: "with ' quote",
+			},
+			expected: `A = '2'
+B = "with ' quote"
+`,
+		},
+		{
 			desc: "inline field",
 			v: struct {
 				A map[string]string `toml:",inline"`
@@ -2467,6 +2482,58 @@ func TestMarshalElementErrors(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, strings.Contains(buf.String(), "1"))
 	})
+}
+
+func TestMarshalMultilineArrayIndentWithoutIndentTables(t *testing.T) {
+	// Regression for #1075: when tables are not indented, a multiline array
+	// nested under tables must have its elements indented relative to its key
+	// (column zero) rather than to the table nesting depth.
+	type exclusions struct {
+		Paths []string `toml:"paths"`
+	}
+	type linters struct {
+		Exclusions exclusions `toml:"exclusions"`
+	}
+	v := struct {
+		Linters linters `toml:"linters"`
+	}{
+		Linters: linters{
+			Exclusions: exclusions{
+				Paths: []string{"third_party$", "builtin$"},
+			},
+		},
+	}
+
+	var buf strings.Builder
+	enc := toml.NewEncoder(&buf)
+	enc.SetArraysMultiline(true)
+	assert.NoError(t, enc.Encode(v))
+
+	expected := `[linters]
+[linters.exclusions]
+paths = [
+  'third_party$',
+  'builtin$'
+]
+`
+	assert.Equal(t, expected, buf.String())
+
+	// With SetIndentTables, the key and its array elements are indented
+	// consistently to the table nesting depth.
+	var buf2 strings.Builder
+	enc2 := toml.NewEncoder(&buf2)
+	enc2.SetArraysMultiline(true)
+	enc2.SetIndentTables(true)
+	assert.NoError(t, enc2.Encode(v))
+
+	expectedIndented := `[linters]
+  [linters.exclusions]
+    paths = [
+      'third_party$',
+      'builtin$'
+    ]
+`
+	assert.Equal(t, expectedIndented, buf2.String())
 }
 
 func TestMarshalStringEscapes(t *testing.T) {

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -2587,6 +2587,107 @@ paths = [
 	assert.Equal(t, expectedIndented, buf2.String())
 }
 
+// TestMarshalIssue1075 reproduces the exact serialization reported in #1075.
+// It mirrors golangci-lint's "version two" config: every field tagged
+// `,multiline,omitempty`, an embedded struct, a non-nil but empty slice, and
+// the default encoder. Before the fix this produced multiline-wrapped short
+// strings (version = """\n2"""), array elements indented to the table depth,
+// and empty [linters.settings(.tagliatelle.case)] tables. The expected output
+// below is byte-for-byte golangci-lint's empty.golden.toml.
+func TestMarshalIssue1075(t *testing.T) {
+	strptr := func(s string) *string { return &s }
+
+	type tagBase struct {
+		Rules         map[string]string `toml:"rules,multiline,omitempty"`
+		UseFieldName  *bool             `toml:"use-field-name,multiline,omitempty"`
+		IgnoredFields []string          `toml:"ignored-fields,multiline,omitempty"`
+	}
+	type tagCase struct {
+		tagBase
+		Overrides []string `toml:"overrides,multiline,omitempty"`
+	}
+	type tagSettings struct {
+		Case tagCase `toml:"case,multiline,omitempty"`
+	}
+	type lintersSettings struct {
+		Tagliatelle tagSettings `toml:"tagliatelle,multiline,omitempty"`
+	}
+	type lintersExclusions struct {
+		Generated *string  `toml:"generated,multiline,omitempty"`
+		Presets   []string `toml:"presets,multiline,omitempty"`
+		Paths     []string `toml:"paths,multiline,omitempty"`
+	}
+	type linters struct {
+		Settings   lintersSettings   `toml:"settings,multiline,omitempty"`
+		Exclusions lintersExclusions `toml:"exclusions,multiline,omitempty"`
+	}
+	type formattersExclusions struct {
+		Generated *string  `toml:"generated,multiline,omitempty"`
+		Paths     []string `toml:"paths,multiline,omitempty"`
+	}
+	type formatters struct {
+		Exclusions formattersExclusions `toml:"exclusions,multiline,omitempty"`
+	}
+	type config struct {
+		Version    *string    `toml:"version,multiline,omitempty"`
+		Linters    linters    `toml:"linters,multiline,omitempty"`
+		Formatters formatters `toml:"formatters,multiline,omitempty"`
+	}
+
+	c := config{
+		Version: strptr("2"),
+		Linters: linters{
+			Settings: lintersSettings{
+				// Non-nil but empty slice: the exact trigger for the empty
+				// [linters.settings.tagliatelle.case] tables.
+				Tagliatelle: tagSettings{Case: tagCase{Overrides: []string{}}},
+			},
+			Exclusions: lintersExclusions{
+				Generated: strptr("lax"),
+				Presets:   []string{"comments", "common-false-positives", "legacy", "std-error-handling"},
+				Paths:     []string{"third_party$", "builtin$", "examples$"},
+			},
+		},
+		Formatters: formatters{
+			Exclusions: formattersExclusions{
+				Generated: strptr("lax"),
+				Paths:     []string{"third_party$", "builtin$", "examples$"},
+			},
+		},
+	}
+
+	expected := `version = '2'
+
+[linters]
+[linters.exclusions]
+generated = 'lax'
+presets = [
+  'comments',
+  'common-false-positives',
+  'legacy',
+  'std-error-handling'
+]
+paths = [
+  'third_party$',
+  'builtin$',
+  'examples$'
+]
+
+[formatters]
+[formatters.exclusions]
+generated = 'lax'
+paths = [
+  'third_party$',
+  'builtin$',
+  'examples$'
+]
+`
+
+	b, err := toml.Marshal(c)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, string(b))
+}
+
 func TestMarshalStringEscapes(t *testing.T) {
 	t.Run("invalid utf8 in basic string", func(t *testing.T) {
 		out, err := toml.Marshal(map[string]string{"a": "\xff"})


### PR DESCRIPTION
Fixes #1075.

The encoder reimplementation in #1067 introduced three serialization regressions, all of which surface when golangci-lint dumps/migrates its config (its `versiontwo` config tags every field `toml:"...,multiline,omitempty"` and encodes with the default encoder). Each was confirmed by comparing against the pre-#1067 encoder, and the whole set is verified end-to-end against golangci-lint's own `migrate` test suite (see below).

### 1. `multiline` tag wrapped single-line strings

A string tagged `multiline` was always emitted as a `"""..."""` block, even with no newline (`version = '2'` → `version = """\n2"""`). The multiline form is now used only when the string actually contains a newline; otherwise a normal single-line string is emitted.

### 2. Multiline array elements over-indented

With `SetArraysMultiline(true)` and `SetIndentTables` off, array elements were indented to the table nesting depth (6 spaces) while their key sat at column zero (2 spaces before). Value indentation now starts from zero when tables are not indented.

### 3. Empty intermediate tables emitted (omitempty)

The rewrite replaced the recursive struct-emptiness check with `reflect.Value.IsZero()`. `IsZero()` reports a struct as non-zero when any field is a **non-nil but empty** map/slice, so `omitempty` emitted an empty table header for it. golangci-lint's migration produces `linters.settings.tagliatelle.case` with a non-nil empty `Overrides` slice, yielding empty `[linters.settings]`, `[linters.settings.tagliatelle]`, and `[linters.settings.tagliatelle.case]` tables.

The recursive rule is restored: a table-valued struct is empty when every field it would encode is itself empty (maps/slices by length). Structs that encode as a scalar (`time.Time`, the local date/time types, any `TextMarshaler`) keep the `IsZero()` check, so non-zero values are still emitted.

### Verification

Beyond go-toml's own suite (green on go1.26.4 and go1.25.x, plus new regression tests for each fix), I ran golangci-lint's `migrate` `TestToConfig` suite against this branch: it **passes** with these fixes and **fails** against `v2` HEAD, reproducing the exact "after" output from the issue.

### Benchmarks (no regression)

Interleaved A/B (`go test -bench`, 6 rounds, n=12), comparing `v2` HEAD vs this branch:

- **macOS (Apple M1 Pro, go1.26.4):** all Marshal benchmarks `~` (not significant); `B/op` and `allocs/op` byte-for-byte identical.
- **linux/amd64 (Ryzen Threadripper, go1.26.4, cores pinned):** `B/op`/`allocs/op` byte-for-byte identical; nothing slower — several Marshal benchmarks marginally faster (geomean −0.70% time).

The new code paths are only reached via `omitempty`/`multiline`, which none of the benchmarks exercise, so this is effectively a no-op on the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)