### PR TITLE
Fix decode of embedded structs tagged with options only (e.g. `,inline`)

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -2238,14 +2238,16 @@ func addFields(plan *structPlan, t reflect.Type, prefix []int) {
 		f := t.Field(i)
 		tag, tagged := f.Tag.Lookup("toml")
 		name := f.Name
+		explicitName := ""
 		if tagged {
 			// A tag of exactly "-" drops the field. "-," names it "-".
 			if tag == "-" {
 				continue
 			}
 			parts := strings.SplitN(tag, ",", 2)
-			if parts[0] != "" {
-				name = parts[0]
+			explicitName = parts[0]
+			if explicitName != "" {
+				name = explicitName
 			}
 		}
 		if f.Anonymous {
@@ -2257,14 +2259,17 @@ func addFields(plan *structPlan, t reflect.Type, prefix []int) {
 				// Embedded non-struct fields are not decoded into.
 				continue
 			}
-			if !tagged {
-				// Untagged embedded structs are flattened, even when their
-				// type is unexported: only their own exported fields are
-				// reachable.
+			if explicitName == "" {
+				// Embedded structs without an explicit tag name are flattened,
+				// even when their type is unexported: only their own exported
+				// fields are reachable. A tag that only sets options (e.g.
+				// `,inline`) still flattens, matching encoding/json and the
+				// encoder's behavior.
 				embedded = append(embedded, f)
 				continue
 			}
-			// A tagged embedded struct acts as a regular named field.
+			// An embedded struct given an explicit tag name acts as a regular
+			// named field.
 		} else if f.PkgPath != "" {
 			// unexported
 			continue

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -4296,6 +4296,60 @@ func TestUnmarshalEmbedNonString(t *testing.T) {
 	assert.Equal(t, d.Foo, nil)
 }
 
+// Regression test for https://github.com/pelletier/go-toml/issues/1078: an
+// embedded struct whose toml tag only sets options (e.g. `,inline`) has no
+// explicit name and must be flattened, just like an untagged embedded struct
+// and just like the encoder does. Before the fix, the fields stayed at their
+// zero values.
+func TestUnmarshalEmbeddedInline(t *testing.T) {
+	type Base struct {
+		Region string
+		Name   string
+		Port   int
+	}
+	type Config struct {
+		Base `toml:",inline"`
+		PID  uint32
+	}
+
+	doc := `
+Region = "us"
+Name = "srv1"
+Port = 100
+PID = 42
+`
+	var c Config
+	err := toml.Unmarshal([]byte(doc), &c)
+	assert.NoError(t, err)
+	assert.Equal(t, Config{
+		Base: Base{Region: "us", Name: "srv1", Port: 100},
+		PID:  42,
+	}, c)
+}
+
+// An embedded struct given an explicit tag name keeps acting as a regular
+// named field: its contents come from a sub-table, not from promoted keys.
+func TestUnmarshalEmbeddedNamed(t *testing.T) {
+	type Base struct {
+		Region string
+	}
+	type Config struct {
+		Base `toml:"base"`
+		PID  uint32
+	}
+
+	var c Config
+	err := toml.Unmarshal([]byte("PID = 42\n[base]\nRegion = 'us'\n"), &c)
+	assert.NoError(t, err)
+	assert.Equal(t, Config{Base: Base{Region: "us"}, PID: 42}, c)
+
+	// Promoted keys must NOT populate a named embedded struct.
+	var c2 Config
+	err = toml.Unmarshal([]byte("Region = 'us'\nPID = 42\n"), &c2)
+	assert.NoError(t, err)
+	assert.Equal(t, Config{PID: 42}, c2)
+}
+
 func TestUnmarshal_Nil(t *testing.T) {
 	type Foo struct {
 		Foo *Foo `toml:"foo,omitempty"`


### PR DESCRIPTION
## Problem

Since v2.4 (the parser/decoder reimplementation, #1067), an embedded struct whose
`toml` tag only sets **options** but no **name** — most commonly `toml:",inline"` —
no longer decodes. Its fields stay at their zero values, while sibling non-embedded
fields decode fine. Reported in #1078.

```go
type Base struct {
	Region        string
	Name          string
	IPv4          string
	BsPort        int
	WebSocketPort int
	OutOfBandPort int
}

type Config struct {
	Base `toml:",inline"`
	PID  uint32
}
```

Decoding a flat document into `Config` left every `Base` field empty (only `PID`
was populated). This worked in v2.3.

## Cause

When building the struct decode plan, `addFields` decided whether to flatten
(promote) an embedded struct's fields based on whether the field had **any** tag:

```go
if !tagged {
	// flatten
}
// otherwise: treat as a regular named field expecting a [Base] sub-table
```

`toml:",inline"` *is* a tag, but its name part is empty, so `Base` was treated as a
named field and the promoted top-level keys never reached it.

This also made the decoder inconsistent with:
- **v2.3**, which flattened when the tag's *name part* was empty (`f.Anonymous && name == ""`);
- **`encoding/json`**, which promotes anonymous fields with an empty tag name;
- the **v2.4 encoder**, which already flattens via `!tagged || tagName(tag) == ""`.

That last inconsistency is exactly what the reporter saw: the value encoded
correctly but would not decode back.

## Fix

Decide flattening on the presence of an **explicit tag name** rather than on the
presence of any tag, mirroring the encoder's rule. An embedded struct given an
explicit name (e.g. `toml:"base"`) still acts as a named sub-table.

## Tests

- `TestUnmarshalEmbeddedInline` — regression for #1078 (`,inline` and option-only tags flatten).
- `TestUnmarshalEmbeddedNamed` — an explicitly named embedded struct still requires a
  sub-table and ignores promoted keys.

Full suite passes on go1.26.4 and go1.25.11. The change lives entirely in the
cached struct-plan builder (one-time per type, off the decode hot path);
`BenchmarkUnmarshal` shows no significant change (benchstat, linux/amd64).

Fixes #1078
