### PR TITLE
Update bundled toml.abnf to TOML 1.1.0 and pin spec-corner behaviour

### DIFF
--- a/compliance_corners_test.go
+++ b/compliance_corners_test.go
@@ -1,0 +1,95 @@
+package toml_test
+
+import (
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/pelletier/go-toml/v2/internal/assert"
+)
+
+// This file pins go-toml's behaviour in TOML spec corners that the upstream
+// toml-test conformance suite intentionally leaves undefined or under-tests.
+// Without these, a future refactor could silently change behaviour while the
+// generated toml_testgen_test.go stays green.
+//
+// It also keeps native regression coverage for the four TOML 1.1.0 grammar
+// changes, independent of the generated suite.
+
+// TOML 1.1.0 grammar features that must be accepted.
+func TestCorners_TOML11Accepted(t *testing.T) {
+	cases := map[string]string{
+		// #894 — seconds are optional in time and datetime.
+		"local-time-no-seconds":      "x = 13:37\n",
+		"offset-datetime-no-seconds": "x = 1979-05-27T07:32Z\n",
+		"offset-datetime-no-sec-num": "x = 1979-05-27T07:32-07:00\n",
+		"local-datetime-no-seconds":  "x = 1979-05-27T07:32\n",
+		// #790 — \e is the escape character (U+001B).
+		"esc-e": "x = \"\\e\"\n",
+		// #796 — \xHH is a two-digit hex escape for codepoints <= 0xFF.
+		"esc-x-lower": "x = \"\\xff\"\n",
+		"esc-x-upper": "x = \"\\xFF\"\n",
+		// #904 — newlines and trailing commas in inline tables.
+		"inline-trailing-comma": "x = {a = 1,}\n",
+		"inline-newline":        "x = {\n\ta = 1,\n}\n",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			var v map[string]interface{}
+			assert.NoError(t, toml.Unmarshal([]byte(input), &v))
+		})
+	}
+}
+
+// Gray-area corners where go-toml deliberately rejects input that the
+// conformance suite does not pin. These assertions document the intent.
+func TestCorners_DeliberateRejections(t *testing.T) {
+	cases := map[string]string{
+		// Leap seconds (:60) are grammar-permitted but not representable by
+		// time.Time without rolling over, so go-toml rejects them. toml-test
+		// only pins :61 as invalid, never :60.
+		"leap-second-local":  "x = 23:59:60\n",
+		"leap-second-offset": "x = 1979-05-27T23:59:60Z\n",
+
+		// Float overflow: 1e400 is rejected rather than decoded to +Inf.
+		// TOML 1.1.0 #1058 makes float size implementation-defined, so either
+		// behaviour is conformant; this pins go-toml's choice.
+		"float-overflow": "x = 1e400\n",
+
+		// #894 — fractional seconds may only appear when seconds are present.
+		"fraction-without-seconds": "x = 07:32.5\n",
+
+		// #796 — \xHH requires exactly two hex digits.
+		"esc-x-one-digit": "x = \"\\xf\"\n",
+		"esc-x-bad-hex":   "x = \"\\xg0\"\n",
+
+		// DEL (0x7F) is excluded from comments (non-eol = %x09 / %x20-7E /
+		// non-ascii) and from every string body.
+		"del-in-comment":   "x = 1 # a\x7fb\n",
+		"del-in-basic-str": "x = \"a\x7fb\"\n",
+
+		// #904 — a leading comma in an inline table is still invalid.
+		"inline-leading-comma": "x = {,a = 1}\n",
+	}
+	for name, input := range cases {
+		t.Run(name, func(t *testing.T) {
+			var v map[string]interface{}
+			assert.Error(t, toml.Unmarshal([]byte(input), &v))
+		})
+	}
+}
+
+// Multiline basic string quote-counting: content may end with up to two
+// quotation marks before the closing delimiter, but no more.
+func TestCorners_MultilineQuoteCounting(t *testing.T) {
+	t.Run("two-trailing-quotes", func(t *testing.T) {
+		var v struct {
+			X string `toml:"x"`
+		}
+		assert.NoError(t, toml.Unmarshal([]byte("x = \"\"\"a\"\"\"\"\"\n"), &v))
+		assert.Equal(t, `a""`, v.X)
+	})
+	t.Run("too-many-trailing-quotes", func(t *testing.T) {
+		var v map[string]interface{}
+		assert.Error(t, toml.Unmarshal([]byte("x = \"\"\"a\"\"\"\"\"\"\"\n"), &v))
+	})
+}

--- a/toml.abnf
+++ b/toml.abnf
@@ -36,7 +36,7 @@ newline =/ %x0D.0A  ; CRLF
 
 comment-start-symbol = %x23 ; #
 non-ascii = %x80-D7FF / %xE000-10FFFF
-non-eol = %x09 / %x20-7F / non-ascii
+non-eol = %x09 / %x20-7E / non-ascii
 
 comment = comment-start-symbol *non-eol
 
@@ -74,12 +74,14 @@ escape = %x5C                   ; \
 escape-seq-char =  %x22         ; "    quotation mark  U+0022
 escape-seq-char =/ %x5C         ; \    reverse solidus U+005C
 escape-seq-char =/ %x62         ; b    backspace       U+0008
+escape-seq-char =/ %x65         ; e    escape          U+001B
 escape-seq-char =/ %x66         ; f    form feed       U+000C
 escape-seq-char =/ %x6E         ; n    line feed       U+000A
 escape-seq-char =/ %x72         ; r    carriage return U+000D
 escape-seq-char =/ %x74         ; t    tab             U+0009
-escape-seq-char =/ %x75 4HEXDIG ; uXXXX                U+XXXX
-escape-seq-char =/ %x55 8HEXDIG ; UXXXXXXXX            U+XXXXXXXX
+escape-seq-char =/ %x78 2HEXDIG ; xHH                  U+00HH
+escape-seq-char =/ %x75 4HEXDIG ; uHHHH                U+HHHH
+escape-seq-char =/ %x55 8HEXDIG ; UHHHHHHHH            U+HHHHHHHH
 
 ;; Multiline Basic String
 
@@ -174,7 +176,7 @@ time-secfrac   = "." 1*DIGIT
 time-numoffset = ( "+" / "-" ) time-hour ":" time-minute
 time-offset    = "Z" / time-numoffset
 
-partial-time   = time-hour ":" time-minute ":" time-second [ time-secfrac ]
+partial-time   = time-hour ":" time-minute [ ":" time-second [ time-secfrac ] ]
 full-date      = date-fullyear "-" date-month "-" date-mday
 full-time      = partial-time time-offset
 
@@ -221,13 +223,14 @@ std-table-close = ws %x5D     ; ] Right square bracket
 
 ;; Inline Table
 
-inline-table = inline-table-open [ inline-table-keyvals ] inline-table-close
+inline-table = inline-table-open [ inline-table-keyvals ] ws-comment-newline inline-table-close
 
-inline-table-open  = %x7B ws     ; {
-inline-table-close = ws %x7D     ; }
-inline-table-sep   = ws %x2C ws  ; , Comma
+inline-table-open  = %x7B  ; {
+inline-table-close = %x7D  ; }
+inline-table-sep   = %x2C  ; , Comma
 
-inline-table-keyvals = keyval [ inline-table-sep inline-table-keyvals ]
+inline-table-keyvals =  ws-comment-newline keyval ws-comment-newline inline-table-sep inline-table-keyvals
+inline-table-keyvals =/ ws-comment-newline keyval ws-comment-newline [ inline-table-sep ]
 
 ;; Array Table
 


### PR DESCRIPTION
## What this does

Follow-up hygiene from a TOML 1.1.0 spec-compliance audit of the reimplemented (#1067) parser/decoder/encoder. The audit found the implementation **highly compliant** — the full toml-test v2.1.0 suite plus ~160 extra targeted probes surfaced **no parser/encoder compliance bugs**. The only concrete defect was the bundled grammar, plus a couple of intentional behaviours that weren't pinned by any test.

### 1. `docs:` fix the bundled `toml.abnf`

It was still the TOML **1.0.0** grammar, and additionally contained an outright error. `toml.abnf` is referenced by no code (documentation only), but the README advertises 1.1.0 support, so the reference should match. Four rules brought in line with the official 1.1.0 ABNF — all four features were **already implemented**; this is doc-only:

| Rule | Change | Ref |
|------|--------|-----|
| `non-eol` | `%x20-7F` → `%x20-7E` (exclude DEL from comments) | — |
| `escape-seq-char` | add `\e` (U+001B) and `\xHH` | #790, #796 |
| `partial-time` | seconds optional | #894 |
| `inline-table` | allow ws/comments/newlines + trailing comma | #904 |

The `non-eol` line is notable: the parser already rejects `0x7F` in comments, so the grammar was the *only* thing in the repo claiming DEL was allowed.

### 2. `test:` pin spec-corner behaviour

`compliance_corners_test.go` adds native regression coverage for corners that toml-test intentionally leaves undefined or under-tests, so a future refactor can't silently change behaviour while the generated suite stays green:

- leap seconds (`:60`) rejected — not representable by `time.Time`;
- float overflow (`1e400`) rejected rather than decoded to `+Inf` — implementation-defined per #1058;
- fractional seconds without seconds rejected (#894);
- `\xHH` requires exactly two hex digits (#796);
- DEL (`0x7F`) rejected in comments and string bodies;
- multiline basic string quote-counting (content may end with up to two quotes).

It also keeps native coverage of the four 1.1.0 grammar features independent of the generated suite.

No behaviour changes to the parser/decoder/encoder — grammar doc + tests only.

---

N/A — no production code changed, so no benchstat results.