### PR TITLE
Deliver the whole document to a root Unmarshaler (#994)

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -512,6 +512,15 @@ func (d *decoder) unmarshal(data []byte, v interface{}) error {
 		}
 	}
 
+	// When the root target itself implements the Unmarshaler interface, the
+	// whole document decodes into it. Open a capture spanning the entire
+	// document up front: the top-level key-values then flow through the
+	// existing capture branch and any tables attach to it via resumeCapture,
+	// so UnmarshalTOML receives the assembled document exactly once.
+	if d.unmarshalerInterface && hasUnmarshaler(root) {
+		d.startRootCapture()
+	}
+
 	for d.p.NextExpression() {
 		err := d.handleRootExpression(d.p.Expression(), root)
 		if err != nil {
@@ -1151,6 +1160,18 @@ func (d *decoder) startCapture(pathLen int, expr *unstable.Node) {
 	if pathLen < len(d.tableKey) {
 		d.appendCaptureHeader(&d.captures[d.captureIdx], expr, pathLen)
 	}
+}
+
+// startRootCapture opens a capture covering the entire document, used when the
+// root target itself implements the Unmarshaler interface. It is opened before
+// reading any expression: top-level key-values are then accumulated through the
+// regular capture branch, and its empty name path matches every table in
+// resumeCapture, so the whole document is handed to UnmarshalTOML once. The
+// single index slot is -1 because the root is never reached through an array
+// table.
+func (d *decoder) startRootCapture() {
+	d.captures = append(d.captures, rawCapture{indexes: []int{-1}})
+	d.captureIdx = len(d.captures) - 1
 }
 
 // resolveCapture walks back to the target of a capture and delivers the

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -4524,8 +4524,74 @@ func TestIssue994_OK(t *testing.T) {
 		Decode(&d)
 
 	assert.NoError(t, err)
-	// With bytes-based interface, raw TOML bytes are passed including quotes
-	assert.Equal(t, "\"bar\" from unmarshaler", d.S)
+	// The root target implements Unmarshaler, so it receives the whole
+	// document (not just the value of the first key).
+	assert.Equal(t, "foo = \"bar\"\n from unmarshaler", d.S)
+}
+
+// rootUnmarshaler994 records every call to UnmarshalTOML and the bytes it
+// received, to assert that a root target gets the entire document exactly once.
+type rootUnmarshaler994 struct {
+	calls [][]byte
+}
+
+func (d *rootUnmarshaler994) UnmarshalTOML(data []byte) error {
+	cp := append([]byte(nil), data...)
+	d.calls = append(d.calls, cp)
+	return nil
+}
+
+// TestIssue994_WholeDocument covers the part of issue #994 that the initial
+// fix (PR #996) left open: when the root target implements Unmarshaler, the
+// entire document — including top-level key-values defined before any table,
+// tables, and array tables — must be delivered to UnmarshalTOML exactly once,
+// as a valid TOML document that re-parses to the original structure.
+func TestIssue994_WholeDocument(t *testing.T) {
+	examples := map[string]string{
+		"single key":           `foo = "bar"`,
+		"multiple keys":        "a = 1\nb = 2\nc = 3\n",
+		"keys then table":      "title = \"TOML Example\"\n[owner]\nname = \"Tom\"\n",
+		"keys then arraytable": "title = \"t\"\n[[item]]\na = 1\n[[item]]\na = 2\n[item.sub]\nb = 3\n",
+		"only table":           "[owner]\nname = \"Tom\"\n",
+		"dotted keys":          "x.y = 1\nx.z = 2\n",
+		"empty document":       "",
+	}
+
+	for name, doc := range examples {
+		t.Run(name, func(t *testing.T) {
+			var root rootUnmarshaler994
+			err := toml.NewDecoder(strings.NewReader(doc)).
+				EnableUnmarshalerInterface().
+				Decode(&root)
+			assert.NoError(t, err)
+
+			// UnmarshalTOML must be called exactly once, with the whole
+			// document, never partial fragments per key-value.
+			assert.Equal(t, 1, len(root.calls))
+
+			// The bytes handed over must be a self-contained TOML document
+			// that decodes to the same structure as the original input. This
+			// is what lets a custom unmarshaler re-parse it (e.g. to preserve
+			// ordering, the issue's original motivation).
+			var fromRaw, fromOriginal map[string]interface{}
+			assert.NoError(t, toml.Unmarshal(root.calls[0], &fromRaw))
+			assert.NoError(t, toml.Unmarshal([]byte(doc), &fromOriginal))
+			assert.Equal(t, fromOriginal, fromRaw)
+		})
+	}
+}
+
+// TestIssue994_ErrorPropagation makes sure an error returned by a root
+// Unmarshaler still surfaces from Decode for documents that exercise the
+// whole-document capture path (not just a single top-level key-value).
+func TestIssue994_ErrorPropagation(t *testing.T) {
+	doc := "title = \"t\"\n[owner]\nname = \"Tom\"\n"
+	var d doc994
+	err := toml.NewDecoder(strings.NewReader(doc)).
+		EnableUnmarshalerInterface().
+		Decode(&d)
+	assert.Error(t, err)
+	assert.Equal(t, "expected-error", err.Error())
 }
 
 func TestIssue995(t *testing.T) {

--- a/unstable/unmarshaler.go
+++ b/unstable/unmarshaler.go
@@ -7,6 +7,10 @@ package unstable
 // For tables (including split tables defined in multiple places), the data
 // contains the raw key-value bytes from the original document with adjusted
 // table headers to be relative to the unmarshaling target.
+//
+// When the decoding target itself implements this interface, it receives the
+// whole document — every top-level key-value as well as every table and array
+// table — assembled into a single valid TOML document and delivered once.
 type Unmarshaler interface {
 	UnmarshalTOML(data []byte) error
 }


### PR DESCRIPTION
Fixes #994.

## Problem

When the decode target itself implements `unstable.Unmarshaler` (with `EnableUnmarshalerInterface()`), `UnmarshalTOML` was not receiving the document. Top-level key-values were delegated **one value at a time**, and a document split into pieces (top-level keys followed by tables) arrived as disconnected fragments instead of a single document:

| Input | Before | After |
|---|---|---|
| `foo = "bar"` | called once with `"bar"` (just the value) | called once with `foo = "bar"\n` |
| two top-level keys | called **twice**, once per value | called **once**, whole doc |
| `title=…` then `[owner]…` | called **twice** with fragments | called **once**, whole doc |

This made a root `Unmarshaler` unusable for its main purpose — re-parsing the full document, e.g. to preserve key ordering, which is exactly what the issue asked for. PR #996 only delegated unmatched top-level keys individually and, as noted when it was merged, never handled piece-wise tables.

## Fix

The rewritten decoder already accumulates a whole table (including split and array tables) into a single raw "capture" that is delivered to `UnmarshalTOML` once. This routes the **root** through the same machinery: when the root target implements the interface, a capture spanning the entire document is opened up front. Top-level key-values then flow through the existing capture branch, and any tables attach to it via `resumeCapture`, so `UnmarshalTOML` is called **exactly once** with a self-contained TOML document that re-parses to the original structure.

The change is gated on the opt-in interface, so it adds no work to the default decode path.

## Example: preserving key order (the issue's use-case)

```go
// OrderedConfig records top-level keys in document order. Because it is the
// decode target and implements unstable.Unmarshaler, it receives the whole
// document and re-parses it with the unstable parser.
type OrderedConfig struct {
	Keys []string
}

func (c *OrderedConfig) UnmarshalTOML(data []byte) error {
	var p unstable.Parser
	p.Reset(data)
	for p.NextExpression() {
		e := p.Expression()
		if e.Kind != unstable.KeyValue {
			continue
		}
		it := e.Key()
		it.Next() // first part of the (possibly dotted) key
		c.Keys = append(c.Keys, string(it.Node().Data))
	}
	return p.Error()
}

func main() {
	doc := `gamma = 1
alpha = 2
beta  = 3`

	var cfg OrderedConfig
	if err := toml.NewDecoder(strings.NewReader(doc)).
		EnableUnmarshalerInterface().
		Decode(&cfg); err != nil {
		panic(err)
	}
	fmt.Println(cfg.Keys) // [gamma alpha beta]
}
```

Before this change, `cfg.Keys` would have been empty (the unmarshaler was handed only the value `1`, twice).

## Tests

- Updated `TestIssue994_OK`, which had baked in the old partial-value result.
- Added `TestIssue994_WholeDocument` (single/multiple keys, keys-then-table, keys-then-array-table, only-table, dotted keys, empty doc): asserts `UnmarshalTOML` is called exactly once **and** that the bytes round-trip back to the same structure as the original input.
- Added `TestIssue994_ErrorPropagation` for the multi-expression capture path.

Full suite passes (`go test ./...`).

## Performance

No regression. Interleaved A/B benchstat on linux/amd64 (go1.26.4, n=12), all benchmarks not statistically significant — `allocs/op` byte-identical:

```
Unmarshal/SimpleDocument/struct-8   335.2n ± 2%   335.6n ± 1%   ~ (p=0.385 n=12)
Unmarshal/SimpleDocument/map-8      386.4n ± 3%   387.9n ± 1%   ~ (p=0.854 n=12)
Unmarshal/ReferenceFile/struct-8    36.51µ ± 0%   36.46µ ± 1%   ~ (p=1.000 n=12)
Unmarshal/ReferenceFile/map-8       29.72µ ± 1%   29.88µ ± 2%   ~ (p=0.478 n=12)
Unmarshal/HugoFrontMatter-8         5.226µ ± 1%   5.192µ ± 2%   ~ (p=0.347 n=12)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
