### PR TITLE
Add RawMessage marshal support to unstable

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -15,6 +15,9 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
+
+	"github.com/pelletier/go-toml/v2/internal/parserbridge"
+	"github.com/pelletier/go-toml/v2/unstable"
 )
 
 // Marshal serializes a Go value as a TOML document.
@@ -25,6 +28,7 @@ func Marshal(v interface{}) ([]byte, error) {
 
 	e := encoderStatePool.Get().(*encoderState)
 	e.Encoder = &enc
+	e.marshalerOn = enc.marshalerInterface
 	e.buf = e.buf[:0]
 	e.keyStack = e.keyStack[:0]
 	e.lastWasHeader = false
@@ -52,6 +56,9 @@ type Encoder struct {
 	indentSymbol       string
 	indentTables       bool
 	marshalJSONNumbers bool
+
+	// toggles the unstable.Marshaler interface
+	marshalerInterface bool
 }
 
 // NewEncoder returns a new Encoder that writes to w.
@@ -107,6 +114,29 @@ func (enc *Encoder) SetIndentTables(indent bool) *Encoder {
 // issued.
 func (enc *Encoder) SetMarshalJSONNumbers(indent bool) *Encoder {
 	enc.marshalJSONNumbers = indent
+	return enc
+}
+
+// EnableMarshalerInterface enables the unstable.Marshaler interface.
+//
+// With this feature enabled, types implementing the unstable.Marshaler
+// interface emit their own raw TOML instead of being encoded structurally. It
+// is the encoding counterpart of Decoder.EnableUnmarshalerInterface, and allows
+// types such as unstable.RawMessage to round-trip raw TOML bytes.
+//
+// The bytes returned by MarshalTOML are spliced into the document verbatim. The
+// encoder parses them to decide between the two valid positions:
+//   - bytes forming a single value are emitted inline, as in `key = <raw>`;
+//   - bytes forming key-value lines are emitted as the body of a `[key]` table.
+//
+// An empty result is omitted from the output. Bytes that form table content
+// cannot be emitted inside an array or inline table and result in an error.
+//
+// *Unstable:* This method does not follow the compatibility guarantees of
+// semver. It can be changed or removed without a new major version being
+// issued.
+func (enc *Encoder) EnableMarshalerInterface() *Encoder {
+	enc.marshalerInterface = true
 	return enc
 }
 
@@ -186,6 +216,7 @@ func (enc *Encoder) SetMarshalJSONNumbers(indent bool) *Encoder {
 func (enc *Encoder) Encode(v interface{}) error {
 	e := encoderStatePool.Get().(*encoderState)
 	e.Encoder = enc
+	e.marshalerOn = enc.marshalerInterface
 	e.buf = e.buf[:0]
 	e.keyStack = e.keyStack[:0]
 	e.lastWasHeader = false
@@ -227,6 +258,15 @@ type encoderState struct {
 	// stringKeyBuf is a reusable buffer to read string map keys without
 	// allocating one per map.
 	stringKeyBuf reflect.Value
+
+	// parser classifies the bytes returned by unstable.Marshaler values as a
+	// single value or a table body. Only used when marshalerOn is set.
+	parser unstable.Parser
+
+	// marshalerOn mirrors Encoder.marshalerInterface, copied onto the state so
+	// the per-value hot path checks a direct field instead of dereferencing the
+	// embedded *Encoder on every value.
+	marshalerOn bool
 }
 
 // valueOptions are the encoding options attached to one entry of a table.
@@ -236,7 +276,13 @@ type valueOptions struct {
 	omitempty bool
 	omitzero  bool
 	commented bool
-	comment   string
+	// rawShape is the unstable.Marshaler classification of the entry's value,
+	// resolved at encode time (not from tags). It lives here, in the byte of
+	// padding the booleans already leave, so that entry does not grow and the
+	// encoder's default (interface-disabled) path keeps its exact layout and
+	// performance. It stays shapeUnknown for everything that is not a Marshaler.
+	rawShape rawShape
+	comment  string
 }
 
 // entry is a deferred key-value of a table being encoded.
@@ -245,6 +291,22 @@ type entry struct {
 	value   reflect.Value
 	options valueOptions
 }
+
+// rawShape classifies the bytes produced by an unstable.Marshaler.
+type rawShape uint8
+
+const (
+	// shapeUnknown is the default: not an unstable.Marshaler, or the interface
+	// is disabled.
+	shapeUnknown rawShape = iota
+	// shapeEmpty is whitespace-only content: it has no TOML representation and
+	// is omitted from the output.
+	shapeEmpty
+	// shapeValue is a single TOML value, emitted inline as `key = <raw>`.
+	shapeValue
+	// shapeTable is one or more key-value lines, emitted as a `[key]` body.
+	shapeTable
+)
 
 func (e *encoderState) encodeRoot(v interface{}) error {
 	if v == nil {
@@ -293,9 +355,14 @@ func resolve(v reflect.Value) (reflect.Value, bool) {
 type typeEncProps struct {
 	// 0: not a TextMarshaler, 1: the type implements it, 2: its pointer does
 	text uint8
+	// 0: not an unstable.Marshaler, 1: the type implements it, 2: its pointer
+	// does. Only consulted when Encoder.marshalerInterface is set.
+	marshaler uint8
 	// encoded as a TOML value (as opposed to a table)
 	isValue bool
 }
+
+var marshalerType = reflect.TypeOf(new(unstable.Marshaler)).Elem()
 
 var typeEncPropsCache sync.Map // reflect.Type -> typeEncProps
 
@@ -309,6 +376,12 @@ func encPropsForType(t reflect.Type) typeEncProps {
 		p.text = 1
 	case reflect.PtrTo(t).Implements(textMarshalerType):
 		p.text = 2
+	}
+	switch {
+	case t.Implements(marshalerType):
+		p.marshaler = 1
+	case reflect.PtrTo(t).Implements(marshalerType):
+		p.marshaler = 2
 	}
 	switch t {
 	case timeType, localDateType, localTimeType, localDateTimeType:
@@ -360,6 +433,11 @@ func (e *encoderState) isArrayOfTables(v reflect.Value) bool {
 	if v.Len() == 0 {
 		return false
 	}
+	// The Marshaler-aware classification lives in a separate method, hoisted out
+	// of this loop, so the default path keeps its exact original shape.
+	if e.marshalerOn {
+		return e.isMarshalerArrayOfTables(v)
+	}
 	for i := 0; i < v.Len(); i++ {
 		elem, ok := resolve(v.Index(i))
 		if !ok || isValueKind(elem) {
@@ -369,6 +447,134 @@ func (e *encoderState) isArrayOfTables(v reflect.Value) bool {
 	return true
 }
 
+// isMarshalerArrayOfTables is the EnableMarshalerInterface variant of
+// isArrayOfTables: a Marshaler element counts as a table only when its raw
+// content is table shaped (key-value lines); one holding a single value makes
+// the whole slice a plain array instead.
+func (e *encoderState) isMarshalerArrayOfTables(v reflect.Value) bool {
+	for i := 0; i < v.Len(); i++ {
+		elem, ok := resolve(v.Index(i))
+		if !ok {
+			return false
+		}
+		if encPropsForType(elem.Type()).marshaler != 0 {
+			raw, err := e.marshalerBytes(elem)
+			if err != nil {
+				return false
+			}
+			if shape, _ := e.classifyRaw(raw); shape != shapeTable {
+				return false
+			}
+			continue
+		}
+		if isValueKind(elem) {
+			return false
+		}
+	}
+	return true
+}
+
+// marshalerBytes returns the raw TOML produced by v's unstable.Marshaler
+// implementation. The caller guarantees v implements the interface
+// (encPropsForType(v.Type()).marshaler != 0).
+func (e *encoderState) marshalerBytes(v reflect.Value) ([]byte, error) {
+	t := v.Type()
+	var m unstable.Marshaler
+	switch {
+	case encPropsForType(t).marshaler == 1:
+		// The type itself implements Marshaler (e.g. a value receiver).
+		m = v.Interface().(unstable.Marshaler)
+	case v.CanAddr():
+		// Only the pointer implements it, and v is addressable.
+		m = v.Addr().Interface().(unstable.Marshaler)
+	default:
+		// Only the pointer implements it, but v is not addressable: take the
+		// address of a copy.
+		tmp := reflect.New(t)
+		tmp.Elem().Set(v)
+		m = tmp.Interface().(unstable.Marshaler)
+	}
+	b, err := m.MarshalTOML()
+	if err != nil {
+		return nil, fmt.Errorf("toml: error calling MarshalTOML: %w", err)
+	}
+	return b, nil
+}
+
+// classifyRaw decides whether b (the output of an unstable.Marshaler) is empty,
+// a single TOML value, or a table body. It returns the trimmed bytes that
+// should be spliced into the document. It reuses e.parser, so it is not safe
+// for concurrent use (encoderState is not shared).
+func (e *encoderState) classifyRaw(b []byte) (rawShape, []byte) {
+	trimmed := bytes.TrimSpace(b)
+	if len(trimmed) == 0 {
+		return shapeEmpty, trimmed
+	}
+	e.parser.Reset(trimmed)
+	_, rest, err := parserbridge.ParseValue(&e.parser, trimmed)
+	if err == nil && len(bytes.TrimSpace(rest)) == 0 {
+		return shapeValue, trimmed
+	}
+	return shapeTable, trimmed
+}
+
+// resolveMarshalerEntries classifies every entry whose value implements
+// unstable.Marshaler, recording the shape on the entry so the two table passes
+// can route it without re-classifying. Any error from MarshalTOML is surfaced
+// eagerly. The marshaled bytes themselves are produced again at emit time by
+// marshalerValue; that keeps entry small on the encoder's hot path, and only
+// runs when the (opt-in) interface is enabled.
+func (e *encoderState) resolveMarshalerEntries(entries []entry) error {
+	for i := range entries {
+		ent := &entries[i]
+		v, ok := resolve(ent.value)
+		if !ok || encPropsForType(v.Type()).marshaler == 0 {
+			continue
+		}
+		raw, err := e.marshalerBytes(v)
+		if err != nil {
+			return err
+		}
+		ent.options.rawShape, _ = e.classifyRaw(raw)
+	}
+	return nil
+}
+
+// marshalerValue returns the trimmed bytes to splice for an entry already known
+// to be an unstable.Marshaler (ent.options.rawShape != shapeUnknown).
+func (e *encoderState) marshalerValue(ent *entry) ([]byte, error) {
+	v, _ := resolve(ent.value)
+	raw, err := e.marshalerBytes(v)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(raw), nil
+}
+
+// appendMarshalerInline emits an unstable.Marshaler value in a value position
+// (array element or inline-table member), where only a single TOML value is
+// valid. done is false when t is not a Marshaler, so appendValue falls through
+// to its normal handling. It is split out of appendValue (type check included)
+// to keep that hot path lean.
+func (e *encoderState) appendMarshalerInline(b []byte, v reflect.Value, t reflect.Type) (out []byte, done bool, err error) {
+	if encPropsForType(t).marshaler == 0 {
+		return b, false, nil
+	}
+	raw, err := e.marshalerBytes(v)
+	if err != nil {
+		return nil, true, err
+	}
+	shape, trimmed := e.classifyRaw(raw)
+	switch shape {
+	case shapeValue:
+		return append(b, trimmed...), true, nil
+	case shapeEmpty:
+		return nil, true, fmt.Errorf("toml: cannot encode an empty %s as an inline value", t)
+	default:
+		return nil, true, fmt.Errorf("toml: cannot encode %s as an inline value: %q is table content", t, trimmed)
+	}
+}
+
 // encodeTable writes the content of a table at the given key path.
 func (e *encoderState) encodeTable(v reflect.Value, commented bool, indent int) error {
 	entries, err := e.collectEntries(v)
@@ -376,15 +582,51 @@ func (e *encoderState) encodeTable(v reflect.Value, commented bool, indent int) 
 		return err
 	}
 
+	// Marshaler routing is hoisted behind a single local flag. When the (opt-in)
+	// interface is off, mOn is false and both passes run the exact baseline
+	// code, so the default Marshal path keeps its performance.
+	mOn := e.marshalerOn
+	if mOn {
+		// Classify Marshaler entries once, up front, so the passes can route
+		// them by shape and surface MarshalTOML errors eagerly.
+		if err := e.resolveMarshalerEntries(entries); err != nil {
+			return err
+		}
+	}
+
 	// First pass: emit all key-values; tables are handled by the second
 	// pass.
 	for i := range entries {
 		ent := &entries[i]
+		if mOn {
+			switch ent.options.rawShape {
+			case shapeUnknown:
+				// Not a Marshaler: handled by the baseline logic below.
+			case shapeEmpty:
+				// No TOML representation: omit the key.
+				continue
+			case shapeValue:
+				if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
+					return err
+				}
+				continue
+			case shapeTable:
+				// A table body is emitted in the second pass, unless it is
+				// forced inline (SetTablesInline / inline tag), which has no
+				// valid inline form and is reported as an error by
+				// encodeKeyValue.
+				if e.tablesInline || ent.options.inline {
+					if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
+						return err
+					}
+				}
+				continue
+			}
+		}
 		if e.entryIsTable(ent) {
 			continue
 		}
-		err := e.encodeKeyValue(*ent, commented, indent)
-		if err != nil {
+		if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
 			return err
 		}
 	}
@@ -392,6 +634,25 @@ func (e *encoderState) encodeTable(v reflect.Value, commented bool, indent int) 
 	// Second pass: emit the sub-tables, extending the shared key stack.
 	for i := range entries {
 		ent := entries[i]
+		if mOn {
+			switch ent.options.rawShape {
+			case shapeUnknown:
+				// Not a Marshaler: handled by the baseline logic below.
+			case shapeValue, shapeEmpty:
+				// Not a table: already handled (or omitted) in the first pass.
+				continue
+			case shapeTable:
+				// Emit the raw body verbatim under the freshly pushed header.
+				// (The forced-inline case already errored in the first pass.)
+				entCommented := commented || ent.options.commented
+				e.keyStack = append(e.keyStack, ent.key)
+				if err := e.encodeMarshalerTable(&ent, entCommented, indent); err != nil {
+					return err
+				}
+				e.keyStack = e.keyStack[:len(e.keyStack)-1]
+				continue
+			}
+		}
 		if !e.entryIsTable(&ent) {
 			continue
 		}
@@ -423,8 +684,23 @@ func (e *encoderState) encodeTable(v reflect.Value, commented bool, indent int) 
 	return nil
 }
 
+// encodeMarshalerTable emits a table-shaped unstable.Marshaler entry: the
+// header for the key currently on the stack, then the raw body verbatim.
+func (e *encoderState) encodeMarshalerTable(ent *entry, commented bool, indent int) error {
+	raw, err := e.marshalerValue(ent)
+	if err != nil {
+		return err
+	}
+	e.writeTableHeader(ent.options.comment, commented, false, indent)
+	e.buf = append(e.buf, raw...)
+	e.buf = append(e.buf, '\n')
+	e.lastWasHeader = false
+	return nil
+}
+
 // entryIsTable reports whether the entry is emitted as a (sub-)table rather
-// than a key-value.
+// than a key-value. Marshaler entries are routed by encodeTable before this is
+// reached, so it carries no marshaler-specific cost.
 func (e *encoderState) entryIsTable(ent *entry) bool {
 	return !e.tablesInline && !ent.options.inline && (e.isTableLike(ent.value) || e.isArrayOfTables(ent.value))
 }
@@ -457,6 +733,20 @@ func (e *encoderState) encodeArrayTable(ent entry, commented bool, indent int) e
 		e.writeTableHeader(comment, commented, true, indent)
 		// The comment is only present before the first element.
 		comment = ""
+
+		// A Marshaler element splices its raw table body verbatim. The shape
+		// was already checked by isArrayOfTables, so it is shapeTable here.
+		if e.marshalerOn && encPropsForType(elem.Type()).marshaler != 0 {
+			raw, err := e.marshalerBytes(elem)
+			if err != nil {
+				return err
+			}
+			_, trimmed := e.classifyRaw(raw)
+			e.buf = append(e.buf, trimmed...)
+			e.buf = append(e.buf, '\n')
+			e.lastWasHeader = false
+			continue
+		}
 
 		err := e.encodeTable(elem, commented, indent+1)
 		if err != nil {
@@ -552,8 +842,15 @@ func (e *encoderState) encodeKeyValue(ent entry, commented bool, indent int) err
 		valueIndent = 0
 	}
 
+	// A Marshaler value is delegated, keeping this hot function lean for the
+	// default path (rawShape stays shapeUnknown when the interface is off). It
+	// shares the commented/newline handling below.
 	var err error
-	e.buf, err = e.appendValue(e.buf, ent.value, ent.options, valueIndent)
+	if ent.options.rawShape != shapeUnknown {
+		e.buf, err = e.appendMarshalerInlineValue(e.buf, &ent)
+	} else {
+		e.buf, err = e.appendValue(e.buf, ent.value, ent.options, valueIndent)
+	}
 	if err != nil {
 		return err
 	}
@@ -574,6 +871,22 @@ func (e *encoderState) encodeKeyValue(ent entry, commented bool, indent int) err
 	e.buf = append(e.buf, '\n')
 	e.lastWasHeader = false
 	return nil
+}
+
+// appendMarshalerInlineValue appends the value part of a `key = ` line for an
+// unstable.Marshaler entry, leaving the trailing newline and commented handling
+// to encodeKeyValue. Empty entries are filtered out before this point, so the
+// value is either a single value (spliced verbatim) or, when forced inline by
+// SetTablesInline or an inline tag, table content (an error).
+func (e *encoderState) appendMarshalerInlineValue(b []byte, ent *entry) ([]byte, error) {
+	if ent.options.rawShape != shapeValue {
+		return nil, fmt.Errorf("toml: cannot encode %s as an inline value: not a single TOML value", ent.value.Type())
+	}
+	raw, err := e.marshalerValue(ent)
+	if err != nil {
+		return nil, err
+	}
+	return append(b, raw...), nil
 }
 
 // collectEntries builds the ordered list of the entries of a table,
@@ -984,6 +1297,16 @@ func (e *encoderState) appendValue(b []byte, v reflect.Value, opts valueOptions,
 	case jsonNumberType:
 		if e.marshalJSONNumbers {
 			return appendJSONNumber(b, v.Interface().(json.Number))
+		}
+	}
+
+	// A Marshaler reached through a value position (an array element or inline
+	// table member) splices its bytes verbatim. Everything (including the type
+	// check) lives in a separate method so this hot function keeps its default
+	// layout: when the opt-in interface is off, only the bool test runs here.
+	if e.marshalerOn {
+		if b2, done, err := e.appendMarshalerInline(b, v, t); done {
+			return b2, err
 		}
 	}
 

--- a/marshaler.go
+++ b/marshaler.go
@@ -125,12 +125,18 @@ func (enc *Encoder) SetMarshalJSONNumbers(indent bool) *Encoder {
 // types such as unstable.RawMessage to round-trip raw TOML bytes.
 //
 // The bytes returned by MarshalTOML are spliced into the document verbatim. The
-// encoder parses them to decide between the two valid positions:
+// encoder parses them to decide between the valid positions:
 //   - bytes forming a single value are emitted inline, as in `key = <raw>`;
-//   - bytes forming key-value lines are emitted as the body of a `[key]` table.
+//   - bytes forming key-value lines are emitted as the body of a `[key]` table;
+//   - at the document root, the bytes are emitted as the whole document: the
+//     encode counterpart of the decoder delivering the whole document to a
+//     root unstable.Unmarshaler.
 //
-// An empty result is omitted from the output. Bytes that form table content
-// cannot be emitted inside an array or inline table and result in an error.
+// An empty result is omitted from the output. Bytes that are not valid TOML
+// for their position result in an error, as do bytes forming table content in
+// a position where only a value is valid (an array element, an inline table,
+// or a table forced inline). MarshalTOML can be called more than once for the
+// same value during a single encode, so it must be deterministic.
 //
 // *Unstable:* This method does not follow the compatibility guarantees of
 // semver. It can be changed or removed without a new major version being
@@ -319,6 +325,10 @@ func (e *encoderState) encodeRoot(v interface{}) error {
 		return errors.New("toml: cannot encode a nil pointer")
 	}
 
+	if e.marshalerOn && encPropsForType(rv.Type()).marshaler != 0 {
+		return e.encodeMarshalerRoot(rv)
+	}
+
 	switch rv.Kind() {
 	case reflect.Map, reflect.Struct:
 		if isValueKind(rv) {
@@ -328,6 +338,34 @@ func (e *encoderState) encodeRoot(v interface{}) error {
 	default:
 		return fmt.Errorf("toml: cannot encode a %s as a document root", rv.Type())
 	}
+}
+
+// encodeMarshalerRoot emits the bytes of a root-level unstable.Marshaler as
+// the whole document: the encode counterpart of the decoder delivering the
+// whole document to a root Unmarshaler. The bytes must form a TOML document
+// (key-value lines and table headers); empty output produces an empty
+// document.
+func (e *encoderState) encodeMarshalerRoot(rv reflect.Value) error {
+	raw, err := e.marshalerBytes(rv)
+	if err != nil {
+		return err
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if err := e.validateRawTableBody(rv.Type(), trimmed); err != nil {
+		// A single TOML value has no meaning at the document root; report it
+		// as such rather than as a syntax error.
+		if shape, _ := e.classifyRaw(trimmed); shape == shapeValue {
+			return fmt.Errorf("toml: cannot encode %s as a document root: MarshalTOML returned a single TOML value, not a document", rv.Type())
+		}
+		return err
+	}
+	e.buf = append(e.buf, trimmed...)
+	e.buf = append(e.buf, '\n')
+	e.lastWasHeader = false
+	return nil
 }
 
 // resolve unwraps pointers and interfaces until a concrete value is found.
@@ -496,9 +534,22 @@ func (e *encoderState) marshalerBytes(v reflect.Value) ([]byte, error) {
 	}
 	b, err := m.MarshalTOML()
 	if err != nil {
-		return nil, fmt.Errorf("toml: error calling MarshalTOML: %w", err)
+		return nil, fmt.Errorf("toml: error calling MarshalTOML for type %s: %w", t, err)
 	}
 	return b, nil
+}
+
+// validateRawTableBody checks that trimmed — table-shaped Marshaler output
+// about to be spliced verbatim — is syntactically valid TOML, so a Marshaler
+// cannot silently corrupt the document. It reuses e.parser, like classifyRaw.
+func (e *encoderState) validateRawTableBody(t reflect.Type, trimmed []byte) error {
+	e.parser.Reset(trimmed)
+	for e.parser.NextExpression() {
+	}
+	if err := e.parser.Error(); err != nil {
+		return fmt.Errorf("toml: error calling MarshalTOML for type %s: invalid TOML: %w", t, err)
+	}
+	return nil
 }
 
 // classifyRaw decides whether b (the output of an unstable.Marshaler) is empty,
@@ -571,7 +622,7 @@ func (e *encoderState) appendMarshalerInline(b []byte, v reflect.Value, t reflec
 	case shapeEmpty:
 		return nil, true, fmt.Errorf("toml: cannot encode an empty %s as an inline value", t)
 	default:
-		return nil, true, fmt.Errorf("toml: cannot encode %s as an inline value: %q is table content", t, trimmed)
+		return nil, true, fmt.Errorf("toml: cannot encode %s as an inline value: %q is not a single TOML value", t, trimmed)
 	}
 }
 
@@ -691,11 +742,33 @@ func (e *encoderState) encodeMarshalerTable(ent *entry, commented bool, indent i
 	if err != nil {
 		return err
 	}
+	// Validate the bytes actually being spliced: MarshalTOML is called again
+	// for the emit, so this both rejects invalid TOML and guards against an
+	// implementation that returned different content than during
+	// classification.
+	if err := e.validateRawTableBody(ent.value.Type(), raw); err != nil {
+		return err
+	}
 	e.writeTableHeader(ent.options.comment, commented, false, indent)
-	e.buf = append(e.buf, raw...)
+	e.spliceRawTableBody(raw, commented)
+	return nil
+}
+
+// spliceRawTableBody appends a raw table body verbatim after its header. When
+// the table is commented, every physical line is prefixed with the comment
+// marker so the body does not leak into the document as live keys.
+func (e *encoderState) spliceRawTableBody(raw []byte, commented bool) {
+	if len(raw) == 0 {
+		return
+	}
+	if commented {
+		e.buf = append(e.buf, "# "...)
+		e.buf = append(e.buf, bytes.ReplaceAll(raw, []byte("\n"), []byte("\n# "))...)
+	} else {
+		e.buf = append(e.buf, raw...)
+	}
 	e.buf = append(e.buf, '\n')
 	e.lastWasHeader = false
-	return nil
 }
 
 // entryIsTable reports whether the entry is emitted as a (sub-)table rather
@@ -735,16 +808,18 @@ func (e *encoderState) encodeArrayTable(ent entry, commented bool, indent int) e
 		comment = ""
 
 		// A Marshaler element splices its raw table body verbatim. The shape
-		// was already checked by isArrayOfTables, so it is shapeTable here.
+		// was checked by isArrayOfTables, but MarshalTOML is called again for
+		// the emit, so the spliced bytes are validated here.
 		if e.marshalerOn && encPropsForType(elem.Type()).marshaler != 0 {
 			raw, err := e.marshalerBytes(elem)
 			if err != nil {
 				return err
 			}
-			_, trimmed := e.classifyRaw(raw)
-			e.buf = append(e.buf, trimmed...)
-			e.buf = append(e.buf, '\n')
-			e.lastWasHeader = false
+			trimmed := bytes.TrimSpace(raw)
+			if err := e.validateRawTableBody(elem.Type(), trimmed); err != nil {
+				return err
+			}
+			e.spliceRawTableBody(trimmed, commented)
 			continue
 		}
 
@@ -879,14 +954,24 @@ func (e *encoderState) encodeKeyValue(ent entry, commented bool, indent int) err
 // value is either a single value (spliced verbatim) or, when forced inline by
 // SetTablesInline or an inline tag, table content (an error).
 func (e *encoderState) appendMarshalerInlineValue(b []byte, ent *entry) ([]byte, error) {
+	errNotValue := func() error {
+		return fmt.Errorf("toml: cannot encode %s as an inline value: not a single TOML value", ent.value.Type())
+	}
 	if ent.options.rawShape != shapeValue {
-		return nil, fmt.Errorf("toml: cannot encode %s as an inline value: not a single TOML value", ent.value.Type())
+		return nil, errNotValue()
 	}
 	raw, err := e.marshalerValue(ent)
 	if err != nil {
 		return nil, err
 	}
-	return append(b, raw...), nil
+	// Classify the just-returned bytes rather than trusting the earlier pass:
+	// MarshalTOML is called again for the emit, and an implementation that
+	// returns different content must not splice non-value bytes into a
+	// `key = ` position.
+	if shape, trimmed := e.classifyRaw(raw); shape == shapeValue {
+		return append(b, trimmed...), nil
+	}
+	return nil, errNotValue()
 }
 
 // collectEntries builds the ordered list of the entries of a table,

--- a/marshaler_raw_test.go
+++ b/marshaler_raw_test.go
@@ -1,0 +1,586 @@
+package toml_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2"
+	"github.com/pelletier/go-toml/v2/internal/assert"
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// encodeRaw marshals v with the unstable.Marshaler interface enabled.
+func encodeRaw(tb testing.TB, v interface{}) (string, error) {
+	tb.Helper()
+	var buf bytes.Buffer
+	err := toml.NewEncoder(&buf).EnableMarshalerInterface().Encode(v)
+	return buf.String(), err
+}
+
+// rawValueConfig and rawTableConfig are tiny reusable targets.
+type rawValueConfig struct {
+	N unstable.RawMessage `toml:"n"`
+}
+
+type rawTableConfig struct {
+	Plugin unstable.RawMessage `toml:"plugin"`
+}
+
+// TestMarshalerInterfaceDisabled checks the default Encoder is unchanged: a
+// RawMessage is a []byte and is emitted as an array of integers.
+func TestMarshalerInterfaceDisabled(t *testing.T) {
+	b, err := toml.Marshal(rawValueConfig{N: unstable.RawMessage("42")})
+	assert.NoError(t, err)
+	assert.Equal(t, "n = [52, 50]\n", string(b))
+
+	// Even on an Encoder, without the toggle the behavior is the byte array.
+	var buf bytes.Buffer
+	err = toml.NewEncoder(&buf).Encode(rawValueConfig{N: unstable.RawMessage("42")})
+	assert.NoError(t, err)
+	assert.Equal(t, "n = [52, 50]\n", buf.String())
+}
+
+// TestMarshalerInterfaceValueShapes checks single-value RawMessages emit inline.
+func TestMarshalerInterfaceValueShapes(t *testing.T) {
+	examples := []struct {
+		desc     string
+		raw      string
+		expected string
+	}{
+		{"integer", "42", "n = 42\n"},
+		{"negative integer", "-17", "n = -17\n"},
+		{"float", "3.14", "n = 3.14\n"},
+		{"bool", "true", "n = true\n"},
+		{"basic string", `"hello"`, "n = \"hello\"\n"},
+		{"literal string", `'lit'`, "n = 'lit'\n"},
+		{"hex integer kept verbatim", "0xDEADBEEF", "n = 0xDEADBEEF\n"},
+		{"array", "[1, 2, 3]", "n = [1, 2, 3]\n"},
+		{"inline table", `{a = 1, b = "x"}`, "n = {a = 1, b = \"x\"}\n"},
+		{"datetime", "1979-05-27T07:32:00Z", "n = 1979-05-27T07:32:00Z\n"},
+		{"surrounding whitespace trimmed", "  42  ", "n = 42\n"},
+		{"trailing newline trimmed", "42\n", "n = 42\n"},
+	}
+
+	for _, e := range examples {
+		t.Run(e.desc, func(t *testing.T) {
+			out, err := encodeRaw(t, rawValueConfig{N: unstable.RawMessage(e.raw)})
+			assert.NoError(t, err)
+			assert.Equal(t, e.expected, out)
+		})
+	}
+}
+
+// TestMarshalerInterfaceSingleTable checks a key-value body emits as a table.
+func TestMarshalerInterfaceSingleTable(t *testing.T) {
+	out, err := encodeRaw(t, rawTableConfig{
+		Plugin: unstable.RawMessage("name = \"example\"\nversion = \"1.0\"\n"),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "[plugin]\nname = \"example\"\nversion = \"1.0\"\n", out)
+}
+
+// TestMarshalerInterfaceDottedKeysPreserved checks dotted keys and odd
+// formatting inside a table body are spliced verbatim.
+func TestMarshalerInterfaceDottedKeysPreserved(t *testing.T) {
+	body := "sub.key   =   'value'\nhex = 0xFF\n"
+	out, err := encodeRaw(t, rawTableConfig{Plugin: unstable.RawMessage(body)})
+	assert.NoError(t, err)
+	assert.Equal(t, "[plugin]\nsub.key   =   'value'\nhex = 0xFF\n", out)
+}
+
+// TestMarshalerInterfaceArrayOfTables checks []RawMessage of table bodies emits
+// as an array of tables.
+func TestMarshalerInterfaceArrayOfTables(t *testing.T) {
+	type config struct {
+		Item []unstable.RawMessage `toml:"item"`
+	}
+	out, err := encodeRaw(t, config{Item: []unstable.RawMessage{
+		unstable.RawMessage("a = 1\n"),
+		unstable.RawMessage("a = 2\nb = 3\n"),
+	}})
+	assert.NoError(t, err)
+	expected := "[[item]]\na = 1\n\n[[item]]\na = 2\nb = 3\n"
+	assert.Equal(t, expected, out)
+}
+
+// TestMarshalerInterfaceArrayOfValues checks a []RawMessage of single values
+// emits as a plain inline array, not as an array of tables.
+func TestMarshalerInterfaceArrayOfValues(t *testing.T) {
+	type config struct {
+		Item []unstable.RawMessage `toml:"item"`
+	}
+	out, err := encodeRaw(t, config{Item: []unstable.RawMessage{
+		unstable.RawMessage("1"),
+		unstable.RawMessage("2"),
+	}})
+	assert.NoError(t, err)
+	assert.Equal(t, "item = [1, 2]\n", out)
+}
+
+// TestMarshalerInterfaceNestedField checks a RawMessage under a sub-table emits
+// under the right key path.
+func TestMarshalerInterfaceNestedField(t *testing.T) {
+	type inner struct {
+		Plugin unstable.RawMessage `toml:"plugin"`
+	}
+	type config struct {
+		Outer inner `toml:"outer"`
+	}
+	out, err := encodeRaw(t, config{Outer: inner{
+		Plugin: unstable.RawMessage("a = 1\n"),
+	}})
+	assert.NoError(t, err)
+	assert.Equal(t, "[outer]\n[outer.plugin]\na = 1\n", out)
+}
+
+// TestMarshalerInterfacePointerField checks *RawMessage works and nil is
+// skipped.
+func TestMarshalerInterfacePointerField(t *testing.T) {
+	type config struct {
+		A *unstable.RawMessage `toml:"a"`
+		B *unstable.RawMessage `toml:"b"`
+	}
+	raw := unstable.RawMessage("42")
+	out, err := encodeRaw(t, config{A: &raw, B: nil})
+	assert.NoError(t, err)
+	assert.Equal(t, "a = 42\n", out)
+}
+
+// TestMarshalerInterfaceMapValues checks RawMessage map values are classified
+// individually.
+func TestMarshalerInterfaceMapValues(t *testing.T) {
+	type config struct {
+		M map[string]unstable.RawMessage `toml:"m"`
+	}
+	out, err := encodeRaw(t, config{M: map[string]unstable.RawMessage{
+		"x": unstable.RawMessage("a = 1\n"),
+	}})
+	assert.NoError(t, err)
+	assert.Equal(t, "[m]\n[m.x]\na = 1\n", out)
+}
+
+// customMarshaler is a non-RawMessage type implementing unstable.Marshaler with
+// a value receiver.
+type customMarshaler struct {
+	body string
+}
+
+func (c customMarshaler) MarshalTOML() ([]byte, error) {
+	return []byte(c.body), nil
+}
+
+// ptrMarshaler implements unstable.Marshaler with a pointer receiver.
+type ptrMarshaler struct {
+	body string
+}
+
+func (c *ptrMarshaler) MarshalTOML() ([]byte, error) {
+	return []byte(c.body), nil
+}
+
+func TestMarshalerInterfaceCustomTypes(t *testing.T) {
+	t.Run("value receiver", func(t *testing.T) {
+		type config struct {
+			X customMarshaler `toml:"x"`
+		}
+		out, err := encodeRaw(t, config{X: customMarshaler{body: "v = 1\n"}})
+		assert.NoError(t, err)
+		assert.Equal(t, "[x]\nv = 1\n", out)
+	})
+
+	t.Run("pointer receiver", func(t *testing.T) {
+		type config struct {
+			X ptrMarshaler `toml:"x"`
+		}
+		out, err := encodeRaw(t, config{X: ptrMarshaler{body: "42"}})
+		assert.NoError(t, err)
+		assert.Equal(t, "x = 42\n", out)
+	})
+
+	t.Run("pointer receiver behind pointer", func(t *testing.T) {
+		type config struct {
+			X *ptrMarshaler `toml:"x"`
+		}
+		out, err := encodeRaw(t, config{X: &ptrMarshaler{body: "k = 1\n"}})
+		assert.NoError(t, err)
+		assert.Equal(t, "[x]\nk = 1\n", out)
+	})
+}
+
+// errMarshaler always fails.
+type errMarshaler struct{}
+
+func (errMarshaler) MarshalTOML() ([]byte, error) {
+	return nil, errors.New("marshal boom")
+}
+
+func TestMarshalerInterfaceErrorPropagation(t *testing.T) {
+	t.Run("table position", func(t *testing.T) {
+		type config struct {
+			X errMarshaler `toml:"x"`
+		}
+		_, err := encodeRaw(t, config{})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "marshal boom"), err.Error())
+	})
+
+	t.Run("inline array element", func(t *testing.T) {
+		type config struct {
+			X []errMarshaler `toml:"x"`
+		}
+		_, err := encodeRaw(t, config{X: []errMarshaler{{}}})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "marshal boom"), err.Error())
+	})
+}
+
+// TestMarshalerInterfaceArrayOfTablesPointerReceiver exercises a slice of a
+// pointer-receiver Marshaler (its elements are addressable).
+func TestMarshalerInterfaceArrayOfTablesPointerReceiver(t *testing.T) {
+	type config struct {
+		Item []ptrMarshaler `toml:"item"`
+	}
+	out, err := encodeRaw(t, config{Item: []ptrMarshaler{
+		{body: "a = 1\n"},
+		{body: "a = 2\n"},
+	}})
+	assert.NoError(t, err)
+	assert.Equal(t, "[[item]]\na = 1\n\n[[item]]\na = 2\n", out)
+}
+
+// TestMarshalerInterfaceCommentedMultilineValue checks a commented multiline
+// raw value has every physical line prefixed with the comment marker, sharing
+// encodeKeyValue's commented handling rather than emitting invalid TOML.
+func TestMarshalerInterfaceCommentedMultilineValue(t *testing.T) {
+	type config struct {
+		A unstable.RawMessage `toml:"a,commented"`
+	}
+	var buf bytes.Buffer
+	err := toml.NewEncoder(&buf).
+		EnableMarshalerInterface().
+		SetArraysMultiline(true).
+		Encode(config{A: unstable.RawMessage("[\n  1,\n  2,\n]")})
+	assert.NoError(t, err)
+	assert.Equal(t, "# a = [\n#   1,\n#   2,\n# ]\n", buf.String())
+}
+
+// flakyMarshaler succeeds on its first call (used by the encoder to classify
+// the shape) and fails on the second (the emit), exercising the emit-time error
+// paths that the eager classification otherwise makes unreachable.
+type flakyMarshaler struct {
+	calls *int
+	body  string
+}
+
+func (f flakyMarshaler) MarshalTOML() ([]byte, error) {
+	*f.calls++
+	if *f.calls == 1 {
+		return []byte(f.body), nil
+	}
+	return nil, errors.New("flaky boom")
+}
+
+func TestMarshalerInterfaceEmitError(t *testing.T) {
+	t.Run("table body", func(t *testing.T) {
+		calls := 0
+		type config struct {
+			X flakyMarshaler `toml:"x"`
+		}
+		_, err := encodeRaw(t, config{X: flakyMarshaler{calls: &calls, body: "a = 1\n"}})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "flaky boom"), err.Error())
+	})
+
+	t.Run("inline value", func(t *testing.T) {
+		calls := 0
+		type config struct {
+			X flakyMarshaler `toml:"x"`
+		}
+		_, err := encodeRaw(t, config{X: flakyMarshaler{calls: &calls, body: "42"}})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "flaky boom"), err.Error())
+	})
+}
+
+// TestMarshalerInterfaceValueSliceField marshals a plain value slice with the
+// interface enabled: it is a regular array, not an array of tables.
+func TestMarshalerInterfaceValueSliceField(t *testing.T) {
+	type config struct {
+		Nums []int `toml:"nums"`
+	}
+	out, err := encodeRaw(t, config{Nums: []int{1, 2, 3}})
+	assert.NoError(t, err)
+	assert.Equal(t, "nums = [1, 2, 3]\n", out)
+}
+
+// TestMarshalerInterfaceNilSliceElement covers a nil (unresolvable) array
+// element while the interface is enabled.
+func TestMarshalerInterfaceNilSliceElement(t *testing.T) {
+	type config struct {
+		Items []interface{} `toml:"items"`
+	}
+	_, err := encodeRaw(t, config{Items: []interface{}{nil}})
+	assert.Error(t, err)
+}
+
+func TestMarshalerInterfaceEmptyOmitted(t *testing.T) {
+	type config struct {
+		A string              `toml:"a"`
+		E unstable.RawMessage `toml:"e"`
+		B string              `toml:"b"`
+	}
+	t.Run("nil", func(t *testing.T) {
+		out, err := encodeRaw(t, config{A: "x", E: nil, B: "y"})
+		assert.NoError(t, err)
+		assert.Equal(t, "a = 'x'\nb = 'y'\n", out)
+	})
+	t.Run("whitespace only", func(t *testing.T) {
+		out, err := encodeRaw(t, config{A: "x", E: unstable.RawMessage("  \n\t"), B: "y"})
+		assert.NoError(t, err)
+		assert.Equal(t, "a = 'x'\nb = 'y'\n", out)
+	})
+}
+
+func TestMarshalerInterfaceTableContentInInlineErrors(t *testing.T) {
+	t.Run("array element with table content", func(t *testing.T) {
+		// Mixed shapes: not an array of tables, so the table-shaped element is
+		// pushed into an inline array, which is invalid.
+		type config struct {
+			X []unstable.RawMessage `toml:"x"`
+		}
+		_, err := encodeRaw(t, config{X: []unstable.RawMessage{
+			unstable.RawMessage("k = 1\n"),
+			unstable.RawMessage("42"),
+		}})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "inline value"), err.Error())
+	})
+
+	t.Run("inline table member with table content", func(t *testing.T) {
+		type config struct {
+			X unstable.RawMessage `toml:"x"`
+		}
+		var buf bytes.Buffer
+		err := toml.NewEncoder(&buf).
+			EnableMarshalerInterface().
+			SetTablesInline(true).
+			Encode(config{X: unstable.RawMessage("k = 1\n")})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "inline value"), err.Error())
+	})
+
+	t.Run("empty in inline array", func(t *testing.T) {
+		type config struct {
+			X []unstable.RawMessage `toml:"x"`
+		}
+		_, err := encodeRaw(t, config{X: []unstable.RawMessage{
+			unstable.RawMessage(""),
+		}})
+		assert.Error(t, err)
+	})
+}
+
+// TestRawMessageRoundTrip decodes a document capturing raw bytes, re-encodes it,
+// and checks the re-encoded document decodes to the same structure.
+func TestRawMessageRoundTrip(t *testing.T) {
+	examples := []struct {
+		desc string
+		doc  string
+	}{
+		{
+			desc: "flat table",
+			doc:  "[plugin]\nname = \"example\"\nversion = \"1.0\"\n",
+		},
+		{
+			desc: "scalar value",
+			doc:  "answer = 42\n",
+		},
+		{
+			desc: "array value",
+			doc:  "ports = [8000, 8001, 8002]\n",
+		},
+		{
+			desc: "inline table value",
+			doc:  "point = {x = 1, y = 2}\n",
+		},
+		{
+			desc: "multiple tables",
+			doc:  "[plugin]\nname = \"a\"\n\n[server]\nhost = \"localhost\"\nport = 8080\n",
+		},
+	}
+
+	for _, e := range examples {
+		t.Run(e.desc, func(t *testing.T) {
+			// Capture every top-level key as a RawMessage.
+			var captured map[string]unstable.RawMessage
+			err := toml.NewDecoder(strings.NewReader(e.doc)).
+				EnableUnmarshalerInterface().
+				Decode(&captured)
+			assert.NoError(t, err)
+
+			reencoded, err := encodeRaw(t, captured)
+			assert.NoError(t, err)
+
+			// Both the original and the re-encoded document must decode to the
+			// same generic structure.
+			var want, got map[string]interface{}
+			assert.NoError(t, toml.Unmarshal([]byte(e.doc), &want))
+			assert.NoError(t, toml.Unmarshal([]byte(reencoded), &got))
+			assert.True(t, reflect.DeepEqual(want, got),
+				"round-trip mismatch\noriginal:\n%s\nre-encoded:\n%s\nwant=%#v\ngot=%#v",
+				e.doc, reencoded, want, got)
+		})
+	}
+}
+
+// TestRawMessageRoundTripArrayTables captures each [[item]] element into a
+// []RawMessage, re-encodes it, and checks the structure survives.
+func TestRawMessageRoundTripArrayTables(t *testing.T) {
+	doc := "[[item]]\na = 1\n\n[[item]]\na = 2\nb = 3\n"
+
+	type config struct {
+		Item []unstable.RawMessage `toml:"item"`
+	}
+	var captured config
+	err := toml.NewDecoder(strings.NewReader(doc)).
+		EnableUnmarshalerInterface().
+		Decode(&captured)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(captured.Item))
+
+	reencoded, err := encodeRaw(t, captured)
+	assert.NoError(t, err)
+
+	var want, got map[string]interface{}
+	assert.NoError(t, toml.Unmarshal([]byte(doc), &want))
+	assert.NoError(t, toml.Unmarshal([]byte(reencoded), &got))
+	assert.True(t, reflect.DeepEqual(want, got),
+		"round-trip mismatch\noriginal:\n%s\nre-encoded:\n%s", doc, reencoded)
+}
+
+// TestRawMessageRoundTripStruct exercises the documented struct-field flow end
+// to end.
+func TestRawMessageRoundTripStruct(t *testing.T) {
+	doc := "[plugin]\nname = \"example\"\nversion = \"1.0\"\nenabled = true\n"
+
+	type config struct {
+		Plugin unstable.RawMessage `toml:"plugin"`
+	}
+	var cfg config
+	err := toml.NewDecoder(strings.NewReader(doc)).
+		EnableUnmarshalerInterface().
+		Decode(&cfg)
+	assert.NoError(t, err)
+
+	out, err := encodeRaw(t, cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, "[plugin]\nname = \"example\"\nversion = \"1.0\"\nenabled = true\n", out)
+}
+
+// TestRawMessageNestedSubTableHeadersLimitation pins the documented limitation:
+// a captured table body that contains its own sub-table headers keeps those
+// headers relative to the captured root, so re-emitting it under a deeper key
+// does not re-root them.
+func TestRawMessageNestedSubTableHeadersLimitation(t *testing.T) {
+	doc := "[outer]\na = 1\n[outer.sub]\nb = 2\n"
+
+	type config struct {
+		Outer unstable.RawMessage `toml:"outer"`
+	}
+	var cfg config
+	err := toml.NewDecoder(strings.NewReader(doc)).
+		EnableUnmarshalerInterface().
+		Decode(&cfg)
+	assert.NoError(t, err)
+
+	// The captured body uses a header relative to [outer].
+	assert.True(t, strings.Contains(string(cfg.Outer), "[sub]"), string(cfg.Outer))
+
+	out, err := encodeRaw(t, cfg)
+	assert.NoError(t, err)
+	// The relative [sub] header is spliced verbatim (not rewritten to
+	// [outer.sub]). This is the documented behavior.
+	assert.Equal(t, "[outer]\na = 1\n[sub]\nb = 2\n", out)
+}
+
+func BenchmarkMarshalRawMessage(b *testing.B) {
+	b.Run("table", func(b *testing.B) {
+		v := rawTableConfig{
+			Plugin: unstable.RawMessage("name = \"example\"\nversion = \"1.0\"\nenabled = true\n"),
+		}
+		benchmarkEncodeRaw(b, v)
+	})
+
+	b.Run("scalar", func(b *testing.B) {
+		benchmarkEncodeRaw(b, rawValueConfig{N: unstable.RawMessage("42")})
+	})
+
+	b.Run("inline-table", func(b *testing.B) {
+		benchmarkEncodeRaw(b, rawValueConfig{N: unstable.RawMessage(`{a = 1, b = "x", c = [1, 2, 3]}`)})
+	})
+
+	b.Run("array-of-tables", func(b *testing.B) {
+		type config struct {
+			Item []unstable.RawMessage `toml:"item"`
+		}
+		v := config{Item: []unstable.RawMessage{
+			unstable.RawMessage("a = 1\nb = 2\n"),
+			unstable.RawMessage("a = 3\nb = 4\n"),
+			unstable.RawMessage("a = 5\nb = 6\n"),
+		}}
+		benchmarkEncodeRaw(b, v)
+	})
+}
+
+func benchmarkEncodeRaw(b *testing.B, v interface{}) {
+	b.Helper()
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf).EnableMarshalerInterface()
+
+	// Warm the per-type caches and compute the output size.
+	buf.Reset()
+	if err := enc.Encode(v); err != nil {
+		b.Fatal(err)
+	}
+	b.SetBytes(int64(buf.Len()))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		if err := enc.Encode(v); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func ExampleEncoder_EnableMarshalerInterface() {
+	// A RawMessage captured (or hand-built) as raw TOML is spliced back into
+	// the document verbatim.
+	type Config struct {
+		Plugin unstable.RawMessage `toml:"plugin"`
+	}
+
+	cfg := Config{
+		Plugin: unstable.RawMessage("name = \"example\"\nversion = \"1.0\"\n"),
+	}
+
+	var buf bytes.Buffer
+	err := toml.NewEncoder(&buf).
+		EnableMarshalerInterface().
+		Encode(cfg)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Print(buf.String())
+
+	// Output:
+	// [plugin]
+	// name = "example"
+	// version = "1.0"
+}

--- a/marshaler_raw_test.go
+++ b/marshaler_raw_test.go
@@ -507,6 +507,203 @@ func TestRawMessageNestedSubTableHeadersLimitation(t *testing.T) {
 	assert.Equal(t, "[outer]\na = 1\n[sub]\nb = 2\n", out)
 }
 
+// TestMarshalerInterfaceInvalidContent checks that bytes which are neither a
+// value nor valid table content produce an error instead of silently splicing
+// an invalid document, mirroring json.RawMessage's validation.
+func TestMarshalerInterfaceInvalidContent(t *testing.T) {
+	type config struct {
+		X unstable.RawMessage `toml:"x"`
+	}
+	for _, raw := range []string{"!!! not toml", "[1, 2", "42 garbage", "a = ", "= 1"} {
+		t.Run(raw, func(t *testing.T) {
+			out, err := encodeRaw(t, config{X: unstable.RawMessage(raw)})
+			assert.Error(t, err)
+			assert.True(t, strings.Contains(err.Error(), "invalid TOML"), err.Error())
+			assert.Equal(t, "", out)
+		})
+	}
+
+	t.Run("array of tables element", func(t *testing.T) {
+		type config struct {
+			Item []unstable.RawMessage `toml:"item"`
+		}
+		// Both elements classify as table-shaped, but the second is invalid.
+		_, err := encodeRaw(t, config{Item: []unstable.RawMessage{
+			unstable.RawMessage("a = 1\n"),
+			unstable.RawMessage("b ="),
+		}})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "invalid TOML"), err.Error())
+	})
+}
+
+// TestMarshalerInterfaceCommentedTable checks a commented table-shaped
+// RawMessage has its body comment-prefixed line by line: it must not leak into
+// the document as live keys of the parent table.
+func TestMarshalerInterfaceCommentedTable(t *testing.T) {
+	t.Run("single table", func(t *testing.T) {
+		type config struct {
+			X unstable.RawMessage `toml:"x,commented"`
+		}
+		out, err := encodeRaw(t, config{X: unstable.RawMessage("a = 1\nb = 2\n")})
+		assert.NoError(t, err)
+		assert.Equal(t, "# [x]\n# a = 1\n# b = 2\n", out)
+
+		// The commented content must not decode into live keys.
+		var m map[string]interface{}
+		assert.NoError(t, toml.Unmarshal([]byte(out), &m))
+		assert.Equal(t, 0, len(m))
+	})
+
+	t.Run("array of tables", func(t *testing.T) {
+		type config struct {
+			Item []unstable.RawMessage `toml:"item,commented"`
+		}
+		out, err := encodeRaw(t, config{Item: []unstable.RawMessage{
+			unstable.RawMessage("a = 1\n"),
+			unstable.RawMessage("a = 2\n"),
+		}})
+		assert.NoError(t, err)
+		assert.Equal(t, "# [[item]]\n# a = 1\n\n# [[item]]\n# a = 2\n", out)
+
+		var m map[string]interface{}
+		assert.NoError(t, toml.Unmarshal([]byte(out), &m))
+		assert.Equal(t, 0, len(m))
+	})
+}
+
+// shiftyMarshaler returns a different body on each call, exercising the
+// emit-time validation that guards against non-deterministic implementations:
+// the encoder classifies on a first call and emits the bytes of a second one.
+type shiftyMarshaler struct {
+	calls  *int
+	bodies []string
+}
+
+func (s shiftyMarshaler) MarshalTOML() ([]byte, error) {
+	i := *s.calls
+	if i >= len(s.bodies) {
+		i = len(s.bodies) - 1
+	}
+	*s.calls++
+	return []byte(s.bodies[i]), nil
+}
+
+func TestMarshalerInterfaceNonDeterministic(t *testing.T) {
+	t.Run("table then value", func(t *testing.T) {
+		calls := 0
+		type config struct {
+			X shiftyMarshaler `toml:"x"`
+		}
+		// Classified as a table body, but the emit call returns a bare value,
+		// which is not valid after a [x] header.
+		_, err := encodeRaw(t, config{X: shiftyMarshaler{calls: &calls, bodies: []string{"a = 1\n", "42"}}})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "invalid TOML"), err.Error())
+	})
+
+	t.Run("value then table", func(t *testing.T) {
+		calls := 0
+		type config struct {
+			X shiftyMarshaler `toml:"x"`
+		}
+		// Classified as a value, but the emit call returns table content,
+		// which must not be spliced into a `key = ` position.
+		_, err := encodeRaw(t, config{X: shiftyMarshaler{calls: &calls, bodies: []string{"42", "a = 1\n"}}})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "inline value"), err.Error())
+	})
+}
+
+// TestMarshalerInterfaceRoot checks a Marshaler at the document root emits its
+// bytes as the whole document: the encode counterpart of the decoder
+// delivering the whole document to a root Unmarshaler.
+func TestMarshalerInterfaceRoot(t *testing.T) {
+	t.Run("document", func(t *testing.T) {
+		doc := "a = 1\n[t]\nb = 2"
+		out, err := encodeRaw(t, unstable.RawMessage(doc))
+		assert.NoError(t, err)
+		assert.Equal(t, doc+"\n", out)
+	})
+
+	t.Run("headers are absolute at the root", func(t *testing.T) {
+		// Unlike a body re-emitted under a [key] header, a root document
+		// keeps its headers at the position they name, so nested tables
+		// round-trip exactly.
+		doc := "[outer]\na = 1\n\n[outer.sub]\nb = 2"
+		out, err := encodeRaw(t, unstable.RawMessage(doc))
+		assert.NoError(t, err)
+		assert.Equal(t, doc+"\n", out)
+	})
+
+	t.Run("numeric table header", func(t *testing.T) {
+		// At the root the bytes are parsed as a document, so [1] is a table
+		// named "1", not an array value.
+		out, err := encodeRaw(t, unstable.RawMessage("[1]\na = 1"))
+		assert.NoError(t, err)
+		assert.Equal(t, "[1]\na = 1\n", out)
+	})
+
+	t.Run("pointer", func(t *testing.T) {
+		raw := unstable.RawMessage("a = 1")
+		out, err := encodeRaw(t, &raw)
+		assert.NoError(t, err)
+		assert.Equal(t, "a = 1\n", out)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		out, err := encodeRaw(t, unstable.RawMessage(" \n\t"))
+		assert.NoError(t, err)
+		assert.Equal(t, "", out)
+	})
+
+	t.Run("single value errors", func(t *testing.T) {
+		_, err := encodeRaw(t, unstable.RawMessage("42"))
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "document root"), err.Error())
+	})
+
+	t.Run("invalid content errors", func(t *testing.T) {
+		_, err := encodeRaw(t, unstable.RawMessage("!!! not toml"))
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "invalid TOML"), err.Error())
+	})
+
+	t.Run("marshal error propagates", func(t *testing.T) {
+		_, err := encodeRaw(t, errMarshaler{})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "marshal boom"), err.Error())
+	})
+
+	t.Run("disabled keeps the baseline error", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := toml.NewEncoder(&buf).Encode(unstable.RawMessage("a = 1"))
+		assert.Error(t, err)
+	})
+}
+
+// TestRawMessageRoundTripRoot captures a whole document into a root RawMessage
+// (as introduced for the decoder in #994) and re-encodes it.
+func TestRawMessageRoundTripRoot(t *testing.T) {
+	doc := "a = 1\nc = [1, 2]\n\n[t]\nb = 2\n\n[t.sub]\nd = 'x'\n"
+
+	var raw unstable.RawMessage
+	err := toml.NewDecoder(strings.NewReader(doc)).
+		EnableUnmarshalerInterface().
+		Decode(&raw)
+	assert.NoError(t, err)
+
+	reencoded, err := encodeRaw(t, raw)
+	assert.NoError(t, err)
+
+	var want, got map[string]interface{}
+	assert.NoError(t, toml.Unmarshal([]byte(doc), &want))
+	assert.NoError(t, toml.Unmarshal([]byte(reencoded), &got))
+	assert.True(t, reflect.DeepEqual(want, got),
+		"round-trip mismatch\noriginal:\n%s\nre-encoded:\n%s\nwant=%#v\ngot=%#v",
+		doc, reencoded, want, got)
+}
+
 func BenchmarkMarshalRawMessage(b *testing.B) {
 	b.Run("table", func(b *testing.B) {
 		v := rawTableConfig{

--- a/unstable/marshaler.go
+++ b/unstable/marshaler.go
@@ -1,0 +1,25 @@
+package unstable
+
+// Marshaler is implemented by types that can marshal themselves into a raw
+// TOML description. The returned bytes are spliced verbatim into the encoded
+// document, so they must be valid TOML for the position they end up in:
+//
+//   - A single value (string, integer, array, inline table, …) is emitted
+//     inline, as in `key = <raw>`.
+//   - One or more key-value lines (optionally with relative sub-table headers)
+//     is emitted as the body of a `[key]` table.
+//
+// The encoder decides between those two forms by parsing the returned bytes;
+// see Encoder.EnableMarshalerInterface in the root toml package.
+//
+// Marshaler is the encoding counterpart of Unmarshaler.
+type Marshaler interface {
+	MarshalTOML() ([]byte, error)
+}
+
+// MarshalTOML implements Marshaler. It returns the raw TOML bytes verbatim,
+// mirroring json.RawMessage.MarshalJSON. The value receiver means both
+// RawMessage and *RawMessage satisfy Marshaler.
+func (m RawMessage) MarshalTOML() ([]byte, error) {
+	return []byte(m), nil
+}

--- a/unstable/marshaler.go
+++ b/unstable/marshaler.go
@@ -8,9 +8,13 @@ package unstable
 //     inline, as in `key = <raw>`.
 //   - One or more key-value lines (optionally with relative sub-table headers)
 //     is emitted as the body of a `[key]` table.
+//   - At the document root, the bytes are emitted as the whole document.
 //
-// The encoder decides between those two forms by parsing the returned bytes;
-// see Encoder.EnableMarshalerInterface in the root toml package.
+// The encoder decides between those forms by parsing the returned bytes, and
+// reports an error when they are not valid TOML for their position; see
+// Encoder.EnableMarshalerInterface in the root toml package. MarshalTOML can
+// be called more than once for the same value during a single encode, so it
+// must be deterministic.
 //
 // Marshaler is the encoding counterpart of Unmarshaler.
 type Marshaler interface {

--- a/unstable/unmarshaler.go
+++ b/unstable/unmarshaler.go
@@ -15,10 +15,12 @@ type Unmarshaler interface {
 	UnmarshalTOML(data []byte) error
 }
 
-// RawMessage is a raw encoded TOML value. It implements Unmarshaler and can
-// be used to delay TOML decoding or capture raw content.
+// RawMessage is a raw encoded TOML value. It implements both Unmarshaler and
+// Marshaler and can be used to delay TOML decoding or capture raw content,
+// similar to json.RawMessage.
 //
-// Example usage:
+// Decoding (requires Decoder.EnableUnmarshalerInterface) captures the raw TOML
+// bytes for the target without decoding them:
 //
 //	type Config struct {
 //	    Plugin RawMessage `toml:"plugin"`
@@ -27,6 +29,11 @@ type Unmarshaler interface {
 //	var cfg Config
 //	toml.NewDecoder(r).EnableUnmarshalerInterface().Decode(&cfg)
 //	// cfg.Plugin now contains the raw TOML bytes for [plugin]
+//
+// Encoding (requires Encoder.EnableMarshalerInterface) splices the stored bytes
+// back into the document verbatim:
+//
+//	toml.NewEncoder(w).EnableMarshalerInterface().Encode(cfg)
 type RawMessage []byte
 
 // UnmarshalTOML implements Unmarshaler.


### PR DESCRIPTION
## What

Makes `unstable.RawMessage` round-trip like `json.RawMessage` by adding the **encode** half of the feature.

The decode side already existed: `unstable.RawMessage` captures raw TOML when `Decoder.EnableUnmarshalerInterface()` is set (the `unstable.Unmarshaler` work from #873 → #940 → #1027, plus root documents in #1083). But marshaling a `RawMessage` emitted the underlying `[]byte` as an array of integers (`plugin = [110, 97, ...]`), so it could not round-trip. This PR adds the missing encoder support.

Fixes #796.

## API (all new public API stays in `unstable`)

- **`unstable.Marshaler`** — `MarshalTOML() ([]byte, error)`, the encode counterpart of `unstable.Unmarshaler`, implemented by `RawMessage` (value receiver, mirroring `json.RawMessage`). It can be called more than once for the same value during a single encode, so it must be deterministic.
- **`Encoder.EnableMarshalerInterface()`** — opt-in toggle in the `toml` package, exactly mirroring the existing `Decoder.EnableUnmarshalerInterface()` (both carry the `*Unstable:*` disclaimer). It is the only addition to the stable package, is backward compatible, and the default `toml.Marshal`/`Encode` behavior is unchanged.

## Behavior

With the interface enabled, the encoder splices a `Marshaler`'s bytes verbatim, parsing them to pick the valid position:

| RawMessage content | emitted as |
|---|---|
| a single value (`42`, `"x"`, `[1,2]`, `{a=1}`) | `key = <raw>` |
| key-value lines (`name = "x"\n...`) | `[key]` table body |
| `[]RawMessage` of table bodies | `[[key]]` array of tables |
| at the document root | the whole document (counterpart of #1083's root decode) |
| empty / whitespace | omitted |
| not valid TOML for its position | error (like `json.RawMessage` with invalid JSON) |
| table content forced inline (e.g. `SetTablesInline`) | error |

Spliced bytes are validated by the same parser the decoder uses, so a `Marshaler` cannot silently corrupt the document; validation runs against the bytes actually emitted, so even a non-deterministic implementation cannot splice table content into a value position. A table-shaped body under a `commented` field is comment-prefixed line by line, like structurally encoded tables.

```go
type Config struct {
    Plugin unstable.RawMessage `toml:"plugin"`
}

var cfg Config
toml.NewDecoder(r).EnableUnmarshalerInterface().Decode(&cfg)
// ... inspect / pass through cfg.Plugin ...
toml.NewEncoder(w).EnableMarshalerInterface().Encode(cfg) // [plugin] re-emitted verbatim
```

### Documented limitation

Bodies are spliced verbatim (the `json.RawMessage` philosophy). A captured table body that itself contains sub-table headers keeps those headers relative to the captured root, so it round-trips exactly only when re-emitted at the same depth. Flat tables, scalars, inline tables, arrays-of-tables — and whole documents at the root, where headers are absolute — round-trip exactly. This is pinned by a test.

## Performance

No regression on the default (interface-disabled) path:
- the `entry` struct is unchanged at 64 bytes (the classification is packed into `valueOptions`' existing padding);
- all marshaler logic lives in separate methods gated behind the opt-in flag, so the hot encoder functions keep their baseline size and allocation profile (the only addition outside gated code is one short-circuited flag test in `encodeRoot`, once per document).

Order-balanced benchstat of `./benchmark/` shows the per-op-sensitive `Marshal/SimpleDocument` cases unchanged (`~`); allocs/op are identical.

## Tests

`marshaler_raw_test.go` adds coverage for every value shape, single/array tables, nested fields, map values, custom and pointer-receiver `Marshaler`s, error propagation, empty omission, inline-context errors, invalid-content errors, commented table bodies, non-deterministic marshalers, root documents, the documented limitation, and full decode→encode→decode round-trips (fields, array tables, and whole documents at the root), plus `BenchmarkMarshalRawMessage` and a godoc example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
