### PR TITLE
fix: report table placement errors with position and key context

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -622,17 +622,18 @@ func (d *decoder) wrapError(data []byte, err error) error {
 	return err
 }
 
-// wrapSeenError turns an error returned by SeenTracker.CheckExpression into a
-// ParserError carrying the position and key of the offending expression, so
-// that redefinition and duplicate-key errors are reported as a DecodeError
-// with context (see issue #668).
+// keyedError turns a bare error raised while processing an expression into a
+// ParserError carrying the position and key of that expression, so that it is
+// reported as a DecodeError with context. It is used for the errors returned
+// by SeenTracker.CheckExpression (redefinitions and duplicate keys, see issue
+// #668) and for table placement errors raised by walkTable (see issue #806).
 //
 // The highlight spans the expression's key. Unlike Node.Raw, key nodes always
 // carry a Raw range, so this works for tables and array tables too (whose own
 // Raw range is not set by the parser). For a duplicate detected inside an
 // inline table, node is the enclosing key-value expression, so the error
 // points at that expression's key.
-func (d *decoder) wrapSeenError(node *unstable.Node, err error) error {
+func (d *decoder) keyedError(node *unstable.Node, err error) error {
 	if err == nil {
 		return nil
 	}
@@ -667,7 +668,7 @@ func (d *decoder) wrapSeenError(node *unstable.Node, err error) error {
 func (d *decoder) handleRootExpression(expr *unstable.Node, root reflect.Value) error {
 	first, err := d.seen.CheckExpression(expr)
 	if err != nil {
-		return d.wrapSeenError(expr, err)
+		return d.keyedError(expr, err)
 	}
 
 	switch expr.Kind {
@@ -788,7 +789,7 @@ walk:
 			}
 			// Anything else is replaced by a fresh generic map.
 			if !mapStringInterfaceType.AssignableTo(v.Type()) {
-				return unstable.NewParserError(d.p.Raw(expr.Raw), "cannot store a table in a %s", v.Type())
+				return d.keyedError(expr, fmt.Errorf("cannot store a table in a %s", v.Type()))
 			}
 			fresh := reflect.ValueOf(map[string]interface{}{})
 			d.storeSlot(&pf, fresh)
@@ -816,7 +817,7 @@ walk:
 				d.setArrayCount(key, 1)
 			}
 			if cnt > v.Len() {
-				return unstable.NewParserError(d.p.Raw(expr.Raw), "cannot reach element %d of array of size %d", cnt-1, v.Len())
+				return d.keyedError(expr, fmt.Errorf("cannot reach element %d of array of size %d", cnt-1, v.Len()))
 			}
 			d.segIdx[idx] = cnt - 1
 			elem := v.Index(cnt - 1)
@@ -899,7 +900,7 @@ walk:
 					}
 				default:
 					if !ceIface {
-						return unstable.NewParserError(d.p.Raw(expr.Raw), "cannot store a table in a %s", ce.Type())
+						return d.keyedError(expr, fmt.Errorf("cannot store a table in a %s", ce.Type()))
 					}
 					fresh := reflect.ValueOf(map[string]interface{}{})
 					d.storeSlot(&w, fresh)
@@ -911,7 +912,7 @@ walk:
 				switch et.Kind() {
 				case reflect.Interface:
 					if !mapStringInterfaceType.AssignableTo(et) {
-						return unstable.NewParserError(d.p.Raw(expr.Raw), "cannot store a table in a %s", et)
+						return d.keyedError(expr, fmt.Errorf("cannot store a table in a %s", et))
 					}
 					fresh := reflect.ValueOf(map[string]interface{}{})
 					d.storeSlot(&w, fresh)
@@ -933,7 +934,7 @@ walk:
 					pf = slotWriter{kind: 1, slot: tmp}
 					v = tmp
 				default:
-					return unstable.NewParserError(d.p.Raw(expr.Raw), "cannot store a table in a %s", et)
+					return d.keyedError(expr, fmt.Errorf("cannot store a table in a %s", et))
 				}
 			}
 			idx++
@@ -950,7 +951,7 @@ walk:
 			v = fv
 			idx++
 		default:
-			return unstable.NewParserError(d.p.Raw(expr.Raw), "cannot store a table in a %s", v.Kind())
+			return d.keyedError(expr, fmt.Errorf("cannot store a table in a %s", v.Kind()))
 		}
 	}
 
@@ -1006,7 +1007,7 @@ walk:
 				cnt = 0
 			}
 			if cnt >= v.Len() {
-				return unstable.NewParserError(d.p.Raw(expr.Raw), "array of size %d is too small to store this array table", v.Len())
+				return d.keyedError(expr, fmt.Errorf("array of size %d is too small to store this array table", v.Len()))
 			}
 			v.Index(cnt).Set(reflect.Zero(v.Type().Elem()))
 			d.setArrayCount(akey, cnt+1)
@@ -1019,7 +1020,7 @@ walk:
 			pf = slotWriter{kind: 1, slot: elem}
 			v = elem
 		default:
-			return fmt.Errorf("toml: cannot store an array table in a %s", v.Kind())
+			return d.keyedError(expr, fmt.Errorf("cannot store an array table in a %s", v.Kind()))
 		}
 	}
 
@@ -1046,7 +1047,7 @@ walk:
 				}
 			}
 			if !mapStringInterfaceType.AssignableTo(v.Type()) {
-				return fmt.Errorf("toml: cannot store a table in a %s", v.Type())
+				return d.keyedError(expr, fmt.Errorf("cannot store a table in a %s", v.Type()))
 			}
 			fresh := reflect.ValueOf(map[string]interface{}{})
 			d.storeSlot(&pf, fresh)
@@ -1072,7 +1073,7 @@ walk:
 			d.tableTargetValid = true
 			return nil
 		default:
-			return fmt.Errorf("toml: cannot store a table in a %s", v.Kind())
+			return d.keyedError(expr, fmt.Errorf("cannot store a table in a %s", v.Kind()))
 		}
 	}
 }

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -5723,3 +5723,95 @@ e = 1
 	assert.NoError(t, toml.Unmarshal([]byte(doc), &m))
 	assert.Equal(t, 1, len(m["a"].([]interface{}))-1)
 }
+
+func TestIssue806_TableErrorContext(t *testing.T) {
+	// Errors raised while placing a [table] or [[array table]] into an
+	// incompatible target must be DecodeErrors carrying the position and key
+	// of the offending header, not bare strings (or errors pointing at the
+	// start of the document).
+	examples := []struct {
+		desc string
+		doc  string
+		unm  func(data []byte) error
+		msg  string
+		row  int
+		col  int
+		key  []string
+	}{
+		{
+			desc: "array table into string field",
+			doc:  "x = 1\n[[A]]\n",
+			unm: func(data []byte) error {
+				var s struct {
+					X int
+					A string
+				}
+				return toml.Unmarshal(data, &s)
+			},
+			msg: "toml: cannot store an array table in a string",
+			row: 2, col: 3,
+			key: []string{"A"},
+		},
+		{
+			desc: "table into string field",
+			doc:  "x = 1\n[A]\n",
+			unm: func(data []byte) error {
+				var s struct {
+					X int
+					A string
+				}
+				return toml.Unmarshal(data, &s)
+			},
+			msg: "toml: cannot store a table in a string",
+			row: 2, col: 2,
+			key: []string{"A"},
+		},
+		{
+			desc: "table into non-generic interface field",
+			doc:  "x = 1\n[A]\n",
+			unm: func(data []byte) error {
+				var s struct {
+					X int
+					A interface{ Foo() }
+				}
+				return toml.Unmarshal(data, &s)
+			},
+			msg: "toml: cannot store a table in a interface { Foo() }",
+			row: 2, col: 2,
+			key: []string{"A"},
+		},
+		{
+			desc: "nested table through a slice of scalars",
+			doc:  "x = 1\n[A.B]\n",
+			unm: func(data []byte) error {
+				var s struct {
+					X int
+					A []int
+				}
+				return toml.Unmarshal(data, &s)
+			},
+			msg: "toml: cannot store a table in a int",
+			row: 2, col: 2,
+			key: []string{"A", "B"},
+		},
+	}
+
+	for _, e := range examples {
+		e := e
+		t.Run(e.desc, func(t *testing.T) {
+			err := e.unm([]byte(e.doc))
+			assert.Error(t, err)
+			assert.Equal(t, e.msg, err.Error())
+
+			var de *toml.DecodeError
+			if !errors.As(err, &de) {
+				t.Fatalf("err should have been a *toml.DecodeError, but got %s (%T)", err, err)
+			}
+			t.Log("\n" + de.String())
+			row, col := de.Position()
+			assert.Equal(t, e.row, row)
+			assert.Equal(t, e.col, col)
+			assert.Equal(t, toml.Key(e.key), de.Key())
+		})
+	}
+}


### PR DESCRIPTION
## What

Errors raised while placing a `[table]` or `[[array table]]` into an incompatible target lacked context:

- The three `fmt.Errorf` sites in `walkTable`'s settle loop returned bare strings (no position, no key, not a `DecodeError`).
- The remaining sites highlighted `d.p.Raw(expr.Raw)` — but `Table`/`ArrayTable` nodes carry no `Raw` range, so the resulting `DecodeError` pointed at **offset 0 (line 1:1) with an empty key**, underlining an unrelated line.

All of `walkTable`'s placement errors now go through `keyedError` (the renamed `wrapSeenError`), which builds the highlight and key from the expression's key nodes — the same mechanism already used for redefinition errors (#668). Error strings are unchanged; they now surface as `DecodeError` with the position and key of the offending header.

Before / after for `[[A]]` into `struct{ A string }`:

```
toml: cannot store an array table in a string
```

```
2| [[A]]
 |   ~ cannot store an array table in a string
```
with `Key() == ["A"]` and `Position() == (2, 3)`.

Fixes #806

## Testing

- Added regression test `TestIssue806_TableErrorContext` covering the three formerly-bare error sites plus one formerly-mispositioned site — red before the fix (plain `*errors.errorString` / position 1:1), green after.
- `go test -race ./...` green; `golangci-lint` (v2.8.0) clean; `./caps.sh check` unchanged; coverage of touched functions 93–98%, total unchanged at 97.2%.

## Benchmarks

Error-path only — the success path through `walkTable` is untouched. Interleaved A/B on linux/amd64 (go1.26.4, 10 samples): all benchmarks statistically unchanged, geomean −0.29%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)