### PR TITLE
fix: do not recurse forever on recursively embedded structs

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -2260,11 +2260,22 @@ func buildPlan(t reflect.Type) *structPlan {
 		byName: map[string]structField{},
 		byFold: map[string]structField{},
 	}
-	addFields(plan, t, nil)
+	addFields(plan, t, nil, map[reflect.Type]bool{})
 	return plan
 }
 
-func addFields(plan *structPlan, t reflect.Type, prefix []int) {
+// addFields flattens the fields of t into the plan. visited holds the types
+// being flattened on the current branch: a struct type that embeds itself
+// (directly or through other types) is not descended into again, mirroring
+// buildEncPlan. Without this guard a recursive embedding would recurse
+// forever; the repeated fields are unreachable by flattening anyway.
+func addFields(plan *structPlan, t reflect.Type, prefix []int, visited map[reflect.Type]bool) {
+	if visited[t] {
+		return
+	}
+	visited[t] = true
+	defer delete(visited, t)
+
 	var embedded []reflect.StructField
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
@@ -2344,7 +2355,7 @@ func addFields(plan *structPlan, t reflect.Type, prefix []int) {
 		index = append(index, prefix...)
 		idx := f.Index[0]
 		index = append(index, idx)
-		addFields(plan, ft, index)
+		addFields(plan, ft, index, visited)
 	}
 }
 

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -5815,3 +5815,55 @@ func TestIssue806_TableErrorContext(t *testing.T) {
 		})
 	}
 }
+
+type selfEmbedded struct {
+	*selfEmbedded
+	X int
+}
+
+// The mutual pair is exported: allocating an embedded pointer during decode
+// requires the embedded field to be settable, which reflect only allows for
+// exported fields.
+type MutualEmbeddedA struct {
+	*MutualEmbeddedB
+	X int
+}
+
+type MutualEmbeddedB struct {
+	*MutualEmbeddedA
+	Y int
+}
+
+func TestUnmarshalRecursiveEmbedded(t *testing.T) {
+	// A struct type that embeds itself (directly or mutually) used to send
+	// the struct-plan builder into infinite recursion, hanging Unmarshal
+	// regardless of the input. The fields of a recursive embedding are
+	// unreachable by flattening, so the cycle is simply not descended into.
+	t.Run("self", func(t *testing.T) {
+		var v selfEmbedded
+		assert.NoError(t, toml.Unmarshal([]byte(`X = 1`), &v))
+		assert.Equal(t, 1, v.X)
+		assert.Zero(t, v.selfEmbedded)
+	})
+
+	t.Run("mutual", func(t *testing.T) {
+		var v MutualEmbeddedA
+		assert.NoError(t, toml.Unmarshal([]byte("X = 1\nY = 2"), &v))
+		assert.Equal(t, 1, v.X)
+		// B's fields remain reachable through the embedding chain: the cycle
+		// only stops where B would re-embed A.
+		assert.Equal(t, 2, v.Y)
+	})
+
+	t.Run("same type twice without cycle", func(t *testing.T) {
+		// The same embedded type on two sibling branches is not a cycle and
+		// must still be flattened.
+		type leaf struct{ Z int }
+		type mid1 struct{ leaf }
+		var v struct {
+			mid1
+		}
+		assert.NoError(t, toml.Unmarshal([]byte(`Z = 3`), &v))
+		assert.Equal(t, 3, v.Z)
+	})
+}


### PR DESCRIPTION
## What

Unmarshaling into a struct type that embeds itself — directly (`type A struct { *A; X int }`) or mutually through another type — hung the decoder with unbounded memory growth. `addFields` flattens embedded structs by recursing on their *type* with no visited-type guard, so a recursive embedding recursed forever at plan-build time, regardless of the input document.

`addFields` now carries the same `visited map[reflect.Type]bool` guard the encoder's `buildEncPlan` has used all along: a type currently being flattened on this branch is not descended into again. The skipped fields are unreachable by flattening anyway, and the enter/defer-delete pattern keeps sibling (non-cyclic) repeats of a type flattening exactly as before. `Marshal` of the same types already worked (the nil embedded pointer stops the value walk), so this brings decode in line with encode.

The hang is pre-existing, not a reimplementation regression: v2.3.1 hangs on the same input in its per-expression field walk.

## Testing

- Added regression test `TestUnmarshalRecursiveEmbedded` (self-embedding, mutual embedding, and a same-type-twice-without-cycle control) — before the fix the test hangs until the go test timeout kills it with the recursion stack; green after.
- `go test -race ./...` green; `golangci-lint` (v2.8.0) clean; `./caps.sh check` unchanged; `addFields`/`buildPlan` at 100% coverage, total unchanged at 97.2%.

## Benchmarks

The visited map is allocated once per plan build, which runs once per type per process (cached in `structPlans`); the steady-state decode path is untouched. Interleaved A/B on linux/amd64 (go1.26.4): all decode benchmarks statistically unchanged (geomean +0.13% on a focused n=24 re-run; the few marshal deltas flagged in the first pass disappeared at higher power, consistent with layout noise — the change is unreachable from the marshal path and allocations are byte-identical).

## Out of scope

While writing the test I hit a separate pre-existing issue (reproduces on v2.4.2 without any recursion): decoding through a **nil unexported embedded pointer** (`type outer struct{ *inner }`) panics with `reflect: reflect.Value.Set using value obtained using unexported field` instead of returning an error. Worth its own issue; encoding/json reports a proper error for this shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)