### PR TITLE
fix: error instead of panic on nil unexported embedded pointer

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -946,7 +946,10 @@ walk:
 				d.skipUntilTable = true
 				return nil
 			}
-			fv := fieldByIndexAlloc(v, f.index)
+			fv, err := fieldByIndexAlloc(v, f.index)
+			if err != nil {
+				return err
+			}
 			pf = slotWriter{kind: 1, slot: fv}
 			v = fv
 			idx++
@@ -1229,7 +1232,10 @@ func (d *decoder) resolveCapture(v reflect.Value, c *rawCapture, idx int, indexe
 		if !found {
 			return v, nil
 		}
-		fv := fieldByIndexAlloc(v, f.index)
+		fv, err := fieldByIndexAlloc(v, f.index)
+		if err != nil {
+			return reflect.Value{}, err
+		}
 		nv, err := d.resolveCapture(fv, c, idx+1, false)
 		if err != nil {
 			return reflect.Value{}, err
@@ -1490,9 +1496,11 @@ func (d *decoder) descend(v reflect.Value, path []pathPart, idx int, expr *unsta
 			}
 			return v, nil
 		}
-		fv := fieldByIndexAlloc(v, f.index)
+		fv, err := fieldByIndexAlloc(v, f.index)
+		if err != nil {
+			return reflect.Value{}, err
+		}
 		var nv reflect.Value
-		var err error
 		if idx+1 == len(path) {
 			// Leaf field: assign directly. descend's first action for a
 			// fully-consumed path is exactly this call, so skipping the extra
@@ -2361,16 +2369,22 @@ func addFields(plan *structPlan, t reflect.Type, prefix []int, visited map[refle
 
 // fieldByIndexAlloc returns the field of v at the given index path,
 // allocating intermediate embedded pointers as needed.
-func fieldByIndexAlloc(v reflect.Value, index []int) reflect.Value {
+func fieldByIndexAlloc(v reflect.Value, index []int) (reflect.Value, error) {
 	// Fast path for non-embedded fields, which have a single-element index:
 	// no intermediate pointer dereferencing is possible.
 	if len(index) == 1 {
-		return v.Field(index[0])
+		return v.Field(index[0]), nil
 	}
 	for i, x := range index {
 		if i > 0 {
 			for v.Kind() == reflect.Ptr {
 				if v.IsNil() {
+					if !v.CanSet() {
+						// A nil embedded pointer of unexported type cannot be
+						// allocated: reflect forbids setting it. Match
+						// encoding/json and report it instead of panicking.
+						return reflect.Value{}, fmt.Errorf("toml: cannot set embedded pointer to unexported struct: %s", v.Type().Elem())
+					}
 					v.Set(reflect.New(v.Type().Elem()))
 				}
 				v = v.Elem()
@@ -2378,5 +2392,5 @@ func fieldByIndexAlloc(v reflect.Value, index []int) reflect.Value {
 		}
 		v = v.Field(x)
 	}
-	return v
+	return v, nil
 }

--- a/unmarshaler_internal_test.go
+++ b/unmarshaler_internal_test.go
@@ -1,0 +1,32 @@
+package toml
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2/internal/assert"
+)
+
+type unexpCaptureInner struct{ C int }
+
+type unexpCaptureOuter struct {
+	*unexpCaptureInner
+}
+
+func TestResolveCaptureUnexportedEmbeddedPointer(t *testing.T) {
+	// resolveCapture walks the same field paths as walkTable, which has
+	// either allocated the intermediate embedded pointers or already failed
+	// by the time captures are resolved. Exercise its defensive branch
+	// directly: resolving a capture through a nil embedded pointer of
+	// unexported type must surface fieldByIndexAlloc's error, not panic.
+	d := &decoder{}
+	c := rawCapture{
+		names:   []string{"C"},
+		indexes: []int{-1, -1},
+		buf:     []byte("x = 1\n"),
+	}
+	root := reflect.ValueOf(&unexpCaptureOuter{}).Elem()
+	_, err := d.resolveCapture(root, &c, 0, false)
+	assert.Error(t, err)
+	assert.Equal(t, "toml: cannot set embedded pointer to unexported struct: toml.unexpCaptureInner", err.Error())
+}

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -5867,3 +5867,45 @@ func TestUnmarshalRecursiveEmbedded(t *testing.T) {
 		assert.Equal(t, 3, v.Z)
 	})
 }
+
+type unexportedEmbedInner struct{ Z int }
+
+type unexportedEmbedOuter struct {
+	*unexportedEmbedInner
+}
+
+func TestUnmarshalNilUnexportedEmbeddedPointer(t *testing.T) {
+	// Reaching a field promoted through a nil embedded pointer of unexported
+	// type requires setting that pointer, which reflect forbids. This must
+	// surface as an error (like encoding/json), not a panic.
+	t.Run("nil pointer errors", func(t *testing.T) {
+		var v unexportedEmbedOuter
+		err := toml.Unmarshal([]byte(`Z = 1`), &v)
+		assert.Error(t, err)
+		assert.Equal(t, "toml: cannot set embedded pointer to unexported struct: toml_test.unexportedEmbedInner", err.Error())
+	})
+
+	// A non-nil pointer needs no allocation and keeps decoding.
+	t.Run("non-nil pointer decodes", func(t *testing.T) {
+		v := unexportedEmbedOuter{unexportedEmbedInner: &unexportedEmbedInner{}}
+		assert.NoError(t, toml.Unmarshal([]byte(`Z = 1`), &v))
+		assert.Equal(t, 1, v.Z)
+	})
+
+	// Same through a table header, which walks the promoted field in
+	// walkTable rather than descend.
+	t.Run("table header errors", func(t *testing.T) {
+		var v unexportedEmbedTableOuter
+		err := toml.Unmarshal([]byte("[Sub]\nA = 1"), &v)
+		assert.Error(t, err)
+		assert.Equal(t, "toml: cannot set embedded pointer to unexported struct: toml_test.unexportedEmbedTableInner", err.Error())
+	})
+}
+
+type unexportedEmbedTableInner struct {
+	Sub struct{ A int }
+}
+
+type unexportedEmbedTableOuter struct {
+	*unexportedEmbedTableInner
+}


### PR DESCRIPTION
## What

Decoding a key promoted through a **nil embedded pointer of unexported type** panicked instead of returning an error (pre-existing, reproduces on v2.4.2 and earlier; found while writing the regression test for #1087):

```go
type inner struct{ Z int }
type outer struct{ *inner }

var v outer
toml.Unmarshal([]byte("Z = 1"), &v)
// panic: reflect: reflect.Value.Set using value obtained using unexported field
```

`fieldByIndexAlloc` must allocate the intermediate pointer to reach `Z`, and reflect forbids setting a pointer obtained through an unexported field. The guard now detects the unsettable pointer and returns an error with the same message and semantics as `encoding/json`:

```
toml: cannot set embedded pointer to unexported struct: toml_test.unexportedEmbedInner
```

Behavior matrix after the fix (matches encoding/json in every cell):

| shape | before | after |
|---|---|---|
| nil unexported embedded ptr, decode | panic | error |
| non-nil unexported embedded ptr, decode | works | works (unchanged) |
| marshal (nil / non-nil) | works | works (unchanged) |

`fieldByIndexAlloc` gains an error return, checked at its three call sites (`walkTable`, `descend`, `resolveCapture`), so the unmarshaler-interface capture path is covered too.

## Testing

- Added regression test `TestUnmarshalNilUnexportedEmbeddedPointer` (nil pointer errors + non-nil pointer keeps decoding) — before the fix the nil case panics, green after.
- `go test -race ./...` green; `golangci-lint` (v2.8.0) clean; `./caps.sh check` unchanged; `fieldByIndexAlloc` at 100% coverage, total 97.1%.

## Benchmarks

`fieldByIndexAlloc` is on the hot struct-decode path, so this was benchmarked carefully: interleaved A/B vs `v2` tip (82b792e) on linux/amd64, go1.26.4, n=12. All struct-decode benchmarks (the ones that exercise the changed code) are statistically unchanged; geomean +0.15%. The two stray flags were in code unreachable from the change (a −5.6% "improvement" on the fused-map citm_catalog decode, +2.4% on `Marshal/SimpleDocument/map`) and disappeared in a focused n=24 re-run (p=0.33) — layout noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)