### PR TITLE
perf: keep default encode path baseline-identical with Marshaler support

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -16,7 +16,6 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/pelletier/go-toml/v2/internal/parserbridge"
 	"github.com/pelletier/go-toml/v2/unstable"
 )
 
@@ -323,22 +322,6 @@ type entry struct {
 	options valueOptions
 }
 
-// rawShape classifies the bytes produced by an unstable.Marshaler.
-type rawShape uint8
-
-const (
-	// shapeUnknown is the default: not an unstable.Marshaler, or the interface
-	// is disabled.
-	shapeUnknown rawShape = iota
-	// shapeEmpty is whitespace-only content: it has no TOML representation and
-	// is omitted from the output.
-	shapeEmpty
-	// shapeValue is a single TOML value, emitted inline as `key = <raw>`.
-	shapeValue
-	// shapeTable is one or more key-value lines, emitted as a `[key]` body.
-	shapeTable
-)
-
 func (e *encoderState) encodeRoot(v interface{}) error {
 	if v == nil {
 		return errors.New("toml: cannot encode a nil interface")
@@ -350,7 +333,7 @@ func (e *encoderState) encodeRoot(v interface{}) error {
 		return errors.New("toml: cannot encode a nil pointer")
 	}
 
-	if e.marshalerOn && encPropsForType(rv.Type()).marshaler != 0 {
+	if e.marshalerOn && marshalerPropsForType(rv.Type()) != 0 {
 		return e.encodeMarshalerRoot(rv)
 	}
 
@@ -363,34 +346,6 @@ func (e *encoderState) encodeRoot(v interface{}) error {
 	default:
 		return fmt.Errorf("toml: cannot encode a %s as a document root", rv.Type())
 	}
-}
-
-// encodeMarshalerRoot emits the bytes of a root-level unstable.Marshaler as
-// the whole document: the encode counterpart of the decoder delivering the
-// whole document to a root Unmarshaler. The bytes must form a TOML document
-// (key-value lines and table headers); empty output produces an empty
-// document.
-func (e *encoderState) encodeMarshalerRoot(rv reflect.Value) error {
-	raw, err := e.marshalerBytes(rv)
-	if err != nil {
-		return err
-	}
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 {
-		return nil
-	}
-	if err := e.validateRawTableBody(rv.Type(), trimmed); err != nil {
-		// A single TOML value has no meaning at the document root; report it
-		// as such rather than as a syntax error.
-		if shape, _ := e.classifyRaw(trimmed); shape == shapeValue {
-			return fmt.Errorf("toml: cannot encode %s as a document root: MarshalTOML returned a single TOML value, not a document", rv.Type())
-		}
-		return err
-	}
-	e.buf = append(e.buf, trimmed...)
-	e.buf = append(e.buf, '\n')
-	e.lastWasHeader = false
-	return nil
 }
 
 // resolve unwraps pointers and interfaces until a concrete value is found.
@@ -418,14 +373,9 @@ func resolve(v reflect.Value) (reflect.Value, bool) {
 type typeEncProps struct {
 	// 0: not a TextMarshaler, 1: the type implements it, 2: its pointer does
 	text uint8
-	// 0: not an unstable.Marshaler, 1: the type implements it, 2: its pointer
-	// does. Only consulted when Encoder.marshalerInterface is set.
-	marshaler uint8
 	// encoded as a TOML value (as opposed to a table)
 	isValue bool
 }
-
-var marshalerType = reflect.TypeOf(new(unstable.Marshaler)).Elem()
 
 var typeEncPropsCache sync.Map // reflect.Type -> typeEncProps
 
@@ -439,12 +389,6 @@ func encPropsForType(t reflect.Type) typeEncProps {
 		p.text = 1
 	case reflect.PtrTo(t).Implements(textMarshalerType):
 		p.text = 2
-	}
-	switch {
-	case t.Implements(marshalerType):
-		p.marshaler = 1
-	case reflect.PtrTo(t).Implements(marshalerType):
-		p.marshaler = 2
 	}
 	switch t {
 	case timeType, localDateType, localTimeType, localDateTimeType:
@@ -510,152 +454,6 @@ func (e *encoderState) isArrayOfTables(v reflect.Value) bool {
 	return true
 }
 
-// isMarshalerArrayOfTables is the EnableMarshalerInterface variant of
-// isArrayOfTables: a Marshaler element counts as a table only when its raw
-// content is table shaped (key-value lines); one holding a single value makes
-// the whole slice a plain array instead.
-func (e *encoderState) isMarshalerArrayOfTables(v reflect.Value) bool {
-	for i := 0; i < v.Len(); i++ {
-		elem, ok := resolve(v.Index(i))
-		if !ok {
-			return false
-		}
-		if encPropsForType(elem.Type()).marshaler != 0 {
-			raw, err := e.marshalerBytes(elem)
-			if err != nil {
-				return false
-			}
-			if shape, _ := e.classifyRaw(raw); shape != shapeTable {
-				return false
-			}
-			continue
-		}
-		if isValueKind(elem) {
-			return false
-		}
-	}
-	return true
-}
-
-// marshalerBytes returns the raw TOML produced by v's unstable.Marshaler
-// implementation. The caller guarantees v implements the interface
-// (encPropsForType(v.Type()).marshaler != 0).
-func (e *encoderState) marshalerBytes(v reflect.Value) ([]byte, error) {
-	t := v.Type()
-	var m unstable.Marshaler
-	switch {
-	case encPropsForType(t).marshaler == 1:
-		// The type itself implements Marshaler (e.g. a value receiver).
-		m = v.Interface().(unstable.Marshaler)
-	case v.CanAddr():
-		// Only the pointer implements it, and v is addressable.
-		m = v.Addr().Interface().(unstable.Marshaler)
-	default:
-		// Only the pointer implements it, but v is not addressable: take the
-		// address of a copy.
-		tmp := reflect.New(t)
-		tmp.Elem().Set(v)
-		m = tmp.Interface().(unstable.Marshaler)
-	}
-	b, err := m.MarshalTOML()
-	if err != nil {
-		return nil, fmt.Errorf("toml: error calling MarshalTOML for type %s: %w", t, err)
-	}
-	return b, nil
-}
-
-// validateRawTableBody checks that trimmed — table-shaped Marshaler output
-// about to be spliced verbatim — is syntactically valid TOML, so a Marshaler
-// cannot silently corrupt the document. It reuses e.parser, like classifyRaw.
-func (e *encoderState) validateRawTableBody(t reflect.Type, trimmed []byte) error {
-	e.parser.Reset(trimmed)
-	for e.parser.NextExpression() {
-	}
-	if err := e.parser.Error(); err != nil {
-		return fmt.Errorf("toml: error calling MarshalTOML for type %s: invalid TOML: %w", t, err)
-	}
-	return nil
-}
-
-// classifyRaw decides whether b (the output of an unstable.Marshaler) is empty,
-// a single TOML value, or a table body. It returns the trimmed bytes that
-// should be spliced into the document. It reuses e.parser, so it is not safe
-// for concurrent use (encoderState is not shared).
-func (e *encoderState) classifyRaw(b []byte) (rawShape, []byte) {
-	trimmed := bytes.TrimSpace(b)
-	if len(trimmed) == 0 {
-		return shapeEmpty, trimmed
-	}
-	e.parser.Reset(trimmed)
-	_, rest, err := parserbridge.ParseValue(&e.parser, trimmed)
-	if err == nil && len(bytes.TrimSpace(rest)) == 0 {
-		return shapeValue, trimmed
-	}
-	return shapeTable, trimmed
-}
-
-// resolveMarshalerEntries classifies every entry whose value implements
-// unstable.Marshaler, recording the shape on the entry so the two table passes
-// can route it without re-classifying. Any error from MarshalTOML is surfaced
-// eagerly. The marshaled bytes themselves are produced again at emit time by
-// marshalerValue; that keeps entry small on the encoder's hot path, and only
-// runs when the (opt-in) interface is enabled.
-func (e *encoderState) resolveMarshalerEntries(entries []entry) error {
-	for i := range entries {
-		ent := &entries[i]
-		if ent.options.rawShape != shapeUnknown {
-			// Already classified: SetOmitEmptySuperTables resolves the
-			// entries early to route them by shape.
-			continue
-		}
-		v, ok := resolve(ent.value)
-		if !ok || encPropsForType(v.Type()).marshaler == 0 {
-			continue
-		}
-		raw, err := e.marshalerBytes(v)
-		if err != nil {
-			return err
-		}
-		ent.options.rawShape, _ = e.classifyRaw(raw)
-	}
-	return nil
-}
-
-// marshalerValue returns the trimmed bytes to splice for an entry already known
-// to be an unstable.Marshaler (ent.options.rawShape != shapeUnknown).
-func (e *encoderState) marshalerValue(ent *entry) ([]byte, error) {
-	v, _ := resolve(ent.value)
-	raw, err := e.marshalerBytes(v)
-	if err != nil {
-		return nil, err
-	}
-	return bytes.TrimSpace(raw), nil
-}
-
-// appendMarshalerInline emits an unstable.Marshaler value in a value position
-// (array element or inline-table member), where only a single TOML value is
-// valid. done is false when t is not a Marshaler, so appendValue falls through
-// to its normal handling. It is split out of appendValue (type check included)
-// to keep that hot path lean.
-func (e *encoderState) appendMarshalerInline(b []byte, v reflect.Value, t reflect.Type) (out []byte, done bool, err error) {
-	if encPropsForType(t).marshaler == 0 {
-		return b, false, nil
-	}
-	raw, err := e.marshalerBytes(v)
-	if err != nil {
-		return nil, true, err
-	}
-	shape, trimmed := e.classifyRaw(raw)
-	switch shape {
-	case shapeValue:
-		return append(b, trimmed...), true, nil
-	case shapeEmpty:
-		return nil, true, fmt.Errorf("toml: cannot encode an empty %s as an inline value", t)
-	default:
-		return nil, true, fmt.Errorf("toml: cannot encode %s as an inline value: %q is not a single TOML value", t, trimmed)
-	}
-}
-
 // encodeTable writes the content of a table at the given key path.
 func (e *encoderState) encodeTable(v reflect.Value, commented bool, indent int) error {
 	entries, err := e.collectEntries(v)
@@ -668,51 +466,23 @@ func (e *encoderState) encodeTable(v reflect.Value, commented bool, indent int) 
 // encodeTableEntries writes the given table entries at the given key path,
 // and returns them to the pool.
 func (e *encoderState) encodeTableEntries(entries []entry, commented bool, indent int) error {
-	// Marshaler routing is hoisted behind a single local flag. When the (opt-in)
-	// interface is off, mOn is false and both passes run the exact baseline
-	// code, so the default Marshal path keeps its performance.
-	mOn := e.marshalerOn
-	if mOn {
-		// Classify Marshaler entries once, up front, so the passes can route
-		// them by shape and surface MarshalTOML errors eagerly.
-		if err := e.resolveMarshalerEntries(entries); err != nil {
-			return err
-		}
+	// The Marshaler-aware passes live in a separate method so that when the
+	// (opt-in) interface is off, the loops below keep their exact baseline
+	// shape and performance: routing costs one branch per table, not one per
+	// entry.
+	if e.marshalerOn {
+		return e.encodeTableWithMarshalers(entries, commented, indent)
 	}
 
 	// First pass: emit all key-values; tables are handled by the second
 	// pass.
 	for i := range entries {
 		ent := &entries[i]
-		if mOn {
-			switch ent.options.rawShape {
-			case shapeUnknown:
-				// Not a Marshaler: handled by the baseline logic below.
-			case shapeEmpty:
-				// No TOML representation: omit the key.
-				continue
-			case shapeValue:
-				if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
-					return err
-				}
-				continue
-			case shapeTable:
-				// A table body is emitted in the second pass, unless it is
-				// forced inline (SetTablesInline / inline tag), which has no
-				// valid inline form and is reported as an error by
-				// encodeKeyValue.
-				if e.tablesInline || ent.options.inline {
-					if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
-						return err
-					}
-				}
-				continue
-			}
-		}
 		if e.entryIsTable(ent) {
 			continue
 		}
-		if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
+		err := e.encodeKeyValue(*ent, commented, indent)
+		if err != nil {
 			return err
 		}
 	}
@@ -720,25 +490,6 @@ func (e *encoderState) encodeTableEntries(entries []entry, commented bool, inden
 	// Second pass: emit the sub-tables, extending the shared key stack.
 	for i := range entries {
 		ent := entries[i]
-		if mOn {
-			switch ent.options.rawShape {
-			case shapeUnknown:
-				// Not a Marshaler: handled by the baseline logic below.
-			case shapeValue, shapeEmpty:
-				// Not a table: already handled (or omitted) in the first pass.
-				continue
-			case shapeTable:
-				// Emit the raw body verbatim under the freshly pushed header.
-				// (The forced-inline case already errored in the first pass.)
-				entCommented := commented || ent.options.commented
-				e.keyStack = append(e.keyStack, ent.key)
-				if err := e.encodeMarshalerTable(&ent, entCommented, indent); err != nil {
-					return err
-				}
-				e.keyStack = e.keyStack[:len(e.keyStack)-1]
-				continue
-			}
-		}
 		if !e.entryIsTable(&ent) {
 			continue
 		}
@@ -764,15 +515,6 @@ func (e *encoderState) encodeTableEntries(entries []entry, commented bool, inden
 
 		subIndent := indent + 1
 		if e.omitEmptySuperTables && ent.options.comment == "" {
-			if mOn {
-				// The check below routes entries by their Marshaler shape,
-				// so classification cannot wait for encodeTableEntries.
-				// resolveMarshalerEntries skips already-classified entries,
-				// making the second call there a no-op.
-				if err := e.resolveMarshalerEntries(subEntries); err != nil {
-					return err
-				}
-			}
 			if e.onlySubTables(subEntries) {
 				// The table has no key-value of its own and at least one
 				// sub-table: emitting the sub-tables implicitly defines it,
@@ -822,45 +564,9 @@ func (e *encoderState) onlySubTables(entries []entry) bool {
 	return true
 }
 
-// encodeMarshalerTable emits a table-shaped unstable.Marshaler entry: the
-// header for the key currently on the stack, then the raw body verbatim.
-func (e *encoderState) encodeMarshalerTable(ent *entry, commented bool, indent int) error {
-	raw, err := e.marshalerValue(ent)
-	if err != nil {
-		return err
-	}
-	// Validate the bytes actually being spliced: MarshalTOML is called again
-	// for the emit, so this both rejects invalid TOML and guards against an
-	// implementation that returned different content than during
-	// classification.
-	if err := e.validateRawTableBody(ent.value.Type(), raw); err != nil {
-		return err
-	}
-	e.writeTableHeader(ent.options.comment, commented, false, indent)
-	e.spliceRawTableBody(raw, commented)
-	return nil
-}
-
-// spliceRawTableBody appends a raw table body verbatim after its header. When
-// the table is commented, every physical line is prefixed with the comment
-// marker so the body does not leak into the document as live keys.
-func (e *encoderState) spliceRawTableBody(raw []byte, commented bool) {
-	if len(raw) == 0 {
-		return
-	}
-	if commented {
-		e.buf = append(e.buf, "# "...)
-		e.buf = append(e.buf, bytes.ReplaceAll(raw, []byte("\n"), []byte("\n# "))...)
-	} else {
-		e.buf = append(e.buf, raw...)
-	}
-	e.buf = append(e.buf, '\n')
-	e.lastWasHeader = false
-}
-
 // entryIsTable reports whether the entry is emitted as a (sub-)table rather
-// than a key-value. Marshaler entries are routed by encodeTable before this is
-// reached, so it carries no marshaler-specific cost.
+// than a key-value. Marshaler entries are routed by encodeTableWithMarshalers
+// before this is reached, so it carries no marshaler-specific cost.
 func (e *encoderState) entryIsTable(ent *entry) bool {
 	return !e.tablesInline && !ent.options.inline && (e.isTableLike(ent.value) || e.isArrayOfTables(ent.value))
 }
@@ -884,6 +590,12 @@ func (e *encoderState) putEntries(s []entry) {
 
 // encodeArrayTable writes all the elements of an array of tables.
 func (e *encoderState) encodeArrayTable(ent entry, commented bool, indent int) error {
+	// The Marshaler-aware variant lives in a separate method so this loop
+	// keeps its exact baseline shape when the (opt-in) interface is off.
+	if e.marshalerOn {
+		return e.encodeArrayTableWithMarshalers(ent, commented, indent)
+	}
+
 	v, _ := resolve(ent.value)
 	comment := ent.options.comment
 	for i := 0; i < v.Len(); i++ {
@@ -893,22 +605,6 @@ func (e *encoderState) encodeArrayTable(ent entry, commented bool, indent int) e
 		e.writeTableHeader(comment, commented, true, indent)
 		// The comment is only present before the first element.
 		comment = ""
-
-		// A Marshaler element splices its raw table body verbatim. The shape
-		// was checked by isArrayOfTables, but MarshalTOML is called again for
-		// the emit, so the spliced bytes are validated here.
-		if e.marshalerOn && encPropsForType(elem.Type()).marshaler != 0 {
-			raw, err := e.marshalerBytes(elem)
-			if err != nil {
-				return err
-			}
-			trimmed := bytes.TrimSpace(raw)
-			if err := e.validateRawTableBody(elem.Type(), trimmed); err != nil {
-				return err
-			}
-			e.spliceRawTableBody(trimmed, commented)
-			continue
-		}
 
 		err := e.encodeTable(elem, commented, indent+1)
 		if err != nil {
@@ -1004,15 +700,8 @@ func (e *encoderState) encodeKeyValue(ent entry, commented bool, indent int) err
 		valueIndent = 0
 	}
 
-	// A Marshaler value is delegated, keeping this hot function lean for the
-	// default path (rawShape stays shapeUnknown when the interface is off). It
-	// shares the commented/newline handling below.
 	var err error
-	if ent.options.rawShape != shapeUnknown {
-		e.buf, err = e.appendMarshalerInlineValue(e.buf, &ent)
-	} else {
-		e.buf, err = e.appendValue(e.buf, ent.value, ent.options, valueIndent)
-	}
+	e.buf, err = e.appendValue(e.buf, ent.value, ent.options, valueIndent)
 	if err != nil {
 		return err
 	}
@@ -1033,32 +722,6 @@ func (e *encoderState) encodeKeyValue(ent entry, commented bool, indent int) err
 	e.buf = append(e.buf, '\n')
 	e.lastWasHeader = false
 	return nil
-}
-
-// appendMarshalerInlineValue appends the value part of a `key = ` line for an
-// unstable.Marshaler entry, leaving the trailing newline and commented handling
-// to encodeKeyValue. Empty entries are filtered out before this point, so the
-// value is either a single value (spliced verbatim) or, when forced inline by
-// SetTablesInline or an inline tag, table content (an error).
-func (e *encoderState) appendMarshalerInlineValue(b []byte, ent *entry) ([]byte, error) {
-	errNotValue := func() error {
-		return fmt.Errorf("toml: cannot encode %s as an inline value: not a single TOML value", ent.value.Type())
-	}
-	if ent.options.rawShape != shapeValue {
-		return nil, errNotValue()
-	}
-	raw, err := e.marshalerValue(ent)
-	if err != nil {
-		return nil, err
-	}
-	// Classify the just-returned bytes rather than trusting the earlier pass:
-	// MarshalTOML is called again for the emit, and an implementation that
-	// returns different content must not splice non-value bytes into a
-	// `key = ` position.
-	if shape, trimmed := e.classifyRaw(raw); shape == shapeValue {
-		return append(b, trimmed...), nil
-	}
-	return nil, errNotValue()
 }
 
 // collectEntries builds the ordered list of the entries of a table,
@@ -1472,14 +1135,13 @@ func (e *encoderState) appendValue(b []byte, v reflect.Value, opts valueOptions,
 		}
 	}
 
-	// A Marshaler reached through a value position (an array element or inline
-	// table member) splices its bytes verbatim. Everything (including the type
-	// check) lives in a separate method so this hot function keeps its default
-	// layout: when the opt-in interface is off, only the bool test runs here.
-	if e.marshalerOn {
-		if b2, done, err := e.appendMarshalerInline(b, v, t); done {
-			return b2, err
-		}
+	// A Marshaler reached through a value position (a key-value line, an array
+	// element or an inline-table member) splices its bytes verbatim. The taken
+	// branch returns immediately, so when the opt-in interface is off only the
+	// short-circuited bool test runs here and no value stays live across a
+	// call.
+	if e.marshalerOn && marshalerPropsForType(t) != 0 {
+		return e.appendMarshalerInline(b, v, t)
 	}
 
 	switch encPropsForType(t).text {

--- a/marshaler_raw.go
+++ b/marshaler_raw.go
@@ -1,0 +1,424 @@
+package toml
+
+// This file contains the implementation of Encoder.EnableMarshalerInterface:
+// the encode half of the unstable.Marshaler / unstable.RawMessage support. It
+// is kept separate from marshaler.go so the feature's (opt-in, mostly cold)
+// code does not sit between the default encode path's hot functions.
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/pelletier/go-toml/v2/internal/parserbridge"
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// rawShape classifies the bytes produced by an unstable.Marshaler.
+type rawShape uint8
+
+const (
+	// shapeUnknown is the default: not an unstable.Marshaler, or the interface
+	// is disabled.
+	shapeUnknown rawShape = iota
+	// shapeEmpty is whitespace-only content: it has no TOML representation and
+	// is omitted from the output.
+	shapeEmpty
+	// shapeValue is a single TOML value, emitted inline as `key = <raw>`.
+	shapeValue
+	// shapeTable is one or more key-value lines, emitted as a `[key]` body.
+	shapeTable
+)
+
+var marshalerType = reflect.TypeOf(new(unstable.Marshaler)).Elem()
+
+// typeMarshalerCache caches, per type, how it implements unstable.Marshaler:
+// 0 not at all, 1 the type itself, 2 its pointer. It is deliberately separate
+// from typeEncPropsCache: growing typeEncProps changes the layout and register
+// shape of every cached-props lookup on the default encode path, which is
+// measurably slower. Only EnableMarshalerInterface paths consult this cache.
+var typeMarshalerCache sync.Map // reflect.Type -> uint8
+
+func marshalerPropsForType(t reflect.Type) uint8 {
+	if p, ok := typeMarshalerCache.Load(t); ok {
+		return p.(uint8)
+	}
+	var p uint8
+	switch {
+	case t.Implements(marshalerType):
+		p = 1
+	case reflect.PtrTo(t).Implements(marshalerType):
+		p = 2
+	}
+	typeMarshalerCache.Store(t, p)
+	return p
+}
+
+// encodeMarshalerRoot emits the bytes of a root-level unstable.Marshaler as
+// the whole document: the encode counterpart of the decoder delivering the
+// whole document to a root Unmarshaler. The bytes must form a TOML document
+// (key-value lines and table headers); empty output produces an empty
+// document.
+func (e *encoderState) encodeMarshalerRoot(rv reflect.Value) error {
+	raw, err := e.marshalerBytes(rv)
+	if err != nil {
+		return err
+	}
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if err := e.validateRawTableBody(rv.Type(), trimmed); err != nil {
+		// A single TOML value has no meaning at the document root; report it
+		// as such rather than as a syntax error.
+		if shape, _ := e.classifyRaw(trimmed); shape == shapeValue {
+			return fmt.Errorf("toml: cannot encode %s as a document root: MarshalTOML returned a single TOML value, not a document", rv.Type())
+		}
+		return err
+	}
+	e.buf = append(e.buf, trimmed...)
+	e.buf = append(e.buf, '\n')
+	e.lastWasHeader = false
+	return nil
+}
+
+// isMarshalerArrayOfTables is the EnableMarshalerInterface variant of
+// isArrayOfTables: a Marshaler element counts as a table only when its raw
+// content is table shaped (key-value lines); one holding a single value makes
+// the whole slice a plain array instead.
+func (e *encoderState) isMarshalerArrayOfTables(v reflect.Value) bool {
+	for i := 0; i < v.Len(); i++ {
+		elem, ok := resolve(v.Index(i))
+		if !ok {
+			return false
+		}
+		if marshalerPropsForType(elem.Type()) != 0 {
+			raw, err := e.marshalerBytes(elem)
+			if err != nil {
+				return false
+			}
+			if shape, _ := e.classifyRaw(raw); shape != shapeTable {
+				return false
+			}
+			continue
+		}
+		if isValueKind(elem) {
+			return false
+		}
+	}
+	return true
+}
+
+// marshalerBytes returns the raw TOML produced by v's unstable.Marshaler
+// implementation. The caller guarantees v implements the interface
+// (marshalerPropsForType(v.Type()) != 0).
+func (e *encoderState) marshalerBytes(v reflect.Value) ([]byte, error) {
+	t := v.Type()
+	var m unstable.Marshaler
+	switch {
+	case marshalerPropsForType(t) == 1:
+		// The type itself implements Marshaler (e.g. a value receiver).
+		m = v.Interface().(unstable.Marshaler)
+	case v.CanAddr():
+		// Only the pointer implements it, and v is addressable.
+		m = v.Addr().Interface().(unstable.Marshaler)
+	default:
+		// Only the pointer implements it, but v is not addressable: take the
+		// address of a copy.
+		tmp := reflect.New(t)
+		tmp.Elem().Set(v)
+		m = tmp.Interface().(unstable.Marshaler)
+	}
+	b, err := m.MarshalTOML()
+	if err != nil {
+		return nil, fmt.Errorf("toml: error calling MarshalTOML for type %s: %w", t, err)
+	}
+	return b, nil
+}
+
+// validateRawTableBody checks that trimmed — table-shaped Marshaler output
+// about to be spliced verbatim — is syntactically valid TOML, so a Marshaler
+// cannot silently corrupt the document. It reuses e.parser, like classifyRaw.
+func (e *encoderState) validateRawTableBody(t reflect.Type, trimmed []byte) error {
+	e.parser.Reset(trimmed)
+	for e.parser.NextExpression() {
+	}
+	if err := e.parser.Error(); err != nil {
+		return fmt.Errorf("toml: error calling MarshalTOML for type %s: invalid TOML: %w", t, err)
+	}
+	return nil
+}
+
+// classifyRaw decides whether b (the output of an unstable.Marshaler) is empty,
+// a single TOML value, or a table body. It returns the trimmed bytes that
+// should be spliced into the document. It reuses e.parser, so it is not safe
+// for concurrent use (encoderState is not shared).
+func (e *encoderState) classifyRaw(b []byte) (rawShape, []byte) {
+	trimmed := bytes.TrimSpace(b)
+	if len(trimmed) == 0 {
+		return shapeEmpty, trimmed
+	}
+	e.parser.Reset(trimmed)
+	_, rest, err := parserbridge.ParseValue(&e.parser, trimmed)
+	if err == nil && len(bytes.TrimSpace(rest)) == 0 {
+		return shapeValue, trimmed
+	}
+	return shapeTable, trimmed
+}
+
+// resolveMarshalerEntries classifies every entry whose value implements
+// unstable.Marshaler, recording the shape on the entry so the two table passes
+// can route it without re-classifying. Any error from MarshalTOML is surfaced
+// eagerly. The marshaled bytes themselves are produced again at emit time by
+// marshalerValue; that keeps entry small on the encoder's hot path, and only
+// runs when the (opt-in) interface is enabled.
+func (e *encoderState) resolveMarshalerEntries(entries []entry) error {
+	for i := range entries {
+		ent := &entries[i]
+		if ent.options.rawShape != shapeUnknown {
+			// Already classified: SetOmitEmptySuperTables resolves the
+			// entries early to route them by shape.
+			continue
+		}
+		v, ok := resolve(ent.value)
+		if !ok || marshalerPropsForType(v.Type()) == 0 {
+			continue
+		}
+		raw, err := e.marshalerBytes(v)
+		if err != nil {
+			return err
+		}
+		ent.options.rawShape, _ = e.classifyRaw(raw)
+	}
+	return nil
+}
+
+// marshalerValue returns the trimmed bytes to splice for an entry already known
+// to be an unstable.Marshaler (ent.options.rawShape != shapeUnknown).
+func (e *encoderState) marshalerValue(ent *entry) ([]byte, error) {
+	v, _ := resolve(ent.value)
+	raw, err := e.marshalerBytes(v)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(raw), nil
+}
+
+// appendMarshalerInline emits an unstable.Marshaler value in a value position
+// (a `key = ` line, an array element or an inline-table member), where only a
+// single TOML value is valid. It classifies the bytes it just fetched, so a
+// Marshaler returning different content across calls cannot splice non-value
+// bytes into a value position. The caller guarantees v implements the
+// interface; appendValue's guard branch returns into this function without
+// rejoining, so the common encode path keeps no values live across a call.
+func (e *encoderState) appendMarshalerInline(b []byte, v reflect.Value, t reflect.Type) ([]byte, error) {
+	raw, err := e.marshalerBytes(v)
+	if err != nil {
+		return nil, err
+	}
+	shape, trimmed := e.classifyRaw(raw)
+	switch shape {
+	case shapeValue:
+		return append(b, trimmed...), nil
+	case shapeEmpty:
+		return nil, fmt.Errorf("toml: cannot encode an empty %s as an inline value", t)
+	default:
+		return nil, fmt.Errorf("toml: cannot encode %s as an inline value: %q is not a single TOML value", t, trimmed)
+	}
+}
+
+// encodeTableWithMarshalers is the EnableMarshalerInterface variant of
+// encodeTable's two passes: entries whose value implements unstable.Marshaler
+// are classified up front and routed by shape; everything else follows the
+// baseline logic.
+func (e *encoderState) encodeTableWithMarshalers(entries []entry, commented bool, indent int) error {
+	// Classify Marshaler entries once so the passes can route them by shape
+	// and surface MarshalTOML errors eagerly.
+	if err := e.resolveMarshalerEntries(entries); err != nil {
+		return err
+	}
+
+	// First pass: emit all key-values; tables are handled by the second
+	// pass.
+	for i := range entries {
+		ent := &entries[i]
+		switch ent.options.rawShape {
+		case shapeUnknown:
+			// Not a Marshaler: handled by the baseline logic below the
+			// switch.
+		case shapeEmpty:
+			// No TOML representation: omit the key.
+			continue
+		case shapeValue:
+			if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
+				return err
+			}
+			continue
+		case shapeTable:
+			// A table body is emitted in the second pass, unless it is
+			// forced inline (SetTablesInline / inline tag), which has no
+			// valid inline form and is reported as an error by the value
+			// path.
+			if e.tablesInline || ent.options.inline {
+				if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		if e.entryIsTable(ent) {
+			continue
+		}
+		if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
+			return err
+		}
+	}
+
+	// Second pass: emit the sub-tables, extending the shared key stack.
+	for i := range entries {
+		ent := entries[i]
+		switch ent.options.rawShape {
+		case shapeUnknown:
+			// Not a Marshaler: handled by the baseline logic below the
+			// switch.
+		case shapeValue, shapeEmpty:
+			// Not a table: already handled (or omitted) in the first pass.
+			continue
+		case shapeTable:
+			// Emit the raw body verbatim under the freshly pushed header.
+			// (The forced-inline case already errored in the first pass.)
+			entCommented := commented || ent.options.commented
+			e.keyStack = append(e.keyStack, ent.key)
+			if err := e.encodeMarshalerTable(&ent, entCommented, indent); err != nil {
+				return err
+			}
+			e.keyStack = e.keyStack[:len(e.keyStack)-1]
+			continue
+		}
+		if !e.entryIsTable(&ent) {
+			continue
+		}
+		entCommented := commented || ent.options.commented
+		e.keyStack = append(e.keyStack, ent.key)
+
+		if e.isArrayOfTables(ent.value) {
+			if err := e.encodeArrayTable(ent, entCommented, indent); err != nil {
+				return err
+			}
+			e.keyStack = e.keyStack[:len(e.keyStack)-1]
+			continue
+		}
+
+		// The value is resolvable: entryIsTable already resolved it.
+		tv, _ := resolve(ent.value)
+
+		subEntries, err := e.collectEntries(tv)
+		if err != nil {
+			return err
+		}
+
+		subIndent := indent + 1
+		if e.omitEmptySuperTables && ent.options.comment == "" {
+			// onlySubTables routes entries by their Marshaler shape, so
+			// classification cannot wait for the recursive call below.
+			// resolveMarshalerEntries skips already-classified entries,
+			// making the second classification there a no-op.
+			if err := e.resolveMarshalerEntries(subEntries); err != nil {
+				return err
+			}
+			if e.onlySubTables(subEntries) {
+				// The table has no key-value of its own and at least one
+				// sub-table: emitting the sub-tables implicitly defines it,
+				// so its header can be omitted. Its children take its place
+				// in the indentation hierarchy.
+				subIndent = indent
+			} else {
+				e.writeTableHeader(ent.options.comment, entCommented, false, indent)
+			}
+		} else {
+			e.writeTableHeader(ent.options.comment, entCommented, false, indent)
+		}
+
+		if err := e.encodeTableEntries(subEntries, entCommented, subIndent); err != nil {
+			return err
+		}
+		e.keyStack = e.keyStack[:len(e.keyStack)-1]
+	}
+
+	e.putEntries(entries)
+	return nil
+}
+
+// encodeMarshalerTable emits a table-shaped unstable.Marshaler entry: the
+// header for the key currently on the stack, then the raw body verbatim.
+func (e *encoderState) encodeMarshalerTable(ent *entry, commented bool, indent int) error {
+	raw, err := e.marshalerValue(ent)
+	if err != nil {
+		return err
+	}
+	// Validate the bytes actually being spliced: MarshalTOML is called again
+	// for the emit, so this both rejects invalid TOML and guards against an
+	// implementation that returned different content than during
+	// classification.
+	if err := e.validateRawTableBody(ent.value.Type(), raw); err != nil {
+		return err
+	}
+	e.writeTableHeader(ent.options.comment, commented, false, indent)
+	e.spliceRawTableBody(raw, commented)
+	return nil
+}
+
+// spliceRawTableBody appends a raw table body verbatim after its header. When
+// the table is commented, every physical line is prefixed with the comment
+// marker so the body does not leak into the document as live keys.
+func (e *encoderState) spliceRawTableBody(raw []byte, commented bool) {
+	if len(raw) == 0 {
+		return
+	}
+	if commented {
+		e.buf = append(e.buf, "# "...)
+		e.buf = append(e.buf, bytes.ReplaceAll(raw, []byte("\n"), []byte("\n# "))...)
+	} else {
+		e.buf = append(e.buf, raw...)
+	}
+	e.buf = append(e.buf, '\n')
+	e.lastWasHeader = false
+}
+
+// encodeArrayTableWithMarshalers is the EnableMarshalerInterface variant of
+// encodeArrayTable: an unstable.Marshaler element splices its raw table body
+// verbatim instead of being encoded structurally.
+func (e *encoderState) encodeArrayTableWithMarshalers(ent entry, commented bool, indent int) error {
+	v, _ := resolve(ent.value)
+	comment := ent.options.comment
+	for i := 0; i < v.Len(); i++ {
+		// Elements are resolvable: isArrayOfTables already resolved them.
+		elem, _ := resolve(v.Index(i))
+
+		e.writeTableHeader(comment, commented, true, indent)
+		// The comment is only present before the first element.
+		comment = ""
+
+		// The shape was checked by isArrayOfTables, but MarshalTOML is called
+		// again for the emit, so the spliced bytes are validated here.
+		if marshalerPropsForType(elem.Type()) != 0 {
+			raw, err := e.marshalerBytes(elem)
+			if err != nil {
+				return err
+			}
+			trimmed := bytes.TrimSpace(raw)
+			if err := e.validateRawTableBody(elem.Type(), trimmed); err != nil {
+				return err
+			}
+			e.spliceRawTableBody(trimmed, commented)
+			continue
+		}
+
+		err := e.encodeTable(elem, commented, indent+1)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/marshaler_raw_test.go
+++ b/marshaler_raw_test.go
@@ -236,6 +236,43 @@ func TestMarshalerInterfaceErrorPropagation(t *testing.T) {
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "marshal boom"), err.Error())
 	})
+
+	t.Run("nested table position", func(t *testing.T) {
+		type inner struct {
+			X errMarshaler `toml:"x"`
+		}
+		type config struct {
+			A inner `toml:"a"`
+		}
+		_, err := encodeRaw(t, config{})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "marshal boom"), err.Error())
+	})
+
+	t.Run("nested table position with omitted super-tables", func(t *testing.T) {
+		type inner struct {
+			X errMarshaler `toml:"x"`
+		}
+		type config struct {
+			A inner `toml:"a"`
+		}
+		var buf bytes.Buffer
+		err := toml.NewEncoder(&buf).
+			EnableMarshalerInterface().
+			SetOmitEmptySuperTables(true).
+			Encode(config{})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "marshal boom"), err.Error())
+	})
+
+	t.Run("bad map key under a table", func(t *testing.T) {
+		type config struct {
+			A map[bool]int `toml:"a"`
+		}
+		_, err := encodeRaw(t, config{A: map[bool]int{true: 1}})
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "map with key type"), err.Error())
+	})
 }
 
 // TestMarshalerInterfaceArrayOfTablesPointerReceiver exercises a slice of a
@@ -250,6 +287,70 @@ func TestMarshalerInterfaceArrayOfTablesPointerReceiver(t *testing.T) {
 	}})
 	assert.NoError(t, err)
 	assert.Equal(t, "[[item]]\na = 1\n\n[[item]]\na = 2\n", out)
+}
+
+// TestMarshalerInterfacePlainArrayOfTables marshals an array of plain
+// (non-Marshaler) tables with the interface enabled: the elements go through
+// the regular structural encoding.
+func TestMarshalerInterfacePlainArrayOfTables(t *testing.T) {
+	type item struct {
+		V int64 `toml:"v"`
+	}
+	type config struct {
+		Item []item `toml:"item"`
+	}
+	out, err := encodeRaw(t, config{Item: []item{{V: 1}, {V: 2}}})
+	assert.NoError(t, err)
+	assert.Equal(t, "[[item]]\nv = 1\n\n[[item]]\nv = 2\n", out)
+}
+
+// TestMarshalerInterfacePlainArrayOfTablesError propagates an encoding error
+// out of a plain (non-Marshaler) element of an array of tables while the
+// interface is enabled.
+func TestMarshalerInterfacePlainArrayOfTablesError(t *testing.T) {
+	type item struct {
+		C chan int `toml:"c"`
+	}
+	type config struct {
+		Item []item `toml:"item"`
+	}
+	_, err := encodeRaw(t, config{Item: []item{{C: make(chan int)}}})
+	assert.Error(t, err)
+}
+
+// budgetMarshaler succeeds for a fixed number of calls, then errors. Unlike
+// flakyMarshaler (which fails on its second call), the budget can be set to
+// survive every classification pass and fail only on the final emit call.
+type budgetMarshaler struct {
+	calls  *int
+	body   string
+	budget int
+}
+
+func (m budgetMarshaler) MarshalTOML() ([]byte, error) {
+	*m.calls++
+	if *m.calls > m.budget {
+		return nil, errors.New("budget boom")
+	}
+	return []byte(m.body), nil
+}
+
+// TestMarshalerInterfaceArrayOfTablesEmitError exercises the emit-time
+// MarshalTOML error inside an array of tables: classification succeeds, the
+// call producing the spliced bytes fails.
+func TestMarshalerInterfaceArrayOfTablesEmitError(t *testing.T) {
+	calls := 0
+	type config struct {
+		Item []budgetMarshaler `toml:"item"`
+	}
+	// The encoder classifies the slice as an array of tables before emitting:
+	// the budget covers the classification calls so the failure lands on the
+	// emit call inside the array-table writer.
+	_, err := encodeRaw(t, config{Item: []budgetMarshaler{
+		{calls: &calls, body: "a = 1\n", budget: 3},
+	}})
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "budget boom"), err.Error())
 }
 
 // TestMarshalerInterfaceCommentedMultilineValue checks a commented multiline
@@ -612,6 +713,18 @@ func TestMarshalerInterfaceNonDeterministic(t *testing.T) {
 		_, err := encodeRaw(t, config{X: shiftyMarshaler{calls: &calls, bodies: []string{"42", "a = 1\n"}}})
 		assert.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "inline value"), err.Error())
+	})
+
+	t.Run("table then empty", func(t *testing.T) {
+		calls := 0
+		type config struct {
+			X shiftyMarshaler `toml:"x"`
+		}
+		// Classified as a table body, but the emit call returns nothing:
+		// empty content is valid TOML, so the header stands alone.
+		out, err := encodeRaw(t, config{X: shiftyMarshaler{calls: &calls, bodies: []string{"a = 1\n", ""}}})
+		assert.NoError(t, err)
+		assert.Equal(t, "[x]\n", out)
 	})
 }
 


### PR DESCRIPTION
## What

Follow-up to #1084 (`Encoder.EnableMarshalerInterface`). Benchmarking that feature against v2 on linux/amd64 (idle host, pinned cores, interleaved rounds, n=12, benchstat) showed statistically significant sec/op regressions on the **default (interface-disabled) Marshal path** — up to +10% on micro-benchmarks — with allocations unchanged.

## Root cause

Bisecting the #1084 diff piece by piece isolated the dominant cost: **widening the per-type `typeEncProps` cache struct from 2 to 3 bytes** (the added `marshaler uint8` classification). Its cached `p.(typeEncProps)` assertion and by-value return run 2–3× per encoded value (via `isValueKind` and the TextMarshaler switch), and the extra field changes the copy size and register-ABI shape of every lookup. That lone change — with **zero** encoder-code modifications — reproduced the regression (geomean +3.8% on the Marshal micro set); padding the struct to 4 bytes only halved it.

## Changes

- `typeEncProps` / `encPropsForType` restored to their exact baseline form; the `unstable.Marshaler` classification lives in its own `sync.Map` (`typeMarshalerCache` / `marshalerPropsForType`), consulted only on `EnableMarshalerInterface` paths.
- `encodeTable`, `encodeKeyValue`, `encodeArrayTable` restored to their exact baseline source; the Marshaler-aware table passes live in `encodeTableWithMarshalers` / `encodeArrayTableWithMarshalers`, selected by one branch per table instead of one per entry. Marshaler values on a `key =` line flow through `appendValue`'s gated guard, which returns without rejoining the fall-through path and re-classifies the fetched bytes (keeping the emit-time guard against non-deterministic marshalers).
- All Marshaler-interface machinery moves to a new `marshaler_raw.go`, out from between the default path's hot functions.

After this change the interface-off encoder differs from the pre-#1084 source only by four single-branch dispatches; `typeEncProps`, `encPropsForType` and the hot encoder functions are byte-identical to baseline. No behavior change: the #1084 test suite passes unmodified.

## Measurements

Full benchstat posted as a collapsed comment below (and on #1084). Summary: allocs/op identical across the whole `./benchmark` suite; ms-scale dataset benchmarks unchanged; remaining µs-scale sec/op deltas are within the measurement host's address-alignment noise floor (demonstrated with dead-code A/A controls and `-ldflags=-randlayout` runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
