### PR TITLE
feat: add Encoder.SetOmitEmptySuperTables

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -51,11 +51,12 @@ type Encoder struct {
 	w io.Writer
 
 	// global settings
-	tablesInline       bool
-	arraysMultiline    bool
-	indentSymbol       string
-	indentTables       bool
-	marshalJSONNumbers bool
+	tablesInline         bool
+	arraysMultiline      bool
+	indentSymbol         string
+	indentTables         bool
+	marshalJSONNumbers   bool
+	omitEmptySuperTables bool
 
 	// toggles the unstable.Marshaler interface
 	marshalerInterface bool
@@ -117,6 +118,29 @@ func (enc *Encoder) SetMarshalJSONNumbers(indent bool) *Encoder {
 	return enc
 }
 
+// SetOmitEmptySuperTables removes the header of tables that do not directly
+// contain any key-value. Emitting a sub-table implicitly defines all its
+// parent tables, so such "super-table" headers are not needed for the
+// document to be valid TOML. For example, instead of:
+//
+//	[a]
+//	[a.b]
+//	[a.b.c]
+//	key = 'value'
+//
+// the encoder emits:
+//
+//	[a.b.c]
+//	key = 'value'
+//
+// Tables with no content at all keep their header: it is their only
+// definition in the document. Tables annotated with a comment tag also keep
+// their header, so the comment has a line to attach to.
+func (enc *Encoder) SetOmitEmptySuperTables(omit bool) *Encoder {
+	enc.omitEmptySuperTables = omit
+	return enc
+}
+
 // EnableMarshalerInterface enables the unstable.Marshaler interface.
 //
 // With this feature enabled, types implementing the unstable.Marshaler
@@ -162,7 +186,8 @@ func (enc *Encoder) EnableMarshalerInterface() *Encoder {
 //
 // Keys in key-values always have one part.
 //
-// Intermediate tables are always printed.
+// Intermediate tables are always printed, unless SetOmitEmptySuperTables is
+// enabled.
 //
 // By default, strings are encoded as literal string, unless they contain
 // either a newline character or a single quote. In that case they are emitted
@@ -578,6 +603,11 @@ func (e *encoderState) classifyRaw(b []byte) (rawShape, []byte) {
 func (e *encoderState) resolveMarshalerEntries(entries []entry) error {
 	for i := range entries {
 		ent := &entries[i]
+		if ent.options.rawShape != shapeUnknown {
+			// Already classified: SetOmitEmptySuperTables resolves the
+			// entries early to route them by shape.
+			continue
+		}
 		v, ok := resolve(ent.value)
 		if !ok || encPropsForType(v.Type()).marshaler == 0 {
 			continue
@@ -632,7 +662,12 @@ func (e *encoderState) encodeTable(v reflect.Value, commented bool, indent int) 
 	if err != nil {
 		return err
 	}
+	return e.encodeTableEntries(entries, commented, indent)
+}
 
+// encodeTableEntries writes the given table entries at the given key path,
+// and returns them to the pool.
+func (e *encoderState) encodeTableEntries(entries []entry, commented bool, indent int) error {
 	// Marshaler routing is hoisted behind a single local flag. When the (opt-in)
 	// interface is off, mOn is false and both passes run the exact baseline
 	// code, so the default Marshal path keeps its performance.
@@ -722,9 +757,36 @@ func (e *encoderState) encodeTable(v reflect.Value, commented bool, indent int) 
 		// The value is resolvable: entryIsTable already resolved it.
 		tv, _ := resolve(ent.value)
 
-		e.writeTableHeader(ent.options.comment, entCommented, false, indent)
+		subEntries, err := e.collectEntries(tv)
+		if err != nil {
+			return err
+		}
 
-		err := e.encodeTable(tv, entCommented, indent+1)
+		subIndent := indent + 1
+		if e.omitEmptySuperTables && ent.options.comment == "" {
+			if mOn {
+				// The check below routes entries by their Marshaler shape,
+				// so classification cannot wait for encodeTableEntries.
+				// resolveMarshalerEntries skips already-classified entries,
+				// making the second call there a no-op.
+				if err := e.resolveMarshalerEntries(subEntries); err != nil {
+					return err
+				}
+			}
+			if e.onlySubTables(subEntries) {
+				// The table has no key-value of its own and at least one
+				// sub-table: emitting the sub-tables implicitly defines it,
+				// so its header can be omitted. Its children take its place
+				// in the indentation hierarchy.
+				subIndent = indent
+			} else {
+				e.writeTableHeader(ent.options.comment, entCommented, false, indent)
+			}
+		} else {
+			e.writeTableHeader(ent.options.comment, entCommented, false, indent)
+		}
+
+		err = e.encodeTableEntries(subEntries, entCommented, subIndent)
 		if err != nil {
 			return err
 		}
@@ -733,6 +795,31 @@ func (e *encoderState) encodeTable(v reflect.Value, commented bool, indent int) 
 
 	e.putEntries(entries)
 	return nil
+}
+
+// onlySubTables reports whether the entries contain at least one sub-table
+// and nothing else. A table made only of sub-tables is a "super-table": every
+// one of its entries emits a header that implicitly defines it, so its own
+// header carries no information.
+func (e *encoderState) onlySubTables(entries []entry) bool {
+	if len(entries) == 0 {
+		return false
+	}
+	for i := range entries {
+		ent := &entries[i]
+		if ent.options.rawShape != shapeUnknown {
+			// Classified unstable.Marshaler entry: only a table-shaped one
+			// that is not forced inline is guaranteed to emit a header.
+			if ent.options.rawShape != shapeTable || e.tablesInline || ent.options.inline {
+				return false
+			}
+			continue
+		}
+		if !e.entryIsTable(ent) {
+			return false
+		}
+	}
+	return true
 }
 
 // encodeMarshalerTable emits a table-shaped unstable.Marshaler entry: the

--- a/marshaler_raw_test.go
+++ b/marshaler_raw_test.go
@@ -756,6 +756,47 @@ func benchmarkEncodeRaw(b *testing.B, v interface{}) {
 	}
 }
 
+// TestMarshalerInterfaceOmitEmptySuperTables checks that the shape of
+// Marshaler entries is taken into account when deciding whether a table only
+// contains sub-tables and can lose its header.
+func TestMarshalerInterfaceOmitEmptySuperTables(t *testing.T) {
+	t.Run("table-shaped raw counts as a sub-table", func(t *testing.T) {
+		var v struct {
+			B struct {
+				C unstable.RawMessage `toml:"c"`
+			}
+		}
+		v.B.C = unstable.RawMessage("a = 1\nb = 2")
+
+		var buf bytes.Buffer
+		err := toml.NewEncoder(&buf).
+			EnableMarshalerInterface().
+			SetOmitEmptySuperTables(true).
+			Encode(v)
+		assert.NoError(t, err)
+		assert.Equal(t, "[B.c]\na = 1\nb = 2\n", buf.String())
+	})
+
+	t.Run("value-shaped raw keeps the super-table header", func(t *testing.T) {
+		var v struct {
+			B struct {
+				N unstable.RawMessage `toml:"n"`
+				C struct{ S string }
+			}
+		}
+		v.B.N = unstable.RawMessage("42")
+		v.B.C.S = "foo"
+
+		var buf bytes.Buffer
+		err := toml.NewEncoder(&buf).
+			EnableMarshalerInterface().
+			SetOmitEmptySuperTables(true).
+			Encode(v)
+		assert.NoError(t, err)
+		assert.Equal(t, "[B]\nn = 42\n\n[B.C]\nS = 'foo'\n", buf.String())
+	})
+}
+
 func ExampleEncoder_EnableMarshalerInterface() {
 	// A RawMessage captured (or hand-built) as raw TOML is spliced back into
 	// the document verbatim.

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -917,11 +917,14 @@ var allFlags = flagsSetters{
 	{"arrays-multiline", (*toml.Encoder).SetArraysMultiline},
 	{"tables-inline", (*toml.Encoder).SetTablesInline},
 	{"indent-tables", (*toml.Encoder).SetIndentTables},
+	{"omit-empty-super-tables", (*toml.Encoder).SetOmitEmptySuperTables},
 }
 
 func setFlags(enc *toml.Encoder, flags int) {
+	// testWithFlags builds the bitmask by shifting at each recursion level, so
+	// the first setter owns the most significant bit.
 	for i := 0; i < len(allFlags); i++ {
-		enabled := flags&1 > 0
+		enabled := flags&(1<<(len(allFlags)-1-i)) > 0
 		allFlags[i].f(enc, enabled)
 	}
 }
@@ -1041,6 +1044,157 @@ func TestMarshalIndentTables(t *testing.T) {
 			err := enc.Encode(e.v)
 			assert.NoError(t, err)
 			assert.Equal(t, e.expected, buf.String())
+		})
+	}
+}
+
+func TestMarshalOmitEmptySuperTables(t *testing.T) {
+	type D struct{ S string }
+	type C struct{ D D }
+	type B struct{ C C }
+
+	examples := []struct {
+		desc     string
+		v        interface{}
+		indent   bool
+		expected string
+	}{
+		{
+			desc: "chain of super-tables",
+			v:    struct{ B B }{B{C{D{S: "foo"}}}},
+			expected: `[B.C.D]
+S = 'foo'
+`,
+		},
+		{
+			desc: "super-table with its own key-value keeps its header",
+			v: struct {
+				B struct {
+					X int
+					C C
+				}
+			}{B: struct {
+				X int
+				C C
+			}{X: 1, C: C{D: D{S: "foo"}}}},
+			expected: `[B]
+X = 1
+
+[B.C.D]
+S = 'foo'
+`,
+		},
+		{
+			desc: "empty table keeps its header",
+			v:    struct{ B struct{} }{},
+			expected: `[B]
+`,
+		},
+		{
+			desc: "empty table under a super-table",
+			v:    struct{ B struct{ C struct{} } }{},
+			expected: `[B.C]
+`,
+		},
+		{
+			desc: "array of tables under super-tables",
+			v: struct{ B struct{ C []D } }{B: struct{ C []D }{
+				C: []D{{S: "x"}, {S: "y"}},
+			}},
+			expected: `[[B.C]]
+S = 'x'
+
+[[B.C]]
+S = 'y'
+`,
+		},
+		{
+			desc: "super-table with a comment keeps its header",
+			v: struct {
+				B struct{ C C } `comment:"hello"`
+			}{B: struct{ C C }{C: C{D: D{S: "foo"}}}},
+			expected: `# hello
+[B]
+[B.C.D]
+S = 'foo'
+`,
+		},
+		{
+			desc: "commented super-tables are still omitted",
+			v: struct {
+				B struct{ C C } `toml:",commented"`
+			}{B: struct{ C C }{C: C{D: D{S: "foo"}}}},
+			expected: `# [B.C.D]
+# S = 'foo'
+`,
+		},
+		{
+			desc: "two sibling sub-tables",
+			v: struct{ B struct{ C, D D } }{B: struct{ C, D D }{
+				C: D{S: "one"},
+				D: D{S: "two"},
+			}},
+			expected: `[B.C]
+S = 'one'
+
+[B.D]
+S = 'two'
+`,
+		},
+		{
+			desc: "maps",
+			v: map[string]map[string]map[string]string{
+				"x": {"y": {"z": "w"}},
+			},
+			expected: `[x.y]
+z = 'w'
+`,
+		},
+		{
+			desc: "table emptied by omitempty",
+			v: struct {
+				B struct {
+					X string `toml:",omitempty"`
+					C C
+				}
+			}{B: struct {
+				X string `toml:",omitempty"`
+				C C
+			}{C: C{D: D{S: "foo"}}}},
+			expected: `[B.C.D]
+S = 'foo'
+`,
+		},
+		{
+			desc:   "omitted tables do not indent their children",
+			v:      struct{ B B }{B{C{D{S: "foo"}}}},
+			indent: true,
+			expected: `[B.C.D]
+  S = 'foo'
+`,
+		},
+	}
+
+	for _, e := range examples {
+		e := e
+		t.Run(e.desc, func(t *testing.T) {
+			var buf strings.Builder
+			enc := toml.NewEncoder(&buf)
+			enc.SetOmitEmptySuperTables(true)
+			enc.SetIndentTables(e.indent)
+			err := enc.Encode(e.v)
+			assert.NoError(t, err)
+			assert.Equal(t, e.expected, buf.String())
+
+			// The omitted headers must not change the meaning of the
+			// document: both outputs decode to the same map.
+			def, err := toml.Marshal(e.v)
+			assert.NoError(t, err)
+			defaultMap := map[string]interface{}{}
+			assert.NoError(t, toml.Unmarshal(def, &defaultMap))
+			omitMap := map[string]interface{}{}
+			assert.NoError(t, toml.Unmarshal([]byte(buf.String()), &omitMap))
+			assert.Equal(t, defaultMap, omitMap)
 		})
 	}
 }
@@ -2125,6 +2279,41 @@ func ExampleMarshal() {
 	// Version = 2
 	// Name = 'go-toml'
 	// Tags = ['go', 'toml']
+}
+
+func ExampleEncoder_SetOmitEmptySuperTables() {
+	type Credentials struct {
+		User     string
+		Password string
+	}
+	type Database struct {
+		Credentials Credentials
+	}
+	type Config struct {
+		Database Database
+	}
+
+	cfg := Config{
+		Database: Database{
+			Credentials: Credentials{
+				User:     "root",
+				Password: "hunter2",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	enc.SetOmitEmptySuperTables(true)
+	if err := enc.Encode(cfg); err != nil {
+		panic(err)
+	}
+	fmt.Println(buf.String())
+
+	// Output:
+	// [Database.Credentials]
+	// User = 'root'
+	// Password = 'hunter2'
 }
 
 // Example that uses the 'commented' field tag option to generate an example


### PR DESCRIPTION
Closes #957.

Adds an opt-in `Encoder.SetOmitEmptySuperTables(bool)` option. When enabled, the encoder removes the header of tables that do not directly contain any key-value: emitting any of their sub-tables implicitly defines them, so their headers carry no information.

```go
toml.NewEncoder(w).SetOmitEmptySuperTables(true).Encode(v)
```

turns

```toml
[B]
[B.C]
[B.C.D]
S = 'foo'
```

into

```toml
[B.C.D]
S = 'foo'
```

Exact rules:

- A table keeps its header if it directly contains at least one key-value (including values forced inline), if it is completely empty (the header is its only definition in the document), or if it is annotated with a `comment` tag (so the comment has a line to attach to). Fields dropped by `omitempty`/`omitzero` don't count as content.
- Skipped levels don't accumulate indentation with `SetIndentTables`.
- Works above `[[array]]` tables, for maps as well as structs, and composes with the `commented` tag and the unstable `Marshaler` interface (only table-shaped raw entries count as sub-tables).

Implementation: `encodeTable` is split into `collectTableEntries` (collect + marshaler shape resolution) and `encodeTableEntries` (the two emit passes), so the parent can inspect a sub-table's entries before deciding whether to write its header — no double collection, and the default path runs the same code as before. Marshal benchmarks are unchanged (macOS/arm64, go1.26.4, interleaved benchstat vs `v2`).

Tests cover the header-keeping rules, sibling sub-tables, maps, `omitempty` interaction, `commented`, indentation, and assert that the omitted-header output decodes to the same document as the default output. The new flag is also added to the `TestMarshal` flag matrix; doing so surfaced that the `setFlags` test helper applied bit 0 of the flag mask to every setter, so the matrix never actually exercised flag combinations — fixed in passing (the matrix is green with real combinations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
