### PR TITLE
Document all unstable API features in README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,9 @@ go-toml is a TOML library for Go. The goal is to provide an easy-to-use and effi
 
 - New features or feature extensions must include documentation
 - Documentation lives in [README.md](./README.md) and throughout source code
+- The "Unstable API" section of the README must list every feature exported by
+  the `unstable` package. When adding, promoting, or removing an unstable
+  feature, update that list in the same change
 
 ### Code Style
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,29 @@ API subject to change.
 Parser is the unstable API that allows iterative parsing of a TOML document at
 the AST level. See https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable.
 
+### Marshaler and Unmarshaler interfaces
+
+[`unstable.Marshaler`][unstable-marshaler] and
+[`unstable.Unmarshaler`][unstable-unmarshaler] let types produce and consume
+their own raw TOML representation, similar to the equivalent `encoding/json`
+interfaces. They are opt-in: enable them with
+[`Encoder.EnableMarshalerInterface`][enable-marshaler] and
+[`Decoder.EnableUnmarshalerInterface`][enable-unmarshaler].
+
+[unstable-marshaler]: https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable#Marshaler
+[unstable-unmarshaler]: https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable#Unmarshaler
+[enable-marshaler]: https://pkg.go.dev/github.com/pelletier/go-toml/v2#Encoder.EnableMarshalerInterface
+[enable-unmarshaler]: https://pkg.go.dev/github.com/pelletier/go-toml/v2#Decoder.EnableUnmarshalerInterface
+
+### RawMessage
+
+[`unstable.RawMessage`][unstable-rawmessage] is a raw encoded TOML value
+implementing both interfaces above. Like `json.RawMessage`, it can delay the
+decoding of part of a document or splice pre-encoded TOML verbatim into the
+output.
+
+[unstable-rawmessage]: https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable#RawMessage
+
 ## Benchmarks
 
 Execution time speedup compared to other Go TOML libraries:

--- a/unmarshaler_internal_test.go
+++ b/unmarshaler_internal_test.go
@@ -7,6 +7,29 @@ import (
 	"github.com/pelletier/go-toml/v2/internal/assert"
 )
 
+func TestArrayCountsFreshDecoder(t *testing.T) {
+	// Whether a decode starts with a nil arrayCounts map depends on decoder
+	// pooling: a reused decoder keeps the map allocated across documents.
+	// Exercise the nil-map paths on a guaranteed-fresh decoder so their
+	// coverage does not depend on sync.Pool behavior.
+	d := &decoder{}
+	key := []byte("a")
+	assert.Equal(t, 0, d.arrayCount(key))
+	d.resetChildArrayCounts(key)
+	d.setArrayCount(key, 1)
+	assert.Equal(t, 1, d.arrayCount(key))
+	d.setArrayCount(key, 2)
+	assert.Equal(t, 2, d.arrayCount(key))
+	assert.Equal(t, 0, d.arrayCount([]byte("b")))
+	// Child paths are joined with a NUL separator; resetting the parent
+	// zeroes the child count but leaves the parent untouched.
+	child := []byte("a\x00b")
+	d.setArrayCount(child, 3)
+	d.resetChildArrayCounts(key)
+	assert.Equal(t, 0, d.arrayCount(child))
+	assert.Equal(t, 2, d.arrayCount(key))
+}
+
 type unexpCaptureInner struct{ C int }
 
 type unexpCaptureOuter struct {


### PR DESCRIPTION
The "Unstable API" section of the README only mentioned `Parser`, but the `unstable` package also exports the `Marshaler`/`Unmarshaler` interfaces (opt-in via `Encoder.EnableMarshalerInterface` / `Decoder.EnableUnmarshalerInterface`) and `RawMessage`. Users browsing the README could not discover them.

- README: add subsections for the marshaling interfaces and `RawMessage`, with pkg.go.dev links, matching the existing style. The AST types (`Node`, `Iterator`, `Kind`, …) remain covered by the `Parser` entry.
- AGENTS.md: add a documentation rule that the Unstable API list must cover every feature exported by the `unstable` package and be updated in the same change that adds, promotes, or removes one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)