### PR TITLE
unstable/edit: comment-preserving document editing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,9 @@ the AST level. See https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable.
 
 The `unstable/edit` package modifies TOML documents in place while preserving
 comments, whitespace, and ordering. Parse a document with `edit.Parse`, then
-`Get`, `Set`, and `Delete` values by key path: only the bytes expressing an
+`Get`, `Set`, and `Delete` values by key path — including array elements by
+index and keys inside inline tables — and read or write the comments attached
+to any key or table with `Comment`/`SetComment`. Only the bytes expressing an
 edit are rewritten, everything else is kept byte-for-byte. See
 https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable/edit.
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ API subject to change.
 Parser is the unstable API that allows iterative parsing of a TOML document at
 the AST level. See https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable.
 
+### Document editing
+
+The `unstable/edit` package modifies TOML documents in place while preserving
+comments, whitespace, and ordering. Parse a document with `edit.Parse`, then
+`Get`, `Set`, and `Delete` values by key path: only the bytes expressing an
+edit are rewritten, everything else is kept byte-for-byte. See
+https://pkg.go.dev/github.com/pelletier/go-toml/v2/unstable/edit.
+
 ## Benchmarks
 
 Execution time speedup compared to other Go TOML libraries:

--- a/unstable/edit/comment.go
+++ b/unstable/edit/comment.go
@@ -1,0 +1,174 @@
+package edit
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// locateExpr resolves key to the expression carrying comments: a key-value,
+// or a table with its own [header] line (including array-of-tables elements
+// addressed by index). Exactly one of the returned leaf and table is non-nil
+// on success.
+func (d *Document) locateExpr(key []string) (*leaf, *table, error) {
+	if len(key) == 0 {
+		return nil, nil, errors.New("toml/edit: key must have at least one element")
+	}
+	t := d.root
+	i := 0
+	for i < len(key) {
+		it := t.items[key[i]]
+		if it == nil {
+			return nil, nil, fmt.Errorf("toml/edit: %q does not exist", pathString(key[:i+1]))
+		}
+		last := i == len(key)-1
+		switch {
+		case it.leaf != nil:
+			if last {
+				return it.leaf, nil, nil
+			}
+			return nil, nil, fmt.Errorf("toml/edit: %q is inside an inline value and has no comments of its own", pathString(key))
+		case it.arr != nil:
+			if last {
+				return nil, nil, fmt.Errorf("toml/edit: %q is an array of tables; address one of its elements", pathString(key))
+			}
+			idx, ok := parseIndex(key[i+1])
+			if !ok || idx >= len(it.arr) {
+				return nil, nil, fmt.Errorf("toml/edit: %q has no element %q", pathString(key[:i+1]), key[i+1])
+			}
+			t = it.arr[idx]
+			i += 2
+			if i == len(key) {
+				return nil, t, nil
+			}
+		default:
+			t = it.tbl
+			i++
+			if last {
+				if !t.explicit {
+					return nil, nil, fmt.Errorf("toml/edit: %q has no header line to carry comments", pathString(key))
+				}
+				return nil, t, nil
+			}
+		}
+	}
+	return nil, nil, errors.New("toml/edit: internal error: key resolution did not terminate")
+}
+
+// commentSpan returns the byte range of the full-line comment block attached
+// above the located expression. The range is empty when there is none.
+func commentSpan(lf *leaf, tb *table) span {
+	if lf != nil {
+		return span{lf.line.start, lf.exprLine}
+	}
+	return span{tb.section.start, tb.headerLine}
+}
+
+// trailingSpan returns the byte range holding the comment trailing the
+// located expression on its last line, including the whitespace separating
+// it from the expression. The range is empty when there is none.
+func (d *Document) trailingSpan(lf *leaf, tb *table) span {
+	var start int
+	if lf != nil {
+		start = lf.value.end
+	} else {
+		start = tb.exprEnd
+	}
+	end := d.lineEnd(start)
+	if end > start && d.data[end-1] == '\n' {
+		end--
+		if end > start && d.data[end-1] == '\r' {
+			end--
+		}
+	}
+	return span{start, end}
+}
+
+// Comment returns the text of the full-line comment block attached above
+// the key-value or table header at key, with the comment markers stripped.
+// It returns ok=false when key does not address a key-value or a table with
+// a header, and an empty string with ok=true when it does but carries no
+// comment.
+func (d *Document) Comment(key []string) (string, bool) {
+	lf, tb, err := d.locateExpr(key)
+	if err != nil {
+		return "", false
+	}
+	s := commentSpan(lf, tb)
+	var lines []string
+	for _, line := range strings.Split(string(d.data[s.start:s.end]), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		line = strings.TrimLeft(line, " \t")
+		if line == "" {
+			continue // the final split element after the last newline
+		}
+		line = strings.TrimPrefix(line, "#")
+		line = strings.TrimPrefix(line, " ")
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n"), true
+}
+
+// SetComment sets the full-line comment block attached above the key-value
+// or table header at key, replacing any existing one. Each line of text
+// becomes one comment line. An empty text removes the block.
+func (d *Document) SetComment(key []string, text string) error {
+	lf, tb, err := d.locateExpr(key)
+	if err != nil {
+		return err
+	}
+	return d.apply(splice{commentSpan(lf, tb), d.renderCommentBlock(text)})
+}
+
+func (d *Document) renderCommentBlock(text string) []byte {
+	if text == "" {
+		return nil
+	}
+	eol := d.eol()
+	var b []byte
+	for _, line := range strings.Split(strings.TrimSuffix(text, "\n"), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if line == "" {
+			b = append(b, '#')
+		} else {
+			b = append(b, "# "...)
+			b = append(b, line...)
+		}
+		b = append(b, eol...)
+	}
+	return b
+}
+
+// TrailingComment returns the text of the comment trailing the key-value or
+// table header at key on the same line, with the comment marker stripped.
+// The ok semantics are the same as Comment's.
+func (d *Document) TrailingComment(key []string) (string, bool) {
+	lf, tb, err := d.locateExpr(key)
+	if err != nil {
+		return "", false
+	}
+	s := d.trailingSpan(lf, tb)
+	b := bytes.TrimLeft(d.data[s.start:s.end], " \t")
+	b = bytes.TrimPrefix(b, []byte("#"))
+	b = bytes.TrimPrefix(b, []byte(" "))
+	return string(b), true
+}
+
+// SetTrailingComment sets the comment trailing the key-value or table header
+// at key on the same line, replacing any existing one. The text must not
+// contain newlines. An empty text removes the comment.
+func (d *Document) SetTrailingComment(key []string, text string) error {
+	if strings.ContainsAny(text, "\r\n") {
+		return errors.New("toml/edit: a trailing comment must be a single line")
+	}
+	lf, tb, err := d.locateExpr(key)
+	if err != nil {
+		return err
+	}
+	var repl []byte
+	if text != "" {
+		repl = []byte(" # " + text)
+	}
+	return d.apply(splice{d.trailingSpan(lf, tb), repl})
+}

--- a/unstable/edit/edit.go
+++ b/unstable/edit/edit.go
@@ -1,0 +1,117 @@
+// Package edit provides comment- and layout-preserving editing of TOML
+// documents.
+//
+// A Document is created from TOML source with Parse. Bytes returns the
+// current source, byte-for-byte identical to the input except for the parts
+// modified through Set and Delete: an edit rewrites only the bytes that
+// express it, leaving the comments, whitespace, and ordering of everything
+// else untouched.
+//
+// Keys are addressed by their path, one element per key part:
+// []string{"servers", "alpha", "ip"} addresses ip in [servers.alpha]. Path
+// elements are plain strings, never quoted or dotted: quoting is applied as
+// needed when writing.
+//
+// Set and Delete address the structures that make up the document: tables
+// and key-values, whether defined by [table] headers or dotted keys. Arrays
+// and inline tables are atomic values: Set can replace one wholesale, but
+// Set and Delete paths cannot reach inside them. Elements of arrays of
+// tables ([[table]]) are not addressable either; Delete removes such an
+// array as a whole. Get operates on decoded values instead, so it can
+// descend into inline tables.
+//
+// Values passed to Set are rendered with the same encoder as toml.Marshal,
+// in inline (single-line) form. New tables created by Set get their own
+// [header] section, appended after the section of their closest existing
+// parent, unless that parent was defined with dotted keys, in which case
+// dotted keys are used for the new values as well.
+//
+// Every mutation is validated: if an edit would produce an invalid TOML
+// document, the document is left unchanged and an error is returned.
+//
+// Like the rest of the unstable API, this package does not follow the
+// backward compatibility guarantees of go-toml. It also favors correctness
+// and fidelity over speed: the document is re-validated and re-indexed after
+// every mutation, so it is meant for editing configuration files, not for
+// hot paths.
+//
+// A Document is not safe for concurrent use.
+package edit
+
+import (
+	"bytes"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// Document is a TOML document whose layout (comments, whitespace, order) is
+// preserved across edits.
+type Document struct {
+	data []byte
+	root *table
+}
+
+// Parse reads a TOML document and returns a Document ready to be inspected
+// and edited. The input must be a valid TOML document: syntactic or semantic
+// errors (for example duplicate keys) are returned, as editing an invalid
+// document would not produce meaningful results. The input slice is copied
+// and can be reused by the caller.
+func Parse(b []byte) (*Document, error) {
+	var v interface{}
+	if err := toml.Unmarshal(b, &v); err != nil {
+		return nil, err
+	}
+	d := &Document{data: bytes.Clone(b)}
+	if err := d.reindex(); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// Bytes returns the current TOML source of the document. If the document has
+// not been modified, it is identical to the input of Parse.
+func (d *Document) Bytes() []byte {
+	return bytes.Clone(d.data)
+}
+
+// String returns the current TOML source of the document, like Bytes.
+func (d *Document) String() string {
+	return string(d.data)
+}
+
+// Unmarshal decodes the current state of the document into v, like
+// toml.Unmarshal.
+func (d *Document) Unmarshal(v interface{}) error {
+	return toml.Unmarshal(d.data, v)
+}
+
+// Get returns the decoded value at the given key path, and whether it
+// exists. Values are decoded like toml.Unmarshal into an interface{}: tables
+// (inline or not) become map[string]interface{}, arrays and arrays of tables
+// become []interface{}, and scalars follow the usual decoding rules. An
+// empty path returns the whole document. Unlike Set and Delete, Get descends
+// into inline tables.
+func (d *Document) Get(key []string) (interface{}, bool) {
+	var v interface{}
+	if err := toml.Unmarshal(d.data, &v); err != nil {
+		// The document is valid by construction.
+		return nil, false
+	}
+	for _, k := range key {
+		m, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		v, ok = m[k]
+		if !ok {
+			return nil, false
+		}
+	}
+	return v, true
+}
+
+// Has reports whether a value exists at the given key path.
+func (d *Document) Has(key []string) bool {
+	_, ok := d.Get(key)
+	return ok
+}

--- a/unstable/edit/edit.go
+++ b/unstable/edit/edit.go
@@ -3,31 +3,54 @@
 //
 // A Document is created from TOML source with Parse. Bytes returns the
 // current source, byte-for-byte identical to the input except for the parts
-// modified through Set and Delete: an edit rewrites only the bytes that
-// express it, leaving the comments, whitespace, and ordering of everything
-// else untouched.
+// modified through Set, Delete, SetComment, and SetTrailingComment: an edit
+// rewrites only the bytes that express it, leaving the comments, whitespace,
+// and ordering of everything else untouched.
 //
-// Keys are addressed by their path, one element per key part:
+// # Key paths
+//
+// Values are addressed by their key path, one element per key part:
 // []string{"servers", "alpha", "ip"} addresses ip in [servers.alpha]. Path
 // elements are plain strings, never quoted or dotted: quoting is applied as
 // needed when writing.
 //
-// Set and Delete address the structures that make up the document: tables
-// and key-values, whether defined by [table] headers or dotted keys. Arrays
-// and inline tables are atomic values: Set can replace one wholesale, but
-// Set and Delete paths cannot reach inside them. Elements of arrays of
-// tables ([[table]]) are not addressable either; Delete removes such an
-// array as a whole. Get operates on decoded values instead, so it can
-// descend into inline tables.
+// Paths descend through tables (whether defined by [table] headers, dotted
+// keys, or inline), through arrays of tables, and through arrays. When a
+// path element steps into an array, it is interpreted as a 0-based decimal
+// index; everywhere else it is a key, so keys that look like numbers are
+// unambiguous. For Set, an index equal to the array's length appends a new
+// element, including a new [[table]] section for arrays of tables.
+//
+// # Values
 //
 // Values passed to Set are rendered with the same encoder as toml.Marshal,
-// in inline (single-line) form. New tables created by Set get their own
-// [header] section, appended after the section of their closest existing
-// parent, unless that parent was defined with dotted keys, in which case
-// dotted keys are used for the new values as well.
+// in inline (single-line) form. To control the exact TOML representation
+// (formatting, multi-line strings, ...), pass an unstable.RawMessage: its
+// bytes are used verbatim as the value. New tables created by Set get their
+// own [header] section, appended after the section of their closest existing
+// parent; dotted keys are used instead when the parent was defined with
+// dotted keys or lives inside an array-of-tables element (where a new header
+// would attach to the wrong element).
+//
+// Setting a path that designates an existing table or array of tables is an
+// error: Set never silently discards parts of the document. Delete it first
+// to replace it wholesale.
+//
+// # Comments
+//
+// Comments travel with the expression they annotate: the contiguous
+// full-line comments directly above a key-value or table header, and the
+// comment trailing it on the same line, move and are deleted with it. They
+// can be read and written with Comment, SetComment, TrailingComment, and
+// SetTrailingComment.
+//
+// # Guarantees
 //
 // Every mutation is validated: if an edit would produce an invalid TOML
-// document, the document is left unchanged and an error is returned.
+// document, the document is left unchanged and an error is returned. A few
+// exotic combinations (for example extending, from outside, a table defined
+// implicitly inside an array-of-tables element) are rejected that way when
+// TOML offers no valid syntax for them.
 //
 // Like the rest of the unstable API, this package does not follow the
 // backward compatibility guarantees of go-toml. It also favors correctness
@@ -88,9 +111,9 @@ func (d *Document) Unmarshal(v interface{}) error {
 // Get returns the decoded value at the given key path, and whether it
 // exists. Values are decoded like toml.Unmarshal into an interface{}: tables
 // (inline or not) become map[string]interface{}, arrays and arrays of tables
-// become []interface{}, and scalars follow the usual decoding rules. An
-// empty path returns the whole document. Unlike Set and Delete, Get descends
-// into inline tables.
+// become []interface{}, and scalars follow the usual decoding rules. Array
+// elements are addressed by a decimal index. An empty path returns the whole
+// document.
 func (d *Document) Get(key []string) (interface{}, bool) {
 	var v interface{}
 	if err := toml.Unmarshal(d.data, &v); err != nil {
@@ -98,12 +121,20 @@ func (d *Document) Get(key []string) (interface{}, bool) {
 		return nil, false
 	}
 	for _, k := range key {
-		m, ok := v.(map[string]interface{})
-		if !ok {
-			return nil, false
-		}
-		v, ok = m[k]
-		if !ok {
+		switch c := v.(type) {
+		case map[string]interface{}:
+			var ok bool
+			v, ok = c[k]
+			if !ok {
+				return nil, false
+			}
+		case []interface{}:
+			idx, ok := parseIndex(k)
+			if !ok || idx >= len(c) {
+				return nil, false
+			}
+			v = c[idx]
+		default:
 			return nil, false
 		}
 	}

--- a/unstable/edit/edit_test.go
+++ b/unstable/edit/edit_test.go
@@ -1,0 +1,556 @@
+package edit
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+// corpus is a set of valid documents exercising the constructs the index has
+// to handle.
+var corpus = []string{
+	"",
+	"# only a comment\n",
+	"a = 1",
+	"key = 'value'\n\n# section\n[table]\nk = 10 # trailing\n\n[table.sub]\narr = [1, 2, { x = 'y' }]\n",
+	"[[products]]\nname = 'Hammer'\nsku = 738594937\n\n[[products]]\n\n[[products]]\nname = 'Nail'\n\n[products.extra]\nnote = 'last one'\n",
+	"[[a.b]]\nx = 1\n\n[[a.b]]\nx = 2\n",
+	"phys.color = 'orange'\nphys.shape = 'round'\n\n[sub]\ndot.ted.key = 1\n",
+	"m = \"\"\"\nmulti \\\" line\nstring '' \"\"\ttab\n\"\"\"\nlit = '''\nliteral\n'''\n",
+	"arr = [\n  1, # one\n  # standalone\n  2,\n]\n",
+	"it = {\n  a = 1, # comment in inline table\n}\n",
+	"crlf = 1\r\n[t]\r\nx = 'y'\r\n",
+	"'quoted key' = 1\n\"another.one\" = 2\n\n[deep.'ta.ble']\nx = 1\n",
+	"[ spaced . 'head er' ]\nx = 1\n\n[[ spaced . arr ]]\ny = 2\n",
+	"d = 1979-05-27T07:32:00Z\nld = 1979-05-27\nlt = 07:32:00\nf = inf\nn = nan\nneg = -0.01\nhex = 0xDEADBEEF\n",
+	"inline = {a = 1, b = [1, 2], c = {d = 'e'}}\n",
+}
+
+func mustParse(t *testing.T, doc string) *Document {
+	t.Helper()
+	d, err := Parse([]byte(doc))
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", doc, err)
+	}
+	return d
+}
+
+func TestRoundTrip(t *testing.T) {
+	for _, doc := range corpus {
+		d := mustParse(t, doc)
+		if got := d.String(); got != doc {
+			t.Errorf("round trip mismatch:\nin:  %q\nout: %q", doc, got)
+		}
+	}
+}
+
+func TestRoundTripReferenceFile(t *testing.T) {
+	b, err := os.ReadFile("../../benchmark/benchmark.toml")
+	if err != nil {
+		t.Skip("reference file not available:", err)
+	}
+	d, err := Parse(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := d.Bytes(); string(got) != string(b) {
+		t.Error("round trip mismatch on reference file")
+	}
+}
+
+func TestParseInvalid(t *testing.T) {
+	for _, doc := range []string{
+		"a =",            // syntax error
+		"a = 1\na = 2\n", // duplicate key
+		"a = 1\n[a]\n",   // table redefines value
+	} {
+		if _, err := Parse([]byte(doc)); err == nil {
+			t.Errorf("Parse(%q): expected error", doc)
+		}
+	}
+}
+
+func TestGet(t *testing.T) {
+	doc := `top = 'level'
+'quoted key' = 1
+
+[table]
+num = 42
+inline = {x = 'y'}
+arr = [1, 2]
+
+[[items]]
+name = 'first'
+`
+	d := mustParse(t, doc)
+
+	tests := []struct {
+		key  []string
+		want interface{}
+		ok   bool
+	}{
+		{[]string{"top"}, "level", true},
+		{[]string{"quoted key"}, int64(1), true},
+		{[]string{"table", "num"}, int64(42), true},
+		{[]string{"table", "inline", "x"}, "y", true},
+		{[]string{"table", "arr"}, []interface{}{int64(1), int64(2)}, true},
+		{[]string{"items"}, []interface{}{map[string]interface{}{"name": "first"}}, true},
+		{[]string{"missing"}, nil, false},
+		{[]string{"table", "missing"}, nil, false},
+		{[]string{"top", "not-a-table"}, nil, false},
+		{[]string{"items", "name"}, nil, false}, // cannot index arrays by name
+	}
+	for _, test := range tests {
+		got, ok := d.Get(test.key)
+		if ok != test.ok || (ok && !reflect.DeepEqual(got, test.want)) {
+			t.Errorf("Get(%q) = (%v, %v), want (%v, %v)", test.key, got, ok, test.want, test.ok)
+		}
+		if d.Has(test.key) != test.ok {
+			t.Errorf("Has(%q) = %v, want %v", test.key, !test.ok, test.ok)
+		}
+	}
+
+	whole, ok := d.Get(nil)
+	if !ok {
+		t.Fatal("Get(nil) not ok")
+	}
+	if _, isMap := whole.(map[string]interface{}); !isMap {
+		t.Errorf("Get(nil) = %T, want map", whole)
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	d := mustParse(t, "[server]\nport = 8080\n")
+	var cfg struct {
+		Server struct{ Port int }
+	}
+	if err := d.Unmarshal(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Server.Port != 8080 {
+		t.Errorf("port = %d, want 8080", cfg.Server.Port)
+	}
+}
+
+func TestSet(t *testing.T) {
+	tests := []struct {
+		name  string
+		doc   string
+		key   []string
+		value interface{}
+		want  string
+	}{
+		{
+			name:  "replace scalar keeps trailing comment",
+			doc:   "# Server config\n[server]\nhost = 'localhost' # the host\nport = 8080\n",
+			key:   []string{"server", "host"},
+			value: "example.com",
+			want:  "# Server config\n[server]\nhost = 'example.com' # the host\nport = 8080\n",
+		},
+		{
+			name:  "replace changes value type",
+			doc:   "port = 8080\n",
+			key:   []string{"port"},
+			value: "auto",
+			want:  "port = 'auto'\n",
+		},
+		{
+			name:  "replace multiline array with scalar",
+			doc:   "a = [\n  1,\n  2, # two\n]\nb = 1\n",
+			key:   []string{"a"},
+			value: 7,
+			want:  "a = 7\nb = 1\n",
+		},
+		{
+			name:  "replace with array value",
+			doc:   "a = 1\n",
+			key:   []string{"a"},
+			value: []interface{}{1, "two"},
+			want:  "a = [1, 'two']\n",
+		},
+		{
+			name:  "replace with inline table value",
+			doc:   "a = 1\n",
+			key:   []string{"a"},
+			value: map[string]interface{}{"x": 1},
+			want:  "a = {x = 1}\n",
+		},
+		{
+			name:  "replace value in inline table is atomic",
+			doc:   "p = {x = 1, y = 2} # keep\n",
+			key:   []string{"p"},
+			value: map[string]interface{}{"x": 5},
+			want:  "p = {x = 5} # keep\n",
+		},
+		{
+			name:  "insert into table before next section comments",
+			doc:   "[a]\nx = 1\n\n# next section\n[b]\ny = 2\n",
+			key:   []string{"a", "z"},
+			value: 3,
+			want:  "[a]\nx = 1\nz = 3\n\n# next section\n[b]\ny = 2\n",
+		},
+		{
+			name:  "insert into empty table",
+			doc:   "[a]\n[b]\n",
+			key:   []string{"a", "x"},
+			value: 1,
+			want:  "[a]\nx = 1\n[b]\n",
+		},
+		{
+			name:  "insert at root after last top-level key",
+			doc:   "a = 1\n\n[t]\nb = 2\n",
+			key:   []string{"c"},
+			value: true,
+			want:  "a = 1\nc = true\n\n[t]\nb = 2\n",
+		},
+		{
+			name:  "insert at root without top-level keys",
+			doc:   "# about t\n[t]\nx = 1\n",
+			key:   []string{"r"},
+			value: 1,
+			want:  "r = 1\n# about t\n[t]\nx = 1\n",
+		},
+		{
+			name:  "insert into empty document",
+			doc:   "",
+			key:   []string{"a"},
+			value: 1,
+			want:  "a = 1\n",
+		},
+		{
+			name:  "insert after document without trailing newline",
+			doc:   "a = 1",
+			key:   []string{"b"},
+			value: 2,
+			want:  "a = 1\nb = 2\n",
+		},
+		{
+			name:  "create section in empty document",
+			doc:   "",
+			key:   []string{"srv", "port"},
+			value: 8080,
+			want:  "[srv]\nport = 8080\n",
+		},
+		{
+			name:  "create section after root keys",
+			doc:   "a = 1\n",
+			key:   []string{"srv", "port"},
+			value: 8080,
+			want:  "a = 1\n\n[srv]\nport = 8080\n",
+		},
+		{
+			name:  "create deep section with single header",
+			doc:   "a = 1\n",
+			key:   []string{"x", "y", "z"},
+			value: 1,
+			want:  "a = 1\n\n[x.y]\nz = 1\n",
+		},
+		{
+			name:  "create section near its parent",
+			doc:   "[a]\nx = 1\n\n[z]\ny = 2\n",
+			key:   []string{"a", "b", "c"},
+			value: 1,
+			want:  "[a]\nx = 1\n\n[a.b]\nc = 1\n\n[z]\ny = 2\n",
+		},
+		{
+			name:  "create header for implicit table",
+			doc:   "[a.b]\nx = 1\n",
+			key:   []string{"a", "y"},
+			value: 2,
+			want:  "[a.b]\nx = 1\n\n[a]\ny = 2\n",
+		},
+		{
+			name:  "extend dotted table with dotted key",
+			doc:   "fruit.apple = 1\n",
+			key:   []string{"fruit", "banana"},
+			value: 2,
+			want:  "fruit.apple = 1\nfruit.banana = 2\n",
+		},
+		{
+			name:  "extend dotted table deeply",
+			doc:   "fruit.apple = 1\n",
+			key:   []string{"fruit", "color", "hue"},
+			value: 3,
+			want:  "fruit.apple = 1\nfruit.color.hue = 3\n",
+		},
+		{
+			name:  "extend dotted table inside section",
+			doc:   "[t]\na.b = 1\n",
+			key:   []string{"t", "a", "c"},
+			value: 2,
+			want:  "[t]\na.b = 1\na.c = 2\n",
+		},
+		{
+			name:  "create section next to array of tables",
+			doc:   "[[t.arr]]\nx = 1\n",
+			key:   []string{"t", "new", "k"},
+			value: 1,
+			want:  "[[t.arr]]\nx = 1\n\n[t.new]\nk = 1\n",
+		},
+		{
+			name:  "quoted key parts",
+			doc:   "",
+			key:   []string{"a b", "x.y"},
+			value: 1,
+			want:  "['a b']\n'x.y' = 1\n",
+		},
+		{
+			name:  "insert key needing quotes",
+			doc:   "a = 1\n",
+			key:   []string{"needs quotes"},
+			value: 1,
+			want:  "a = 1\n'needs quotes' = 1\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if err := d.Set(test.key, test.value); err != nil {
+				t.Fatalf("Set(%q, %v): %v", test.key, test.value, err)
+			}
+			if got := d.String(); got != test.want {
+				t.Errorf("Set(%q, %v):\ngot:  %q\nwant: %q", test.key, test.value, got, test.want)
+			}
+			if got, ok := d.Get(test.key); !ok {
+				t.Errorf("Get(%q) after Set: missing (got %v)", test.key, got)
+			}
+		})
+	}
+}
+
+func TestSetErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		doc   string
+		key   []string
+		value interface{}
+	}{
+		{"empty key", "a = 1\n", nil, 1},
+		{"through value", "a = 1\n", []string{"a", "b"}, 1},
+		{"through inline table", "a = {b = 1}\n", []string{"a", "b"}, 2},
+		{"through array of tables", "[[x]]\nk = 1\n", []string{"x", "k"}, 2},
+		{"onto array of tables", "[[x]]\nk = 1\n", []string{"x"}, 1},
+		{"onto table", "[t]\nx = 1\n", []string{"t"}, 5},
+		{"onto dotted table", "a.b = 1\n", []string{"a"}, 5},
+		{"nil value", "", []string{"a"}, nil},
+		{"unsupported value", "", []string{"a"}, func() {}},
+		{"nil value on existing key", "a = 1\n", []string{"a"}, nil},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if err := d.Set(test.key, test.value); err == nil {
+				t.Fatalf("Set(%q, %v): expected error, document is now %q", test.key, test.value, d.String())
+			}
+			if got := d.String(); got != test.doc {
+				t.Errorf("document changed after failed Set:\ngot:  %q\nwant: %q", got, test.doc)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		key  []string
+		want string
+	}{
+		{
+			name: "key-value with attached comments",
+			doc:  "# keep\n\n# about a\n# more about a\na = 1 # trail\nb = 2\n",
+			key:  []string{"a"},
+			want: "# keep\n\nb = 2\n",
+		},
+		{
+			name: "key-value without trailing newline",
+			doc:  "a = 1",
+			key:  []string{"a"},
+			want: "",
+		},
+		{
+			name: "dotted key-value",
+			doc:  "a.b = 1\nc = 2\n",
+			key:  []string{"a", "b"},
+			want: "c = 2\n",
+		},
+		{
+			name: "dotted table deletes its lines",
+			doc:  "a.b = 1\na.c = 2\nz = 1\n",
+			key:  []string{"a"},
+			want: "z = 1\n",
+		},
+		{
+			name: "last key of table leaves empty section",
+			doc:  "[a]\nx = 1\n",
+			key:  []string{"a", "x"},
+			want: "[a]\n",
+		},
+		{
+			name: "table with attached header comment",
+			doc:  "a = 1\n\n# about t\n[t]\nx = 1\n",
+			key:  []string{"t"},
+			want: "a = 1\n",
+		},
+		{
+			name: "table with non-contiguous sub-table",
+			doc:  "[a]\nx = 1\n\n[b]\ny = 2\n\n[a.sub]\nz = 3\n",
+			key:  []string{"a"},
+			want: "[b]\ny = 2\n",
+		},
+		{
+			name: "sub-table only",
+			doc:  "[a]\nx = 1\n\n[a.sub]\nz = 3\n\n[b]\ny = 2\n",
+			key:  []string{"a", "sub"},
+			want: "[a]\nx = 1\n\n[b]\ny = 2\n",
+		},
+		{
+			name: "array of tables",
+			doc:  "x = 5\n\n[[s]]\na = 1\n\n[[s]]\na = 2\n",
+			key:  []string{"s"},
+			want: "x = 5\n",
+		},
+		{
+			name: "implicit parent disappears",
+			doc:  "[a.b]\nx = 1\n",
+			key:  []string{"a", "b"},
+			want: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if !d.Delete(test.key) {
+				t.Fatalf("Delete(%q) = false", test.key)
+			}
+			if got := d.String(); got != test.want {
+				t.Errorf("Delete(%q):\ngot:  %q\nwant: %q", test.key, got, test.want)
+			}
+			if d.Has(test.key) {
+				t.Errorf("Has(%q) still true after Delete", test.key)
+			}
+		})
+	}
+}
+
+func TestDeleteFalse(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		key  []string
+	}{
+		{"empty key", "a = 1\n", nil},
+		{"missing", "a = 1\n", []string{"b"}},
+		{"missing nested", "[t]\n", []string{"t", "x"}},
+		{"through value", "a = 1\n", []string{"a", "b"}},
+		{"inside inline table", "a = {b = 1}\n", []string{"a", "b"}},
+		{"inside array of tables", "[[x]]\nk = 1\n", []string{"x", "k"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if d.Delete(test.key) {
+				t.Fatalf("Delete(%q) = true, document is now %q", test.key, d.String())
+			}
+			if got := d.String(); got != test.doc {
+				t.Errorf("document changed after Delete returning false:\ngot:  %q\nwant: %q", got, test.doc)
+			}
+		})
+	}
+}
+
+func TestCRLF(t *testing.T) {
+	d := mustParse(t, "a = 1\r\n[t]\r\nb = 2\r\n")
+	if err := d.Set([]string{"t", "c"}, 3); err != nil {
+		t.Fatal(err)
+	}
+	want := "a = 1\r\n[t]\r\nb = 2\r\nc = 3\r\n"
+	if got := d.String(); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if err := d.Set([]string{"n", "k"}, 1); err != nil {
+		t.Fatal(err)
+	}
+	want = "a = 1\r\n[t]\r\nb = 2\r\nc = 3\r\n\r\n[n]\r\nk = 1\r\n"
+	if got := d.String(); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// collectPaths gathers the key paths of the leaves and tables of the index
+// that are addressable by Set and Delete (that is, not inside an array of
+// tables).
+func collectPaths(t *table, prefix []string, leaves, tables *[][]string) {
+	for name, it := range t.items {
+		p := append(append([]string{}, prefix...), name)
+		switch {
+		case it.leaf != nil:
+			*leaves = append(*leaves, p)
+		case it.tbl != nil:
+			*tables = append(*tables, p)
+			collectPaths(it.tbl, p, leaves, tables)
+		case it.arr != nil:
+			*tables = append(*tables, p)
+		}
+	}
+}
+
+// TestEveryPathEditable checks, for every addressable path of every corpus
+// document, that Set and Delete apply cleanly and that the result decodes as
+// expected.
+func TestEveryPathEditable(t *testing.T) {
+	for _, doc := range corpus {
+		var leaves, tables [][]string
+		collectPaths(mustParse(t, doc).root, nil, &leaves, &tables)
+
+		for _, path := range leaves {
+			d := mustParse(t, doc)
+			if err := d.Set(path, "edited"); err != nil {
+				t.Errorf("doc %q: Set(%q): %v", doc, path, err)
+				continue
+			}
+			if v, _ := d.Get(path); v != "edited" {
+				t.Errorf("doc %q: Get(%q) after Set = %v", doc, path, v)
+			}
+		}
+		for _, path := range append(leaves, tables...) {
+			d := mustParse(t, doc)
+			if !d.Delete(path) {
+				t.Errorf("doc %q: Delete(%q) = false", doc, path)
+				continue
+			}
+			if d.Has(path) {
+				t.Errorf("doc %q: Has(%q) after Delete", doc, path)
+			}
+		}
+	}
+}
+
+func TestReindexInvalidDocuments(t *testing.T) {
+	// reindex is only ever called on pre-validated documents, but it must
+	// fail cleanly rather than build a broken index if that invariant is
+	// ever violated.
+	for _, doc := range []string{
+		"a = 1\na = 2\n",      // duplicate key
+		"a = 1\na.b = 2\n",    // dotted key crosses value
+		"a = 1\n[a]\n",        // table header redefines value
+		"a = 1\n[a.b]\n",      // table header crosses value
+		"a = 1\n[[a]]\n",      // array table redefines value
+		"a = 1\n[[a.b]]\n",    // array table crosses value
+		"[t]\nx = 1\nx = 2\n", // duplicate key in table
+	} {
+		d := &Document{data: []byte(doc)}
+		if err := d.reindex(); err == nil {
+			t.Errorf("reindex(%q): expected error", doc)
+		}
+	}
+}
+
+func TestApplyOverlap(t *testing.T) {
+	d := mustParse(t, "abc = 1\n")
+	err := d.apply(splice{span{0, 5}, nil}, splice{span{3, 7}, nil})
+	if err == nil {
+		t.Fatal("expected error on overlapping edits")
+	}
+}

--- a/unstable/edit/edit_test.go
+++ b/unstable/edit/edit_test.go
@@ -3,6 +3,7 @@ package edit
 import (
 	"os"
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -328,9 +329,18 @@ func TestSetErrors(t *testing.T) {
 	}{
 		{"empty key", "a = 1\n", nil, 1},
 		{"through value", "a = 1\n", []string{"a", "b"}, 1},
-		{"through inline table", "a = {b = 1}\n", []string{"a", "b"}, 2},
-		{"through array of tables", "[[x]]\nk = 1\n", []string{"x", "k"}, 2},
+		{"non-index into array of tables", "[[x]]\nk = 1\n", []string{"x", "k"}, 2},
 		{"onto array of tables", "[[x]]\nk = 1\n", []string{"x"}, 1},
+		{"onto array-of-tables element", "[[x]]\nk = 1\n", []string{"x", "0"}, 1},
+		{"array-of-tables index out of range", "[[x]]\nk = 1\n", []string{"x", "2", "k"}, 1},
+		{"append element without keys", "[[x]]\nk = 1\n", []string{"x", "1"}, 1},
+		{"append element with nil value", "[[x]]\nk = 1\n", []string{"x", "1", "k"}, nil},
+		{"insert into inline table with nil value", "p = {a = 1}\n", []string{"p", "b"}, nil},
+		{"append to array with nil value", "a = [1]\n", []string{"a", "1"}, nil},
+		{"through scalar in inline table", "a = {b = 1}\n", []string{"a", "b", "c"}, 2},
+		{"non-index into array", "a = [1, 2]\n", []string{"a", "x"}, 1},
+		{"array index out of range", "a = [1, 2]\n", []string{"a", "5"}, 1},
+		{"onto implicit table in inline", "a = {b.c = 1}\n", []string{"a", "b"}, 1},
 		{"onto table", "[t]\nx = 1\n", []string{"t"}, 5},
 		{"onto dotted table", "a.b = 1\n", []string{"a"}, 5},
 		{"nil value", "", []string{"a"}, nil},
@@ -444,8 +454,11 @@ func TestDeleteFalse(t *testing.T) {
 		{"missing", "a = 1\n", []string{"b"}},
 		{"missing nested", "[t]\n", []string{"t", "x"}},
 		{"through value", "a = 1\n", []string{"a", "b"}},
-		{"inside inline table", "a = {b = 1}\n", []string{"a", "b"}},
-		{"inside array of tables", "[[x]]\nk = 1\n", []string{"x", "k"}},
+		{"missing in inline table", "a = {b = 1}\n", []string{"a", "c"}},
+		{"non-index into array of tables", "[[x]]\nk = 1\n", []string{"x", "k"}},
+		{"element index out of range", "[[x]]\nk = 1\n", []string{"x", "1"}},
+		{"array index out of range", "a = [1]\n", []string{"a", "1"}},
+		{"non-index into array", "a = [1]\n", []string{"a", "x"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -492,6 +505,11 @@ func collectPaths(t *table, prefix []string, leaves, tables *[][]string) {
 			collectPaths(it.tbl, p, leaves, tables)
 		case it.arr != nil:
 			*tables = append(*tables, p)
+			for idx, elem := range it.arr {
+				ep := append(append([]string{}, p...), strconv.Itoa(idx))
+				*tables = append(*tables, ep)
+				collectPaths(elem, ep, leaves, tables)
+			}
 		}
 	}
 }
@@ -520,7 +538,9 @@ func TestEveryPathEditable(t *testing.T) {
 				t.Errorf("doc %q: Delete(%q) = false", doc, path)
 				continue
 			}
-			if d.Has(path) {
+			// Deleting an array element shifts the following ones, so an
+			// index-ended path may legitimately still exist.
+			if _, isIdx := parseIndex(path[len(path)-1]); !isIdx && d.Has(path) {
 				t.Errorf("doc %q: Has(%q) after Delete", doc, path)
 			}
 		}

--- a/unstable/edit/edit_test.go
+++ b/unstable/edit/edit_test.go
@@ -337,10 +337,15 @@ func TestSetErrors(t *testing.T) {
 		{"append element with nil value", "[[x]]\nk = 1\n", []string{"x", "1", "k"}, nil},
 		{"insert into inline table with nil value", "p = {a = 1}\n", []string{"p", "b"}, nil},
 		{"append to array with nil value", "a = [1]\n", []string{"a", "1"}, nil},
+		{"replace array element with nil", "a = [1]\n", []string{"a", "0"}, nil},
 		{"through scalar in inline table", "a = {b = 1}\n", []string{"a", "b", "c"}, 2},
 		{"non-index into array", "a = [1, 2]\n", []string{"a", "x"}, 1},
 		{"array index out of range", "a = [1, 2]\n", []string{"a", "5"}, 1},
 		{"onto implicit table in inline", "a = {b.c = 1}\n", []string{"a", "b"}, 1},
+		{"replace inline value with nil", "p = {x = 1}\n", []string{"p", "x"}, nil},
+		{"extend dotted table with nil", "a.b = 1\n", []string{"a", "c"}, nil},
+		{"element sub-table with nil", "[[s]]\nx = 1\n", []string{"s", "0", "o", "k"}, nil},
+		{"new section with nil", "", []string{"a", "b"}, nil},
 		{"onto table", "[t]\nx = 1\n", []string{"t"}, 5},
 		{"onto dotted table", "a.b = 1\n", []string{"a"}, 5},
 		{"nil value", "", []string{"a"}, nil},
@@ -426,6 +431,12 @@ func TestDelete(t *testing.T) {
 			doc:  "[a.b]\nx = 1\n",
 			key:  []string{"a", "b"},
 			want: "",
+		},
+		{
+			name: "crlf table at end absorbs separator",
+			doc:  "a = 1\r\n\r\n[t]\r\nx = 1\r\n",
+			key:  []string{"t"},
+			want: "a = 1\r\n",
 		},
 	}
 	for _, test := range tests {

--- a/unstable/edit/errors_test.go
+++ b/unstable/edit/errors_test.go
@@ -1,0 +1,114 @@
+package edit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// parseExpr parses a single expression with a fresh parser. Feeding the
+// resulting nodes to a Document holding different bytes exercises the
+// defensive error paths of the span scanners, which are unreachable through
+// the public API.
+func parseExpr(t *testing.T, doc string) *unstable.Node {
+	t.Helper()
+	p := &unstable.Parser{}
+	p.Reset([]byte(doc))
+	if !p.NextExpression() {
+		t.Fatalf("no expression in %q: %v", doc, p.Error())
+	}
+	return p.Expression()
+}
+
+func TestExprSpanErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		expr string
+		data string
+	}{
+		{"missing open bracket", "[a]\n", "(a)\n"},
+		{"missing close bracket", "[a]\n", "[a)\n"},
+		{"missing second open bracket", "[[a]]\n", "([a]]\n"},
+		{"missing second close bracket", "[[a]]\n", "[[a])\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := &Document{data: []byte(test.data)}
+			if _, _, err := d.exprSpan(parseExpr(t, test.expr)); err == nil {
+				t.Error("expected error")
+			}
+		})
+	}
+}
+
+func TestValueSpanError(t *testing.T) {
+	d := &Document{data: []byte("a x 1\n")}
+	if _, err := d.valueSpan(parseExpr(t, "a = 1\n")); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestValueNodeEndErrors(t *testing.T) {
+	t.Run("inline table close", func(t *testing.T) {
+		d := &Document{data: []byte("k = {a = 1 x")}
+		n := parseExpr(t, "k = {a = 1}\n").Value()
+		if _, err := d.valueNodeEnd(n, 4); err == nil {
+			t.Error("expected error")
+		}
+	})
+	t.Run("array close", func(t *testing.T) {
+		d := &Document{data: []byte("k = [1 x")}
+		n := parseExpr(t, "k = [1]\n").Value()
+		if _, err := d.valueNodeEnd(n, 4); err == nil {
+			t.Error("expected error")
+		}
+	})
+	t.Run("array element error propagates", func(t *testing.T) {
+		d := &Document{data: []byte("k = [{a = 1 ]")}
+		n := parseExpr(t, "k = [{a = 1}]\n").Value()
+		if _, err := d.valueNodeEnd(n, 4); err == nil {
+			t.Error("expected error")
+		}
+		if _, err := d.arrayElems(n, 4); err == nil {
+			t.Error("expected error")
+		}
+	})
+}
+
+func TestLeafValueNodeError(t *testing.T) {
+	d := mustParse(t, "a = 1\n")
+	stale := &leaf{value: span{0, 999}}
+	if _, err := d.leafValueNode(stale); err == nil {
+		t.Error("leafValueNode: expected error")
+	}
+	if err := d.setInline(stale, []string{"a", "b"}, 1, 1); err == nil {
+		t.Error("setInline: expected error")
+	}
+	if _, _, ok := d.deleteInline(stale, []string{"a", "b"}, 1); ok {
+		t.Error("deleteInline: expected not ok")
+	}
+}
+
+func TestReindexParseError(t *testing.T) {
+	d := &Document{data: []byte("a =")}
+	if err := d.reindex(); err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestSkipInlineTriviaEOF(t *testing.T) {
+	d := mustParse(t, "a = 1\n")
+	if got := d.skipInlineTrivia(5, true); got != 6 {
+		t.Errorf("skipInlineTrivia = %d, want 6", got)
+	}
+}
+
+func TestParseIndexLimits(t *testing.T) {
+	if _, ok := parseIndex(strings.Repeat("9", 19)); ok {
+		t.Error("oversized index should not parse")
+	}
+	if _, ok := parseIndex(""); ok {
+		t.Error("empty index should not parse")
+	}
+}

--- a/unstable/edit/example_test.go
+++ b/unstable/edit/example_test.go
@@ -43,6 +43,65 @@ host = 'localhost'
 	// port = 5432
 }
 
+func ExampleDocument_Set_arraysAndInline() {
+	doc := `[[servers]]
+ip = '10.0.0.1'
+ports = [8080]
+
+[[servers]]
+ip = '10.0.0.2'
+ports = [8080]
+`
+	d, err := edit.Parse([]byte(doc))
+	if err != nil {
+		panic(err)
+	}
+
+	// Array elements (of tables or not) are addressed by decimal indexes.
+	if err := d.Set([]string{"servers", "1", "ip"}, "10.0.0.3"); err != nil {
+		panic(err)
+	}
+	// An index equal to the length appends: a port to the first server...
+	if err := d.Set([]string{"servers", "0", "ports", "1"}, 8081); err != nil {
+		panic(err)
+	}
+	// ...or a whole new [[servers]] element.
+	if err := d.Set([]string{"servers", "2", "ip"}, "10.0.0.4"); err != nil {
+		panic(err)
+	}
+
+	fmt.Print(d.String())
+	// Output:
+	// [[servers]]
+	// ip = '10.0.0.1'
+	// ports = [8080, 8081]
+	//
+	// [[servers]]
+	// ip = '10.0.0.3'
+	// ports = [8080]
+	//
+	// [[servers]]
+	// ip = '10.0.0.4'
+}
+
+func ExampleDocument_SetComment() {
+	d, err := edit.Parse([]byte("[server]\nport = 8080\n"))
+	if err != nil {
+		panic(err)
+	}
+	if err := d.SetComment([]string{"server"}, "Connection settings."); err != nil {
+		panic(err)
+	}
+	if err := d.SetTrailingComment([]string{"server", "port"}, "default"); err != nil {
+		panic(err)
+	}
+	fmt.Print(d.String())
+	// Output:
+	// # Connection settings.
+	// [server]
+	// port = 8080 # default
+}
+
 func ExampleDocument_Set() {
 	d, err := edit.Parse(nil)
 	if err != nil {

--- a/unstable/edit/example_test.go
+++ b/unstable/edit/example_test.go
@@ -1,0 +1,64 @@
+package edit_test
+
+import (
+	"fmt"
+
+	"github.com/pelletier/go-toml/v2/unstable/edit"
+)
+
+func Example() {
+	doc := `# my app config
+
+title = 'My App'
+debug = false # do not touch
+
+[database]
+host = 'localhost'
+`
+
+	d, err := edit.Parse([]byte(doc))
+	if err != nil {
+		panic(err)
+	}
+
+	// Replacing a value only rewrites the value itself: the comment trailing
+	// it stays.
+	if err := d.Set([]string{"debug"}, true); err != nil {
+		panic(err)
+	}
+	// New keys are appended to the table they belong to.
+	if err := d.Set([]string{"database", "port"}, 5432); err != nil {
+		panic(err)
+	}
+	d.Delete([]string{"title"})
+
+	fmt.Print(d.String())
+	// Output:
+	// # my app config
+	//
+	// debug = true # do not touch
+	//
+	// [database]
+	// host = 'localhost'
+	// port = 5432
+}
+
+func ExampleDocument_Set() {
+	d, err := edit.Parse(nil)
+	if err != nil {
+		panic(err)
+	}
+	if err := d.Set([]string{"title"}, "example"); err != nil {
+		panic(err)
+	}
+	// Missing tables are created with a single header.
+	if err := d.Set([]string{"servers", "alpha", "ip"}, "10.0.0.1"); err != nil {
+		panic(err)
+	}
+	fmt.Print(d.String())
+	// Output:
+	// title = 'example'
+	//
+	// [servers.alpha]
+	// ip = '10.0.0.1'
+}

--- a/unstable/edit/feature_test.go
+++ b/unstable/edit/feature_test.go
@@ -1,0 +1,644 @@
+package edit
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+func TestSetArrayTables(t *testing.T) {
+	tests := []struct {
+		name  string
+		doc   string
+		key   []string
+		value interface{}
+		want  string
+	}{
+		{
+			name:  "replace value in element",
+			doc:   "[[s]]\na = 1\n\n[[s]]\na = 2\n",
+			key:   []string{"s", "1", "a"},
+			value: 3,
+			want:  "[[s]]\na = 1\n\n[[s]]\na = 3\n",
+		},
+		{
+			name:  "insert key into element",
+			doc:   "[[s]]\na = 1\n\n[[s]]\na = 2\n",
+			key:   []string{"s", "0", "b"},
+			value: 4,
+			want:  "[[s]]\na = 1\nb = 4\n\n[[s]]\na = 2\n",
+		},
+		{
+			name:  "new table under non-last element uses dotted keys",
+			doc:   "[[s]]\nx = 1\n\n[[s]]\nx = 2\n",
+			key:   []string{"s", "0", "opts", "k"},
+			value: 1,
+			want:  "[[s]]\nx = 1\nopts.k = 1\n\n[[s]]\nx = 2\n",
+		},
+		{
+			name:  "append element",
+			doc:   "[[s]]\na = 1\n\n[[s]]\na = 2\n",
+			key:   []string{"s", "2", "a"},
+			value: 9,
+			want:  "[[s]]\na = 1\n\n[[s]]\na = 2\n\n[[s]]\na = 9\n",
+		},
+		{
+			name:  "append element with deep key",
+			doc:   "[[s]]\na = 1\n",
+			key:   []string{"s", "1", "o", "k"},
+			value: 1,
+			want:  "[[s]]\na = 1\n\n[[s]]\no.k = 1\n",
+		},
+		{
+			name:  "append element to nested array of tables",
+			doc:   "[[a.b]]\nx = 1\n",
+			key:   []string{"a", "b", "1", "x"},
+			value: 2,
+			want:  "[[a.b]]\nx = 1\n\n[[a.b]]\nx = 2\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if err := d.Set(test.key, test.value); err != nil {
+				t.Fatalf("Set(%q, %v): %v", test.key, test.value, err)
+			}
+			if got := d.String(); got != test.want {
+				t.Errorf("Set(%q, %v):\ngot:  %q\nwant: %q", test.key, test.value, got, test.want)
+			}
+			if got, ok := d.Get(test.key); !ok || !reflect.DeepEqual(got, int64(test.value.(int))) {
+				t.Errorf("Get(%q) after Set = %v, %v", test.key, got, ok)
+			}
+		})
+	}
+}
+
+func TestSetInline(t *testing.T) {
+	tests := []struct {
+		name  string
+		doc   string
+		key   []string
+		value interface{}
+		want  string
+	}{
+		{
+			name:  "replace in nested inline table",
+			doc:   "p = {a = {b = 1}, c = 2} # keep\n",
+			key:   []string{"p", "a", "b"},
+			value: 5,
+			want:  "p = {a = {b = 5}, c = 2} # keep\n",
+		},
+		{
+			name:  "insert into inline table",
+			doc:   "p = {a = 1, c = 2}\n",
+			key:   []string{"p", "d"},
+			value: 3,
+			want:  "p = {a = 1, c = 2, d = 3}\n",
+		},
+		{
+			name:  "insert into empty inline table",
+			doc:   "e = {}\n",
+			key:   []string{"e", "x"},
+			value: 1,
+			want:  "e = {x = 1}\n",
+		},
+		{
+			name:  "insert reuses trailing comma",
+			doc:   "e = {a = 1,}\n",
+			key:   []string{"e", "b"},
+			value: 2,
+			want:  "e = {a = 1, b = 2}\n",
+		},
+		{
+			name:  "insert into multi-line inline table",
+			doc:   "m = {\n  a = 1, # one\n}\n",
+			key:   []string{"m", "b"},
+			value: 2,
+			want:  "m = {\n  a = 1, b = 2 # one\n}\n",
+		},
+		{
+			name:  "replace dotted key in inline table",
+			doc:   "d = {a.b = 1}\n",
+			key:   []string{"d", "a", "b"},
+			value: 9,
+			want:  "d = {a.b = 9}\n",
+		},
+		{
+			name:  "extend dotted key in inline table",
+			doc:   "d = {a.b = 1}\n",
+			key:   []string{"d", "a", "c"},
+			value: 2,
+			want:  "d = {a.b = 1, a.c = 2}\n",
+		},
+		{
+			name:  "replace array element",
+			doc:   "arr = [1, 2, 3]\n",
+			key:   []string{"arr", "1"},
+			value: 9,
+			want:  "arr = [1, 9, 3]\n",
+		},
+		{
+			name:  "append to array",
+			doc:   "arr = [1, 2, 3]\n",
+			key:   []string{"arr", "3"},
+			value: 4,
+			want:  "arr = [1, 2, 3, 4]\n",
+		},
+		{
+			name:  "append to empty array",
+			doc:   "arr = []\n",
+			key:   []string{"arr", "0"},
+			value: 9,
+			want:  "arr = [9]\n",
+		},
+		{
+			name:  "append to multi-line array",
+			doc:   "arr = [\n  1,\n  2,\n]\n",
+			key:   []string{"arr", "2"},
+			value: 3,
+			want:  "arr = [\n  1,\n  2, 3\n]\n",
+		},
+		{
+			name:  "replace in nested array",
+			doc:   "aa = [[1], [2, 3]]\n",
+			key:   []string{"aa", "1", "0"},
+			value: 9,
+			want:  "aa = [[1], [9, 3]]\n",
+		},
+		{
+			name:  "replace in array of inline tables",
+			doc:   "pts = [{x = 1}, {x = 2}]\n",
+			key:   []string{"pts", "1", "x"},
+			value: 5,
+			want:  "pts = [{x = 1}, {x = 5}]\n",
+		},
+		{
+			name:  "insert into inline table element",
+			doc:   "pts = [{x = 1}, {x = 2}]\n",
+			key:   []string{"pts", "0", "y"},
+			value: 7,
+			want:  "pts = [{x = 1, y = 7}, {x = 2}]\n",
+		},
+		{
+			name:  "append wraps remaining keys in tables",
+			doc:   "pts = [{x = 1}]\n",
+			key:   []string{"pts", "1", "x"},
+			value: 3,
+			want:  "pts = [{x = 1}, {x = 3}]\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if err := d.Set(test.key, test.value); err != nil {
+				t.Fatalf("Set(%q, %v): %v", test.key, test.value, err)
+			}
+			if got := d.String(); got != test.want {
+				t.Errorf("Set(%q, %v):\ngot:  %q\nwant: %q", test.key, test.value, got, test.want)
+			}
+			if got, ok := d.Get(test.key); !ok || !reflect.DeepEqual(got, int64(test.value.(int))) {
+				t.Errorf("Get(%q) after Set = %v, %v", test.key, got, ok)
+			}
+		})
+	}
+}
+
+func TestDeleteArrayTables(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		key  []string
+		want string
+	}{
+		{
+			name: "middle element",
+			doc:  "[[s]]\na = 1\n\n[[s]]\na = 2\n\n[[s]]\na = 3\n",
+			key:  []string{"s", "1"},
+			want: "[[s]]\na = 1\n\n[[s]]\na = 3\n",
+		},
+		{
+			name: "last element",
+			doc:  "[[s]]\na = 1\n\n[[s]]\na = 2\n",
+			key:  []string{"s", "1"},
+			want: "[[s]]\na = 1\n",
+		},
+		{
+			name: "only element",
+			doc:  "x = 1\n\n[[s]]\na = 1\n",
+			key:  []string{"s", "0"},
+			want: "x = 1\n",
+		},
+		{
+			name: "element with sub-table section",
+			doc:  "[[s]]\na = 1\n\n[s.opts]\nk = 1\n\n[[s]]\na = 2\n",
+			key:  []string{"s", "0"},
+			want: "[[s]]\na = 2\n",
+		},
+		{
+			name: "key inside element",
+			doc:  "[[s]]\na = 1\nb = 2\n",
+			key:  []string{"s", "0", "a"},
+			want: "[[s]]\nb = 2\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if !d.Delete(test.key) {
+				t.Fatalf("Delete(%q) = false", test.key)
+			}
+			if got := d.String(); got != test.want {
+				t.Errorf("Delete(%q):\ngot:  %q\nwant: %q", test.key, got, test.want)
+			}
+		})
+	}
+}
+
+func TestDeleteInline(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		key  []string
+		want string
+	}{
+		{
+			name: "first key of inline table",
+			doc:  "p = {a = 1, b = 2, c = 3}\n",
+			key:  []string{"p", "a"},
+			want: "p = {b = 2, c = 3}\n",
+		},
+		{
+			name: "last key of inline table",
+			doc:  "p = {a = 1, b = 2, c = 3}\n",
+			key:  []string{"p", "c"},
+			want: "p = {a = 1, b = 2}\n",
+		},
+		{
+			name: "only key of inline table",
+			doc:  "o = {a = 1}\n",
+			key:  []string{"o", "a"},
+			want: "o = {}\n",
+		},
+		{
+			name: "only key with trailing comma",
+			doc:  "o = {a = 1,}\n",
+			key:  []string{"o", "a"},
+			want: "o = {}\n",
+		},
+		{
+			name: "dotted key group",
+			doc:  "g = {a.b = 1, a.c = 2, z = 3}\n",
+			key:  []string{"g", "a"},
+			want: "g = {z = 3}\n",
+		},
+		{
+			name: "nested inline table key",
+			doc:  "p = {a = {b = 1, c = 2}}\n",
+			key:  []string{"p", "a", "b"},
+			want: "p = {a = {c = 2}}\n",
+		},
+		{
+			name: "first array element",
+			doc:  "arr = [1, 2, 3]\n",
+			key:  []string{"arr", "0"},
+			want: "arr = [2, 3]\n",
+		},
+		{
+			name: "last array element",
+			doc:  "arr = [1, 2, 3]\n",
+			key:  []string{"arr", "2"},
+			want: "arr = [1, 2]\n",
+		},
+		{
+			name: "only array element",
+			doc:  "arr = [1]\n",
+			key:  []string{"arr", "0"},
+			want: "arr = []\n",
+		},
+		{
+			name: "element of multi-line array",
+			doc:  "arr = [\n  1, # one\n  2,\n]\n",
+			key:  []string{"arr", "0"},
+			want: "arr = [\n  2,\n]\n",
+		},
+		{
+			name: "inline table element of array",
+			doc:  "pts = [{x = 1}, {x = 2}]\n",
+			key:  []string{"pts", "0"},
+			want: "pts = [{x = 2}]\n",
+		},
+		{
+			name: "key inside array element",
+			doc:  "pts = [{x = 1}, {x = 2}]\n",
+			key:  []string{"pts", "1", "x"},
+			want: "pts = [{x = 1}, {}]\n",
+		},
+		{
+			name: "nested array element",
+			doc:  "aa = [[1], [2, 3]]\n",
+			key:  []string{"aa", "1", "1"},
+			want: "aa = [[1], [2]]\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if !d.Delete(test.key) {
+				t.Fatalf("Delete(%q) = false", test.key)
+			}
+			if got := d.String(); got != test.want {
+				t.Errorf("Delete(%q):\ngot:  %q\nwant: %q", test.key, got, test.want)
+			}
+			// Deleting an array element shifts the following ones, so an
+			// index-ended path may legitimately still exist.
+			if _, isIdx := parseIndex(test.key[len(test.key)-1]); !isIdx && d.Has(test.key) {
+				t.Errorf("Has(%q) still true after Delete", test.key)
+			}
+		})
+	}
+}
+
+func TestComment(t *testing.T) {
+	doc := `# about a
+# on two lines
+a = 1 # trailing
+
+[t] # table side
+x = 1
+
+[[s]]
+y = 1
+`
+	d := mustParse(t, doc)
+
+	if got, ok := d.Comment([]string{"a"}); !ok || got != "about a\non two lines" {
+		t.Errorf("Comment(a) = %q, %v", got, ok)
+	}
+	if got, ok := d.TrailingComment([]string{"a"}); !ok || got != "trailing" {
+		t.Errorf("TrailingComment(a) = %q, %v", got, ok)
+	}
+	if got, ok := d.Comment([]string{"t"}); !ok || got != "" {
+		t.Errorf("Comment(t) = %q, %v", got, ok)
+	}
+	if got, ok := d.TrailingComment([]string{"t"}); !ok || got != "table side" {
+		t.Errorf("TrailingComment(t) = %q, %v", got, ok)
+	}
+	if got, ok := d.Comment([]string{"s", "0"}); !ok || got != "" {
+		t.Errorf("Comment(s.0) = %q, %v", got, ok)
+	}
+	if _, ok := d.Comment([]string{"missing"}); ok {
+		t.Error("Comment(missing) should not be ok")
+	}
+	if _, ok := d.Comment([]string{"s"}); ok {
+		t.Error("Comment on array of tables should not be ok")
+	}
+}
+
+func TestSetComment(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		key  []string
+		text string
+		want string
+	}{
+		{
+			name: "add to key-value",
+			doc:  "a = 1\n",
+			key:  []string{"a"},
+			text: "hi",
+			want: "# hi\na = 1\n",
+		},
+		{
+			name: "replace block",
+			doc:  "# keep\n\n# old\n# block\na = 1\nb = 2\n",
+			key:  []string{"a"},
+			text: "new",
+			want: "# keep\n\n# new\na = 1\nb = 2\n",
+		},
+		{
+			name: "remove block",
+			doc:  "# old\na = 1\n",
+			key:  []string{"a"},
+			text: "",
+			want: "a = 1\n",
+		},
+		{
+			name: "multi-line text",
+			doc:  "a = 1\n",
+			key:  []string{"a"},
+			text: "l1\n\nl3",
+			want: "# l1\n#\n# l3\na = 1\n",
+		},
+		{
+			name: "table header",
+			doc:  "[t]\nx = 1\n",
+			key:  []string{"t"},
+			text: "about t",
+			want: "# about t\n[t]\nx = 1\n",
+		},
+		{
+			name: "array-of-tables element",
+			doc:  "[[s]]\nx = 1\n\n[[s]]\nx = 2\n",
+			key:  []string{"s", "1"},
+			text: "second",
+			want: "[[s]]\nx = 1\n\n# second\n[[s]]\nx = 2\n",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if err := d.SetComment(test.key, test.text); err != nil {
+				t.Fatalf("SetComment(%q, %q): %v", test.key, test.text, err)
+			}
+			if got := d.String(); got != test.want {
+				t.Errorf("SetComment(%q, %q):\ngot:  %q\nwant: %q", test.key, test.text, got, test.want)
+			}
+			if got, _ := d.Comment(test.key); got != test.text {
+				t.Errorf("Comment(%q) after SetComment = %q, want %q", test.key, got, test.text)
+			}
+		})
+	}
+}
+
+func TestSetTrailingComment(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		key  []string
+		text string
+		want string
+	}{
+		{
+			name: "add to key-value",
+			doc:  "a = 1\n",
+			key:  []string{"a"},
+			text: "hi",
+			want: "a = 1 # hi\n",
+		},
+		{
+			name: "replace",
+			doc:  "a = 1 # old\n",
+			key:  []string{"a"},
+			text: "new",
+			want: "a = 1 # new\n",
+		},
+		{
+			name: "remove",
+			doc:  "a = 1 # old\n",
+			key:  []string{"a"},
+			text: "",
+			want: "a = 1\n",
+		},
+		{
+			name: "table header",
+			doc:  "[t]\nx = 1\n",
+			key:  []string{"t"},
+			text: "side",
+			want: "[t] # side\nx = 1\n",
+		},
+		{
+			name: "after multi-line value",
+			doc:  "arr = [\n  1,\n] # end\n",
+			key:  []string{"arr"},
+			text: "x",
+			want: "arr = [\n  1,\n] # x\n",
+		},
+		{
+			name: "key-value without trailing newline",
+			doc:  "a = 1",
+			key:  []string{"a"},
+			text: "hi",
+			want: "a = 1 # hi",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := mustParse(t, test.doc)
+			if err := d.SetTrailingComment(test.key, test.text); err != nil {
+				t.Fatalf("SetTrailingComment(%q, %q): %v", test.key, test.text, err)
+			}
+			if got := d.String(); got != test.want {
+				t.Errorf("SetTrailingComment(%q, %q):\ngot:  %q\nwant: %q", test.key, test.text, got, test.want)
+			}
+			if got, _ := d.TrailingComment(test.key); got != test.text {
+				t.Errorf("TrailingComment(%q) = %q, want %q", test.key, got, test.text)
+			}
+		})
+	}
+}
+
+func TestCommentErrors(t *testing.T) {
+	d := mustParse(t, "a.b = 1\np = {x = 1}\n\n[[s]]\ny = 1\n")
+	for _, key := range [][]string{
+		nil,                 // empty key
+		{"missing"},         // does not exist
+		{"a"},               // dotted table: no header line
+		{"p", "x"},          // inside an inline value
+		{"s"},               // array of tables, no index
+		{"s", "5"},          // element out of range
+		{"s", "not-an-int"}, // not an index
+	} {
+		if err := d.SetComment(key, "c"); err == nil {
+			t.Errorf("SetComment(%q): expected error", key)
+		}
+		if err := d.SetTrailingComment(key, "c"); err == nil {
+			t.Errorf("SetTrailingComment(%q): expected error", key)
+		}
+		if _, ok := d.Comment(key); ok {
+			t.Errorf("Comment(%q): expected not ok", key)
+		}
+		if _, ok := d.TrailingComment(key); ok {
+			t.Errorf("TrailingComment(%q): expected not ok", key)
+		}
+	}
+	if err := d.SetTrailingComment([]string{"p"}, "two\nlines"); err == nil {
+		t.Error("SetTrailingComment with newline: expected error")
+	}
+	if got := d.String(); got != "a.b = 1\np = {x = 1}\n\n[[s]]\ny = 1\n" {
+		t.Errorf("document changed by failed comment edits: %q", got)
+	}
+}
+
+func TestCommentCRLF(t *testing.T) {
+	d := mustParse(t, "a = 1\r\n")
+	if err := d.SetComment([]string{"a"}, "hi\nthere"); err != nil {
+		t.Fatal(err)
+	}
+	want := "# hi\r\n# there\r\na = 1\r\n"
+	if got := d.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if got, _ := d.Comment([]string{"a"}); got != "hi\nthere" {
+		t.Errorf("Comment = %q", got)
+	}
+}
+
+func TestRawMessage(t *testing.T) {
+	d := mustParse(t, "a = 1\n")
+	if err := d.Set([]string{"a"}, unstable.RawMessage("0x10")); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := d.String(), "a = 0x10\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+
+	// Raw values keep their exact representation, including multi-line
+	// strings that the regular rendering never produces.
+	if err := d.Set([]string{"m"}, unstable.RawMessage("\"\"\"\nhi\n\"\"\"")); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := d.String(), "a = 0x10\nm = \"\"\"\nhi\n\"\"\"\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	if v, _ := d.Get([]string{"m"}); v != "hi\n" {
+		t.Errorf("Get(m) = %q", v)
+	}
+
+	// Inside an inline value.
+	if err := d.Set([]string{"p", "x"}, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Set([]string{"p", "x"}, unstable.RawMessage("'raw'")); err != nil {
+		t.Fatal(err)
+	}
+	if v, _ := d.Get([]string{"p", "x"}); v != "raw" {
+		t.Errorf("Get(p.x) = %q", v)
+	}
+
+	// Invalid and empty raw values are rejected and leave the document
+	// unchanged.
+	before := d.String()
+	if err := d.Set([]string{"bad"}, unstable.RawMessage("= not toml")); err == nil {
+		t.Error("expected error for invalid raw value")
+	}
+	if err := d.Set([]string{"bad"}, unstable.RawMessage("  ")); err == nil {
+		t.Error("expected error for empty raw value")
+	}
+	if got := d.String(); got != before {
+		t.Errorf("document changed by failed raw edits: %q", got)
+	}
+}
+
+func TestGetIndexes(t *testing.T) {
+	d := mustParse(t, "arr = [1, [2, 3]]\n\n[[s]]\nv = 'a'\n\n[[s]]\nv = 'b'\n")
+	tests := []struct {
+		key  []string
+		want interface{}
+		ok   bool
+	}{
+		{[]string{"arr", "0"}, int64(1), true},
+		{[]string{"arr", "1", "1"}, int64(3), true},
+		{[]string{"s", "1", "v"}, "b", true},
+		{[]string{"arr", "2"}, nil, false},
+		{[]string{"arr", "x"}, nil, false},
+		{[]string{"s", "2", "v"}, nil, false},
+	}
+	for _, test := range tests {
+		got, ok := d.Get(test.key)
+		if ok != test.ok || (ok && !reflect.DeepEqual(got, test.want)) {
+			t.Errorf("Get(%q) = (%v, %v), want (%v, %v)", test.key, got, ok, test.want, test.ok)
+		}
+	}
+}

--- a/unstable/edit/feature_test.go
+++ b/unstable/edit/feature_test.go
@@ -573,6 +573,17 @@ func TestCommentCRLF(t *testing.T) {
 	if got, _ := d.Comment([]string{"a"}); got != "hi\nthere" {
 		t.Errorf("Comment = %q", got)
 	}
+
+	d = mustParse(t, "a = 1 # old\r\n")
+	if got, _ := d.TrailingComment([]string{"a"}); got != "old" {
+		t.Errorf("TrailingComment = %q", got)
+	}
+	if err := d.SetTrailingComment([]string{"a"}, "new"); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := d.String(), "a = 1 # new\r\n"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
 }
 
 func TestRawMessage(t *testing.T) {

--- a/unstable/edit/index.go
+++ b/unstable/edit/index.go
@@ -202,10 +202,7 @@ func (d *Document) exprSpan(e *unstable.Node) (int, int, error) {
 	// Table and ArrayTable nodes carry no Raw range: recover the header span
 	// from the key parts. Only whitespace can separate them from the
 	// brackets.
-	first, last, err := firstLastKey(e)
-	if err != nil {
-		return 0, 0, err
-	}
+	first, last := firstLastKey(e)
 	brackets := 1
 	if e.Kind == unstable.ArrayTable {
 		brackets = 2
@@ -239,10 +236,7 @@ func (d *Document) exprSpan(e *unstable.Node) (int, int, error) {
 // is recovered from the last key part instead: the value starts after the
 // '=' separator and ends where the key-value does.
 func (d *Document) valueSpan(e *unstable.Node) (span, error) {
-	_, last, err := firstLastKey(e)
-	if err != nil {
-		return span{}, err
-	}
+	_, last := firstLastKey(e)
 	i := int(last.Raw.Offset + last.Raw.Length)
 	for i < len(d.data) && (d.data[i] == ' ' || d.data[i] == '\t') {
 		i++
@@ -257,7 +251,10 @@ func (d *Document) valueSpan(e *unstable.Node) (span, error) {
 	return span{i, int(e.Raw.Offset + e.Raw.Length)}, nil
 }
 
-func firstLastKey(e *unstable.Node) (*unstable.Node, *unstable.Node, error) {
+// firstLastKey returns the first and last parts of the key of e. Key-value
+// and header expressions produced by the parser always have at least one key
+// part.
+func firstLastKey(e *unstable.Node) (*unstable.Node, *unstable.Node) {
 	var first, last *unstable.Node
 	it := e.Key()
 	for it.Next() {
@@ -266,10 +263,7 @@ func firstLastKey(e *unstable.Node) (*unstable.Node, *unstable.Node, error) {
 		}
 		last = it.Node()
 	}
-	if first == nil {
-		return nil, nil, fmt.Errorf("toml/edit: internal error: %s expression without key", e.Kind)
-	}
-	return first, last, nil
+	return first, last
 }
 
 func keyParts(e *unstable.Node) []string {

--- a/unstable/edit/index.go
+++ b/unstable/edit/index.go
@@ -21,22 +21,32 @@ type leaf struct {
 	line span
 	// value covers exactly the bytes of the value.
 	value span
+	// exprLine is the start of the line the key-value itself is on; the
+	// bytes between line.start and exprLine are the attached comments.
+	exprLine int
 }
 
 // table is a table of the document: the root, a [table] section, an element
 // of an [[array table]], or a table implied by a header or a dotted key.
 type table struct {
-	path []string
-	root bool
+	path   []string
+	parent *table
+	root   bool
 	// explicit tables have their own section in the document: a [header] (or
 	// [[header]] for array-table elements) followed by key-values.
 	explicit bool
-	section  span // for explicit tables: header start (incl. attached comments) to end of section
-	insertAt int  // for explicit tables and the root: where to insert a new key-value line
-	// dotted tables are defined by a dotted key inside the section of host;
-	// they have no section of their own and are extended with dotted keys.
+	// viaArray is set on array-table elements and everything below them:
+	// their absolute path is only meaningful relative to the last element of
+	// each array, so new sub-tables cannot be created with [headers].
+	viaArray   bool
+	section    span // for explicit tables: header start (incl. attached comments) to end of section
+	headerLine int  // for explicit tables: start of the [header] line itself
+	exprEnd    int  // for explicit tables: past the closing bracket of the header
+	insertAt   int  // for explicit tables and the root: where to insert a new key-value line
+	// dotted tables are defined by a dotted key inside the section of their
+	// nearest section ancestor; they have no header and are extended with
+	// dotted keys.
 	dotted bool
-	host   *table
 	items  map[string]*item
 }
 
@@ -47,8 +57,14 @@ type item struct {
 	arr  []*table // array of tables: one table per [[element]]
 }
 
-func newTable(path []string) *table {
-	return &table{path: path, items: map[string]*item{}}
+func newTable(parent *table, name string) *table {
+	t := &table{items: map[string]*item{}}
+	if parent != nil {
+		t.path = childPath(parent, name)
+		t.parent = parent
+		t.viaArray = parent.viaArray
+	}
+	return t
 }
 
 func childPath(t *table, name string) []string {
@@ -58,11 +74,20 @@ func childPath(t *table, name string) []string {
 	return p
 }
 
+// nearestSection returns the closest ancestor-or-self of t that has its own
+// section to insert key-values into: an explicit table or the root.
+func nearestSection(t *table) *table {
+	for !t.explicit && !t.root {
+		t = t.parent
+	}
+	return t
+}
+
 // reindex rebuilds the span index from d.data, which must be a valid TOML
 // document. Errors are only possible on invalid input and indicate a bug in
 // the caller.
 func (d *Document) reindex() error {
-	root := newTable(nil)
+	root := newTable(nil, "")
 	root.root = true
 	root.section = span{0, len(d.data)}
 	root.insertAt = -1
@@ -108,7 +133,7 @@ func (d *Document) reindex() error {
 			if err != nil {
 				return err
 			}
-			lf := &leaf{line: span{attach, le}, value: value}
+			lf := &leaf{line: span{attach, le}, value: value, exprLine: ls}
 			if err := addKeyValue(current, keyParts(e), lf); err != nil {
 				return err
 			}
@@ -121,6 +146,8 @@ func (d *Document) reindex() error {
 			}
 			t.explicit = true
 			t.section = span{attach, len(d.data)}
+			t.headerLine = ls
+			t.exprEnd = exprEnd
 			t.insertAt = le
 			if firstHeaderAttach < 0 {
 				firstHeaderAttach = attach
@@ -133,6 +160,8 @@ func (d *Document) reindex() error {
 				return err
 			}
 			elem.section = span{attach, len(d.data)}
+			elem.headerLine = ls
+			elem.exprEnd = exprEnd
 			elem.insertAt = le
 			if firstHeaderAttach < 0 {
 				firstHeaderAttach = attach
@@ -204,10 +233,11 @@ func (d *Document) exprSpan(e *unstable.Node) (int, int, error) {
 	return start, end, nil
 }
 
-// valueSpan returns the byte range of the value of a KeyValue expression.
+// valueSpan returns the byte range of the value of a KeyValue node, which
+// may be a top-level expression or a key-value inside an inline table.
 // Composite values (arrays, inline tables) carry no usable Raw range, so it
 // is recovered from the last key part instead: the value starts after the
-// '=' separator and ends where the expression does.
+// '=' separator and ends where the key-value does.
 func (d *Document) valueSpan(e *unstable.Node) (span, error) {
 	_, last, err := firstLastKey(e)
 	if err != nil {
@@ -260,7 +290,7 @@ func resolveHeader(root *table, parts []string) (*table, error) {
 		it := t.items[name]
 		switch {
 		case it == nil:
-			nt := newTable(childPath(t, name))
+			nt := newTable(t, name)
 			t.items[name] = &item{tbl: nt}
 			t = nt
 		case it.tbl != nil:
@@ -282,7 +312,7 @@ func appendArrayElement(root *table, parts []string) (*table, error) {
 		it := t.items[name]
 		switch {
 		case it == nil:
-			nt := newTable(childPath(t, name))
+			nt := newTable(t, name)
 			t.items[name] = &item{tbl: nt}
 			t = nt
 		case it.tbl != nil:
@@ -294,8 +324,9 @@ func appendArrayElement(root *table, parts []string) (*table, error) {
 		}
 	}
 	name := parts[len(parts)-1]
-	elem := newTable(childPath(t, name))
+	elem := newTable(t, name)
 	elem.explicit = true
+	elem.viaArray = true
 	it := t.items[name]
 	switch {
 	case it == nil:
@@ -316,9 +347,8 @@ func addKeyValue(sec *table, parts []string, lf *leaf) error {
 		it := t.items[name]
 		switch {
 		case it == nil:
-			nt := newTable(childPath(t, name))
+			nt := newTable(t, name)
 			nt.dotted = true
-			nt.host = sec
 			t.items[name] = &item{tbl: nt}
 			t = nt
 		case it.tbl != nil:
@@ -341,21 +371,27 @@ func addKeyValue(sec *table, parts []string, lf *leaf) error {
 func subtreeEnd(t *table) int {
 	end := t.section.end
 	for _, it := range t.items {
-		e := 0
+		var e int
 		switch {
 		case it.leaf != nil:
 			e = it.leaf.line.end
 		case it.tbl != nil:
 			e = subtreeEnd(it.tbl)
 		default:
-			for _, elem := range it.arr {
-				if se := subtreeEnd(elem); se > e {
-					e = se
-				}
-			}
+			e = arraySubtreeEnd(it.arr)
 		}
 		if e > end {
 			end = e
+		}
+	}
+	return end
+}
+
+func arraySubtreeEnd(arr []*table) int {
+	end := 0
+	for _, elem := range arr {
+		if se := subtreeEnd(elem); se > end {
+			end = se
 		}
 	}
 	return end
@@ -374,4 +410,20 @@ func (d *Document) lineEnd(off int) int {
 		return len(d.data)
 	}
 	return off + i + 1
+}
+
+// parseIndex interprets a key path element as an array index: a non-empty
+// string of decimal digits.
+func parseIndex(s string) (int, bool) {
+	if s == "" || len(s) > 18 {
+		return 0, false
+	}
+	n := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return 0, false
+		}
+		n = n*10 + int(s[i]-'0')
+	}
+	return n, true
 }

--- a/unstable/edit/index.go
+++ b/unstable/edit/index.go
@@ -1,0 +1,377 @@
+package edit
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// span is a range of bytes in the document.
+type span struct {
+	start, end int
+}
+
+// leaf is a key-value in the document.
+type leaf struct {
+	// line covers the whole key-value expression: from the start of the
+	// full-line comments attached above it to past the end of its last line
+	// (including any comment trailing the value).
+	line span
+	// value covers exactly the bytes of the value.
+	value span
+}
+
+// table is a table of the document: the root, a [table] section, an element
+// of an [[array table]], or a table implied by a header or a dotted key.
+type table struct {
+	path []string
+	root bool
+	// explicit tables have their own section in the document: a [header] (or
+	// [[header]] for array-table elements) followed by key-values.
+	explicit bool
+	section  span // for explicit tables: header start (incl. attached comments) to end of section
+	insertAt int  // for explicit tables and the root: where to insert a new key-value line
+	// dotted tables are defined by a dotted key inside the section of host;
+	// they have no section of their own and are extended with dotted keys.
+	dotted bool
+	host   *table
+	items  map[string]*item
+}
+
+// item is a named entry in a table: exactly one of leaf, tbl, or arr is set.
+type item struct {
+	leaf *leaf
+	tbl  *table
+	arr  []*table // array of tables: one table per [[element]]
+}
+
+func newTable(path []string) *table {
+	return &table{path: path, items: map[string]*item{}}
+}
+
+func childPath(t *table, name string) []string {
+	p := make([]string, len(t.path)+1)
+	copy(p, t.path)
+	p[len(t.path)] = name
+	return p
+}
+
+// reindex rebuilds the span index from d.data, which must be a valid TOML
+// document. Errors are only possible on invalid input and indicate a bug in
+// the caller.
+func (d *Document) reindex() error {
+	root := newTable(nil)
+	root.root = true
+	root.section = span{0, len(d.data)}
+	root.insertAt = -1
+
+	p := &unstable.Parser{KeepComments: true}
+	p.Reset(d.data)
+
+	current := root
+	firstHeaderAttach := -1
+	// Current run of contiguous full-line comments. A run that ends on the
+	// line right above an expression is attached to that expression: it
+	// moves, or is removed, with it.
+	runStart, runEnd := -1, -1
+
+	for p.NextExpression() {
+		e := p.Expression()
+
+		if e.Kind == unstable.Comment {
+			ls := d.lineStart(int(e.Raw.Offset))
+			le := d.lineEnd(int(e.Raw.Offset + e.Raw.Length))
+			if runEnd != ls {
+				runStart = ls
+			}
+			runEnd = le
+			continue
+		}
+
+		exprStart, exprEnd, err := d.exprSpan(e)
+		if err != nil {
+			return err
+		}
+		ls := d.lineStart(exprStart)
+		le := d.lineEnd(exprEnd)
+		attach := ls
+		if runEnd == ls {
+			attach = runStart
+		}
+		runStart, runEnd = -1, -1
+
+		switch e.Kind {
+		case unstable.KeyValue:
+			value, err := d.valueSpan(e)
+			if err != nil {
+				return err
+			}
+			lf := &leaf{line: span{attach, le}, value: value}
+			if err := addKeyValue(current, keyParts(e), lf); err != nil {
+				return err
+			}
+			current.insertAt = le
+		case unstable.Table:
+			current.section.end = attach
+			t, err := resolveHeader(root, keyParts(e))
+			if err != nil {
+				return err
+			}
+			t.explicit = true
+			t.section = span{attach, len(d.data)}
+			t.insertAt = le
+			if firstHeaderAttach < 0 {
+				firstHeaderAttach = attach
+			}
+			current = t
+		case unstable.ArrayTable:
+			current.section.end = attach
+			elem, err := appendArrayElement(root, keyParts(e))
+			if err != nil {
+				return err
+			}
+			elem.section = span{attach, len(d.data)}
+			elem.insertAt = le
+			if firstHeaderAttach < 0 {
+				firstHeaderAttach = attach
+			}
+			current = elem
+		default:
+			return fmt.Errorf("toml/edit: internal error: unexpected %s expression", e.Kind)
+		}
+	}
+	if err := p.Error(); err != nil {
+		return err
+	}
+	if current != root {
+		current.section.end = len(d.data)
+	}
+	if root.insertAt < 0 {
+		// No top-level key-value: new ones go before the first section
+		// (comments attached to its header included), or at the end of a
+		// document without sections.
+		if firstHeaderAttach >= 0 {
+			root.insertAt = firstHeaderAttach
+		} else {
+			root.insertAt = len(d.data)
+		}
+	}
+	d.root = root
+	return nil
+}
+
+// exprSpan returns the byte range of a top-level expression, from the first
+// byte of its key or opening bracket to past its value or closing bracket,
+// excluding surrounding whitespace and trailing comment.
+func (d *Document) exprSpan(e *unstable.Node) (int, int, error) {
+	if e.Kind == unstable.KeyValue {
+		return int(e.Raw.Offset), int(e.Raw.Offset + e.Raw.Length), nil
+	}
+
+	// Table and ArrayTable nodes carry no Raw range: recover the header span
+	// from the key parts. Only whitespace can separate them from the
+	// brackets.
+	first, last, err := firstLastKey(e)
+	if err != nil {
+		return 0, 0, err
+	}
+	brackets := 1
+	if e.Kind == unstable.ArrayTable {
+		brackets = 2
+	}
+	start := int(first.Raw.Offset)
+	for start > 0 && (d.data[start-1] == ' ' || d.data[start-1] == '\t') {
+		start--
+	}
+	for i := 0; i < brackets; i++ {
+		if start == 0 || d.data[start-1] != '[' {
+			return 0, 0, fmt.Errorf("toml/edit: internal error: cannot find opening bracket of %s header", e.Kind)
+		}
+		start--
+	}
+	end := int(last.Raw.Offset + last.Raw.Length)
+	for end < len(d.data) && (d.data[end] == ' ' || d.data[end] == '\t') {
+		end++
+	}
+	for i := 0; i < brackets; i++ {
+		if end >= len(d.data) || d.data[end] != ']' {
+			return 0, 0, fmt.Errorf("toml/edit: internal error: cannot find closing bracket of %s header", e.Kind)
+		}
+		end++
+	}
+	return start, end, nil
+}
+
+// valueSpan returns the byte range of the value of a KeyValue expression.
+// Composite values (arrays, inline tables) carry no usable Raw range, so it
+// is recovered from the last key part instead: the value starts after the
+// '=' separator and ends where the expression does.
+func (d *Document) valueSpan(e *unstable.Node) (span, error) {
+	_, last, err := firstLastKey(e)
+	if err != nil {
+		return span{}, err
+	}
+	i := int(last.Raw.Offset + last.Raw.Length)
+	for i < len(d.data) && (d.data[i] == ' ' || d.data[i] == '\t') {
+		i++
+	}
+	if i >= len(d.data) || d.data[i] != '=' {
+		return span{}, errors.New("toml/edit: internal error: cannot find '=' of key-value")
+	}
+	i++
+	for i < len(d.data) && (d.data[i] == ' ' || d.data[i] == '\t') {
+		i++
+	}
+	return span{i, int(e.Raw.Offset + e.Raw.Length)}, nil
+}
+
+func firstLastKey(e *unstable.Node) (*unstable.Node, *unstable.Node, error) {
+	var first, last *unstable.Node
+	it := e.Key()
+	for it.Next() {
+		if first == nil {
+			first = it.Node()
+		}
+		last = it.Node()
+	}
+	if first == nil {
+		return nil, nil, fmt.Errorf("toml/edit: internal error: %s expression without key", e.Kind)
+	}
+	return first, last, nil
+}
+
+func keyParts(e *unstable.Node) []string {
+	var parts []string
+	it := e.Key()
+	for it.Next() {
+		parts = append(parts, string(it.Node().Data))
+	}
+	return parts
+}
+
+// resolveHeader returns the table for a [header] expression, creating
+// implicit intermediate tables as needed. Traversing an array of tables
+// descends into its last element, per TOML semantics.
+func resolveHeader(root *table, parts []string) (*table, error) {
+	t := root
+	for i, name := range parts {
+		it := t.items[name]
+		switch {
+		case it == nil:
+			nt := newTable(childPath(t, name))
+			t.items[name] = &item{tbl: nt}
+			t = nt
+		case it.tbl != nil:
+			t = it.tbl
+		case it.arr != nil && i < len(parts)-1:
+			t = it.arr[len(it.arr)-1]
+		default:
+			return nil, fmt.Errorf("toml/edit: internal error: header %q redefines a value", parts)
+		}
+	}
+	return t, nil
+}
+
+// appendArrayElement appends a new element table to the array of tables
+// designated by an [[header]] expression, creating it if needed.
+func appendArrayElement(root *table, parts []string) (*table, error) {
+	t := root
+	for _, name := range parts[:len(parts)-1] {
+		it := t.items[name]
+		switch {
+		case it == nil:
+			nt := newTable(childPath(t, name))
+			t.items[name] = &item{tbl: nt}
+			t = nt
+		case it.tbl != nil:
+			t = it.tbl
+		case it.arr != nil:
+			t = it.arr[len(it.arr)-1]
+		default:
+			return nil, fmt.Errorf("toml/edit: internal error: array table header %q crosses a value", parts)
+		}
+	}
+	name := parts[len(parts)-1]
+	elem := newTable(childPath(t, name))
+	elem.explicit = true
+	it := t.items[name]
+	switch {
+	case it == nil:
+		t.items[name] = &item{arr: []*table{elem}}
+	case it.arr != nil:
+		it.arr = append(it.arr, elem)
+	default:
+		return nil, fmt.Errorf("toml/edit: internal error: array table header %q redefines a table or value", parts)
+	}
+	return elem, nil
+}
+
+// addKeyValue records a key-value parsed in the section of table sec,
+// creating the tables implied by dotted key parts as needed.
+func addKeyValue(sec *table, parts []string, lf *leaf) error {
+	t := sec
+	for _, name := range parts[:len(parts)-1] {
+		it := t.items[name]
+		switch {
+		case it == nil:
+			nt := newTable(childPath(t, name))
+			nt.dotted = true
+			nt.host = sec
+			t.items[name] = &item{tbl: nt}
+			t = nt
+		case it.tbl != nil:
+			t = it.tbl
+		default:
+			return fmt.Errorf("toml/edit: internal error: dotted key %q crosses a value", parts)
+		}
+	}
+	name := parts[len(parts)-1]
+	if t.items[name] != nil {
+		return fmt.Errorf("toml/edit: internal error: duplicate key %q", parts)
+	}
+	t.items[name] = &item{leaf: lf}
+	return nil
+}
+
+// subtreeEnd returns the offset right after the last byte of the document
+// that belongs to t or any of its descendants. It is where a new section for
+// a child of t is inserted.
+func subtreeEnd(t *table) int {
+	end := t.section.end
+	for _, it := range t.items {
+		e := 0
+		switch {
+		case it.leaf != nil:
+			e = it.leaf.line.end
+		case it.tbl != nil:
+			e = subtreeEnd(it.tbl)
+		default:
+			for _, elem := range it.arr {
+				if se := subtreeEnd(elem); se > e {
+					e = se
+				}
+			}
+		}
+		if e > end {
+			end = e
+		}
+	}
+	return end
+}
+
+// lineStart returns the offset of the first byte of the line off is on.
+func (d *Document) lineStart(off int) int {
+	return bytes.LastIndexByte(d.data[:off], '\n') + 1
+}
+
+// lineEnd returns the offset right past the newline ending the line off is
+// on, or the end of the document.
+func (d *Document) lineEnd(off int) int {
+	i := bytes.IndexByte(d.data[off:], '\n')
+	if i < 0 {
+		return len(d.data)
+	}
+	return off + i + 1
+}

--- a/unstable/edit/inline.go
+++ b/unstable/edit/inline.go
@@ -1,0 +1,331 @@
+package edit
+
+// Editing inside inline values (arrays and inline tables). The index only
+// records document-level structures, so when a path descends into the value
+// of a key-value, the value is re-parsed on demand and its sub-spans are
+// recovered from the AST: precise splices then rewrite only the element
+// being edited.
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+func rawEnd(n *unstable.Node) int {
+	return int(n.Raw.Offset + n.Raw.Length)
+}
+
+// leafValueNode re-parses the document and returns the AST node of the value
+// of lf. The node references the parser's arena, which stays alive as long
+// as the node does.
+func (d *Document) leafValueNode(lf *leaf) (*unstable.Node, error) {
+	p := &unstable.Parser{}
+	p.Reset(d.data)
+	for p.NextExpression() {
+		e := p.Expression()
+		if e.Kind == unstable.KeyValue && rawEnd(e) == lf.value.end {
+			return e.Value(), nil
+		}
+	}
+	return nil, errors.New("toml/edit: internal error: cannot locate key-value to edit")
+}
+
+// skipInlineTrivia advances past the bytes that may separate the elements of
+// an inline value: whitespace, newlines, comments, and (optionally) commas.
+func (d *Document) skipInlineTrivia(i int, skipComma bool) int {
+	for i < len(d.data) {
+		switch c := d.data[i]; {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			i++
+		case c == ',' && skipComma:
+			i++
+		case c == '#':
+			i = d.lineEnd(i)
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+// valueNodeEnd returns the offset right past a value node starting at start.
+// Composite nodes carry no usable Raw range, so their end is recovered by
+// walking their children and scanning for the closing bracket.
+func (d *Document) valueNodeEnd(n *unstable.Node, start int) (int, error) {
+	switch n.Kind {
+	case unstable.InlineTable:
+		pos := start + 1
+		it := n.Children()
+		for it.Next() {
+			pos = rawEnd(it.Node())
+		}
+		pos = d.skipInlineTrivia(pos, true)
+		if pos >= len(d.data) || d.data[pos] != '}' {
+			return 0, errors.New("toml/edit: internal error: cannot find '}' closing an inline table")
+		}
+		return pos + 1, nil
+	case unstable.Array:
+		elems, err := d.arrayElems(n, start)
+		if err != nil {
+			return 0, err
+		}
+		pos := start + 1
+		if len(elems) > 0 {
+			pos = elems[len(elems)-1].sp.end
+		}
+		pos = d.skipInlineTrivia(pos, true)
+		if pos >= len(d.data) || d.data[pos] != ']' {
+			return 0, errors.New("toml/edit: internal error: cannot find ']' closing an array")
+		}
+		return pos + 1, nil
+	default:
+		return rawEnd(n), nil
+	}
+}
+
+// elemNode is an element of an array with its byte span.
+type elemNode struct {
+	node *unstable.Node
+	sp   span
+}
+
+// arrayElems returns the elements of the array node starting at start ('[')
+// with their spans.
+func (d *Document) arrayElems(n *unstable.Node, start int) ([]elemNode, error) {
+	var elems []elemNode
+	pos := start + 1
+	it := n.Children()
+	for it.Next() {
+		c := it.Node()
+		cs := d.skipInlineTrivia(pos, true)
+		if c.Raw.Length > 0 {
+			cs = int(c.Raw.Offset)
+		}
+		ce, err := d.valueNodeEnd(c, cs)
+		if err != nil {
+			return nil, err
+		}
+		elems = append(elems, elemNode{c, span{cs, ce}})
+		pos = ce
+	}
+	return elems, nil
+}
+
+// kvNode is a key-value of an inline table with its key parts and byte span.
+type kvNode struct {
+	kv    *unstable.Node
+	parts []string
+	sp    span
+}
+
+func inlineTableKVs(n *unstable.Node) []kvNode {
+	var kvs []kvNode
+	it := n.Children()
+	for it.Next() {
+		kv := it.Node()
+		kvs = append(kvs, kvNode{kv, keyParts(kv), span{int(kv.Raw.Offset), rawEnd(kv)}})
+	}
+	return kvs
+}
+
+func kvSpans(kvs []kvNode) []span {
+	spans := make([]span, len(kvs))
+	for i, e := range kvs {
+		spans[i] = e.sp
+	}
+	return spans
+}
+
+func elemSpans(elems []elemNode) []span {
+	spans := make([]span, len(elems))
+	for i, e := range elems {
+		spans[i] = e.sp
+	}
+	return spans
+}
+
+func commonPrefix(a, b []string) int {
+	n := 0
+	for n < len(a) && n < len(b) && a[n] == b[n] {
+		n++
+	}
+	return n
+}
+
+// setInline handles Set when the path continues inside the value of lf.
+func (d *Document) setInline(lf *leaf, key []string, from int, value interface{}) error {
+	node, err := d.leafValueNode(lf)
+	if err != nil {
+		return err
+	}
+	s, err := d.inlineSetSplice(node, lf.value, key, from, value)
+	if err != nil {
+		return err
+	}
+	return d.apply(s)
+}
+
+func (d *Document) inlineSetSplice(n *unstable.Node, ns span, key []string, from int, value interface{}) (splice, error) {
+	switch n.Kind {
+	case unstable.InlineTable:
+		parts := key[from:]
+		kvs := inlineTableKVs(n)
+		for _, e := range kvs {
+			m := commonPrefix(e.parts, parts)
+			switch {
+			case m == len(e.parts):
+				// The key-value's full key lies on the path.
+				vs, err := d.valueSpan(e.kv)
+				if err != nil {
+					return splice{}, err
+				}
+				if m == len(parts) {
+					raw, err := d.renderValue(value)
+					if err != nil {
+						return splice{}, err
+					}
+					return splice{vs, raw}, nil
+				}
+				return d.inlineSetSplice(e.kv.Value(), vs, key, from+m, value)
+			case m == len(parts):
+				// The path stops at a table implied by this dotted key.
+				return splice{}, fmt.Errorf("toml/edit: cannot set %q: it is a table; delete it first or set its keys individually", pathString(key))
+			}
+		}
+		// Not found: add a new key-value to this inline table.
+		text, err := d.renderInlineKV(parts, value)
+		if err != nil {
+			return splice{}, err
+		}
+		return d.containerInsert(ns, kvSpans(kvs), text), nil
+
+	case unstable.Array:
+		idx, ok := parseIndex(key[from])
+		if !ok {
+			return splice{}, fmt.Errorf("toml/edit: cannot set %q: %q is an array and %q is not an index", pathString(key), pathString(key[:from]), key[from])
+		}
+		elems, err := d.arrayElems(n, ns.start)
+		if err != nil {
+			return splice{}, err
+		}
+		if idx > len(elems) {
+			return splice{}, fmt.Errorf("toml/edit: cannot set %q: index %d out of range: %q has %d elements",
+				pathString(key), idx, pathString(key[:from]), len(elems))
+		}
+		if idx == len(elems) {
+			// Append; the remaining key parts wrap the value in tables.
+			v := value
+			rest := key[from+1:]
+			for j := len(rest) - 1; j >= 0; j-- {
+				v = map[string]interface{}{rest[j]: v}
+			}
+			raw, err := d.renderValue(v)
+			if err != nil {
+				return splice{}, err
+			}
+			return d.containerInsert(ns, elemSpans(elems), raw), nil
+		}
+		if from == len(key)-1 {
+			raw, err := d.renderValue(value)
+			if err != nil {
+				return splice{}, err
+			}
+			return splice{elems[idx].sp, raw}, nil
+		}
+		return d.inlineSetSplice(elems[idx].node, elems[idx].sp, key, from+1, value)
+
+	default:
+		return splice{}, fmt.Errorf("toml/edit: cannot set %q: %q is not a table or array", pathString(key), pathString(key[:from]))
+	}
+}
+
+// deleteInline computes the splice removing the target of key inside the
+// value of lf. A dotted key group inside an inline table is removed one
+// key-value at a time: again reports that the caller must re-resolve the
+// path and call again to remove the rest of the group.
+func (d *Document) deleteInline(lf *leaf, key []string, from int) (splice, bool, bool) {
+	node, err := d.leafValueNode(lf)
+	if err != nil {
+		return splice{}, false, false
+	}
+	return d.inlineDeleteSplice(node, lf.value, key, from)
+}
+
+func (d *Document) inlineDeleteSplice(n *unstable.Node, ns span, key []string, from int) (splice, bool, bool) {
+	switch n.Kind {
+	case unstable.InlineTable:
+		parts := key[from:]
+		kvs := inlineTableKVs(n)
+		for k, e := range kvs {
+			m := commonPrefix(e.parts, parts)
+			switch {
+			case m == len(e.parts) && m == len(parts):
+				return d.containerDelete(ns, kvSpans(kvs), k), false, true
+			case m == len(e.parts):
+				vs, err := d.valueSpan(e.kv)
+				if err != nil {
+					return splice{}, false, false
+				}
+				return d.inlineDeleteSplice(e.kv.Value(), vs, key, from+m)
+			case m == len(parts):
+				// The path addresses a table implied by this dotted key:
+				// remove the whole key-value, then let the caller resolve
+				// again for the other key-values of the group.
+				return d.containerDelete(ns, kvSpans(kvs), k), true, true
+			}
+		}
+		return splice{}, false, false
+
+	case unstable.Array:
+		idx, ok := parseIndex(key[from])
+		if !ok {
+			return splice{}, false, false
+		}
+		elems, err := d.arrayElems(n, ns.start)
+		if err != nil || idx >= len(elems) {
+			return splice{}, false, false
+		}
+		if from == len(key)-1 {
+			return d.containerDelete(ns, elemSpans(elems), idx), false, true
+		}
+		return d.inlineDeleteSplice(elems[idx].node, elems[idx].sp, key, from+1)
+
+	default:
+		return splice{}, false, false
+	}
+}
+
+// containerInsert builds the splice adding text as a new element of the
+// inline container at ns whose current element spans are elems.
+func (d *Document) containerInsert(ns span, elems []span, text []byte) splice {
+	if len(elems) == 0 {
+		return splice{span{ns.start + 1, ns.start + 1}, text}
+	}
+	e := elems[len(elems)-1].end
+	if p := d.skipInlineTrivia(e, false); p < len(d.data) && d.data[p] == ',' {
+		// Reuse the trailing comma as the separator.
+		return splice{span{p + 1, p + 1}, append([]byte(" "), text...)}
+	}
+	return splice{span{e, e}, append([]byte(", "), text...)}
+}
+
+// containerDelete builds the splice removing element k of the inline
+// container at ns, keeping the separating commas balanced.
+func (d *Document) containerDelete(ns span, elems []span, k int) splice {
+	var s span
+	switch {
+	case len(elems) == 1:
+		s = span{ns.start + 1, elems[0].end}
+	case k < len(elems)-1:
+		return splice{span: span{elems[k].start, elems[k+1].start}}
+	default:
+		s = span{elems[k-1].end, elems[k].end}
+	}
+	// Absorb the trailing comma, if any.
+	if p := d.skipInlineTrivia(s.end, false); p < len(d.data) && d.data[p] == ',' {
+		s.end = p + 1
+	}
+	return splice{span: s}
+}

--- a/unstable/edit/mutate.go
+++ b/unstable/edit/mutate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
+	"github.com/pelletier/go-toml/v2/unstable"
 )
 
 // splice is a pending replacement of a byte range of the document. An empty
@@ -20,16 +21,19 @@ type splice struct {
 // Set sets the value at the given key path, creating the tables leading to
 // it as needed.
 //
-// If the path designates an existing key-value, only the bytes of its value
-// are replaced: comments and layout around it are preserved. Otherwise a new
-// `key = value` line is added at the end of the section of the closest
-// existing parent table, under new [table] headers or dotted keys as
-// appropriate. The value is rendered like toml.Marshal would, in inline
-// (single-line) form.
+// If the path designates an existing value, only the bytes of that value are
+// replaced: comments and layout around it are preserved. Paths descend into
+// arrays and inline tables; elements of arrays (of tables or not) are
+// addressed by a decimal index, and the index equal to the current length
+// appends a new element. Otherwise a new `key = value` line is added at the
+// end of the section of the closest existing parent table, under a new
+// [table] header or dotted keys as appropriate. Values are rendered like
+// toml.Marshal would, in inline (single-line) form; pass an
+// unstable.RawMessage to use an exact TOML representation instead.
 //
-// Setting a path that designates or crosses an existing table, array of
-// tables, or non-table value is an error: Set never silently discards parts
-// of the document. Delete first to replace a whole table.
+// Setting a path that designates an existing table or array of tables is an
+// error: Set never silently discards parts of the document. Delete first to
+// replace a whole table.
 func (d *Document) Set(key []string, value interface{}) error {
 	if len(key) == 0 {
 		return errors.New("toml/edit: key must have at least one element")
@@ -37,7 +41,7 @@ func (d *Document) Set(key []string, value interface{}) error {
 
 	t := d.root
 	i := 0
-	for ; i < len(key); i++ {
+	for i < len(key) {
 		it := t.items[key[i]]
 		if it == nil {
 			break
@@ -45,21 +49,39 @@ func (d *Document) Set(key []string, value interface{}) error {
 		last := i == len(key)-1
 		switch {
 		case it.leaf != nil:
-			if !last {
-				return fmt.Errorf("toml/edit: cannot set %q: %q is not a table", pathString(key), pathString(key[:i+1]))
+			if last {
+				raw, err := d.renderValue(value)
+				if err != nil {
+					return err
+				}
+				return d.apply(splice{it.leaf.value, raw})
 			}
-			raw, err := d.renderValue(value)
-			if err != nil {
-				return err
-			}
-			return d.apply(splice{it.leaf.value, raw})
+			return d.setInline(it.leaf, key, i+1, value)
 		case it.arr != nil:
-			return fmt.Errorf("toml/edit: cannot set %q: %q is an array of tables", pathString(key), pathString(key[:i+1]))
+			if last {
+				return fmt.Errorf("toml/edit: cannot set %q: it is an array of tables; address its elements by index or delete it first", pathString(key))
+			}
+			idx, ok := parseIndex(key[i+1])
+			if !ok {
+				return fmt.Errorf("toml/edit: cannot set %q: %q is an array of tables and %q is not an index", pathString(key), pathString(key[:i+1]), key[i+1])
+			}
+			if idx > len(it.arr) {
+				return fmt.Errorf("toml/edit: cannot set %q: index %d out of range: %q has %d elements", pathString(key), idx, pathString(key[:i+1]), len(it.arr))
+			}
+			if idx == len(it.arr) {
+				return d.appendElement(it.arr, key, i+2, value)
+			}
+			if i+1 == len(key)-1 {
+				return fmt.Errorf("toml/edit: cannot set %q: it is a table; delete it first or set its keys individually", pathString(key))
+			}
+			t = it.arr[idx]
+			i += 2
 		default:
 			if last {
 				return fmt.Errorf("toml/edit: cannot set %q: it is a table; delete it first or set its keys individually", pathString(key))
 			}
 			t = it.tbl
+			i++
 		}
 	}
 
@@ -69,25 +91,39 @@ func (d *Document) Set(key []string, value interface{}) error {
 		return fmt.Errorf("toml/edit: internal error: no keys left to create for %q", pathString(key))
 	}
 
-	if t.dotted {
-		// t was defined by a dotted key in the section of t.host: extend it
-		// the same way, relative to the host table.
-		rel := make([]string, 0, len(t.path)-len(t.host.path)+len(suffix))
-		rel = append(rel, t.path[len(t.host.path):]...)
+	// Tables defined by dotted keys, and tables inside array-of-tables
+	// elements that have no section of their own, are extended with dotted
+	// key-values in their nearest section.
+	if t.dotted || (t.viaArray && !t.explicit) {
+		sec := nearestSection(t)
+		rel := make([]string, 0, len(t.path)-len(sec.path)+len(suffix))
+		rel = append(rel, t.path[len(sec.path):]...)
 		rel = append(rel, suffix...)
 		line, err := d.renderDottedKV(rel, value)
 		if err != nil {
 			return err
 		}
-		return d.apply(d.insertion(t.host.insertAt, line, false))
+		return d.apply(d.insertion(sec.insertAt, line, false))
 	}
 
-	if (t.explicit || t.root) && len(suffix) == 1 {
-		line, err := d.renderKV(suffix[0], value)
-		if err != nil {
-			return err
+	if t.explicit || t.root {
+		if len(suffix) == 1 {
+			line, err := d.renderDottedKV(suffix, value)
+			if err != nil {
+				return err
+			}
+			return d.apply(d.insertion(t.insertAt, line, false))
 		}
-		return d.apply(d.insertion(t.insertAt, line, false))
+		if t.viaArray {
+			// A [header] below an array element would attach to the last
+			// element of the array, not necessarily this one: dotted keys
+			// stay unambiguous.
+			line, err := d.renderDottedKV(suffix, value)
+			if err != nil {
+				return err
+			}
+			return d.apply(d.insertion(t.insertAt, line, false))
+		}
 	}
 
 	// The remaining tables need a section of their own, placed right after
@@ -102,7 +138,7 @@ func (d *Document) Set(key []string, value interface{}) error {
 	if err != nil {
 		return err
 	}
-	kv, err := d.renderKV(suffix[len(suffix)-1], value)
+	kv, err := d.renderDottedKV(suffix[len(suffix)-1:], value)
 	if err != nil {
 		return err
 	}
@@ -111,33 +147,104 @@ func (d *Document) Set(key []string, value interface{}) error {
 	return d.apply(d.insertion(subtreeEnd(t), text, true))
 }
 
-// Delete removes the key-value, table, or array of tables at the given key
-// path, along with the comments attached to it. It returns true if something
-// was deleted. Deleting a table removes all its content, including sections
+// appendElement appends a new [[element]] to an existing array of tables,
+// initialized with the key-value described by key[restFrom:] and value.
+func (d *Document) appendElement(arr []*table, key []string, restFrom int, value interface{}) error {
+	rest := key[restFrom:]
+	if len(rest) == 0 {
+		return fmt.Errorf("toml/edit: cannot set %q: a new array element is a table; set its keys individually", pathString(key))
+	}
+	headerKey, err := d.renderKeyPath(arr[0].path)
+	if err != nil {
+		return err
+	}
+	kv, err := d.renderDottedKV(rest, value)
+	if err != nil {
+		return err
+	}
+	text := append([]byte("[["+headerKey+"]]"), d.eol()...)
+	text = append(text, kv...)
+	return d.apply(d.insertion(arraySubtreeEnd(arr), text, true))
+}
+
+// Delete removes the value, key-value, table, or array of tables at the
+// given key path, along with the comments attached to it. It returns true if
+// something was deleted. Elements of arrays are addressed by a decimal
+// index. Deleting a table removes all its content, including sections
 // defined elsewhere in the document.
 func (d *Document) Delete(key []string) bool {
+	// Document-level targets are removed in one batch. A target inside an
+	// inline value may be expressed by several key-values of a dotted group:
+	// those are removed one at a time, re-resolving the path in between.
+	deleted := false
+	for {
+		splices, again, found := d.resolveDelete(key)
+		if !found || d.apply(splices...) != nil {
+			return deleted
+		}
+		deleted = true
+		if !again {
+			return true
+		}
+	}
+}
+
+// resolveDelete computes the splices removing the target of key. again
+// reports that the deletion may be partial (one key-value of a dotted group)
+// and that the caller should resolve the path again after applying.
+func (d *Document) resolveDelete(key []string) ([]splice, bool, bool) {
 	if len(key) == 0 {
-		return false
+		return nil, false, false
 	}
 	t := d.root
-	for _, name := range key[:len(key)-1] {
-		it := t.items[name]
-		if it == nil || it.tbl == nil {
-			return false
+	i := 0
+	for i < len(key) {
+		it := t.items[key[i]]
+		if it == nil {
+			return nil, false, false
 		}
-		t = it.tbl
+		last := i == len(key)-1
+		switch {
+		case it.leaf != nil:
+			if last {
+				return d.deletionSplices([]span{it.leaf.line}), false, true
+			}
+			s, again, ok := d.deleteInline(it.leaf, key, i+1)
+			if !ok {
+				return nil, false, false
+			}
+			return []splice{s}, again, true
+		case it.arr != nil:
+			if last {
+				return d.deletionSplices(collectSpans(it, nil)), false, true
+			}
+			idx, ok := parseIndex(key[i+1])
+			if !ok || idx >= len(it.arr) {
+				return nil, false, false
+			}
+			if i+1 == len(key)-1 {
+				return d.deletionSplices(collectTableSpans(it.arr[idx], nil)), false, true
+			}
+			t = it.arr[idx]
+			i += 2
+		default:
+			if last {
+				return d.deletionSplices(collectSpans(it, nil)), false, true
+			}
+			t = it.tbl
+			i++
+		}
 	}
-	it := t.items[key[len(key)-1]]
-	if it == nil {
-		return false
-	}
+	return nil, false, false
+}
 
-	spans := mergeSpans(collectSpans(it, nil))
+func (d *Document) deletionSplices(spans []span) []splice {
+	spans = mergeSpans(spans)
 	splices := make([]splice, len(spans))
 	for i, s := range spans {
 		splices[i] = splice{span: d.absorbTrailingBlanks(s)}
 	}
-	return d.apply(splices...) == nil
+	return splices
 }
 
 // collectSpans accumulates the byte ranges expressing an item: key-value
@@ -291,18 +398,16 @@ func renderKVLine(name string, value interface{}) ([]byte, error) {
 	return line, nil
 }
 
-// renderKV renders a `key = value` line ending with the document's line
-// ending.
-func (d *Document) renderKV(name string, value interface{}) ([]byte, error) {
-	line, err := renderKVLine(name, value)
-	if err != nil {
-		return nil, err
-	}
-	return d.withEOL(line), nil
-}
-
-// renderValue renders the bare TOML representation of a value.
+// renderValue renders the bare TOML representation of a value. An
+// unstable.RawMessage is used as-is.
 func (d *Document) renderValue(value interface{}) ([]byte, error) {
+	if raw, ok := value.(unstable.RawMessage); ok {
+		raw = bytes.TrimSpace(raw)
+		if len(raw) == 0 {
+			return nil, errors.New("toml/edit: raw value is empty")
+		}
+		return bytes.Clone(raw), nil
+	}
 	line, err := renderKVLine("v", value)
 	if err != nil {
 		return nil, err
@@ -314,9 +419,9 @@ func (d *Document) renderValue(value interface{}) ([]byte, error) {
 	return line[len(prefix) : len(line)-1], nil
 }
 
-// renderDottedKV renders a `dotted.key = value` line ending with the
-// document's line ending.
-func (d *Document) renderDottedKV(parts []string, value interface{}) ([]byte, error) {
+// renderInlineKV renders a `dotted.key = value` fragment without a line
+// ending, as used inside inline tables.
+func (d *Document) renderInlineKV(parts []string, value interface{}) ([]byte, error) {
 	kp, err := d.renderKeyPath(parts)
 	if err != nil {
 		return nil, err
@@ -325,11 +430,21 @@ func (d *Document) renderDottedKV(parts []string, value interface{}) ([]byte, er
 	if err != nil {
 		return nil, err
 	}
-	line := make([]byte, 0, len(kp)+len(v)+5)
-	line = append(line, kp...)
-	line = append(line, " = "...)
-	line = append(line, v...)
-	return append(line, d.eol()...), nil
+	b := make([]byte, 0, len(kp)+len(v)+3)
+	b = append(b, kp...)
+	b = append(b, " = "...)
+	b = append(b, v...)
+	return b, nil
+}
+
+// renderDottedKV renders a `dotted.key = value` line ending with the
+// document's line ending.
+func (d *Document) renderDottedKV(parts []string, value interface{}) ([]byte, error) {
+	b, err := d.renderInlineKV(parts, value)
+	if err != nil {
+		return nil, err
+	}
+	return append(b, d.eol()...), nil
 }
 
 // renderKeyPath renders a dotted key path, quoting the parts that need it
@@ -348,15 +463,6 @@ func (d *Document) renderKeyPath(parts []string) (string, error) {
 		rendered[i] = string(line[:len(line)-len(suffix)])
 	}
 	return strings.Join(rendered, "."), nil
-}
-
-func (d *Document) withEOL(line []byte) []byte {
-	// line ends with '\n'; rewrite it as CRLF if the document uses CRLF.
-	eol := d.eol()
-	if len(eol) == 2 {
-		line = append(line[:len(line)-1], eol...)
-	}
-	return line
 }
 
 func pathString(key []string) string {

--- a/unstable/edit/mutate.go
+++ b/unstable/edit/mutate.go
@@ -1,0 +1,364 @@
+package edit
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// splice is a pending replacement of a byte range of the document. An empty
+// range is an insertion; an empty repl is a deletion.
+type splice struct {
+	span
+	repl []byte
+}
+
+// Set sets the value at the given key path, creating the tables leading to
+// it as needed.
+//
+// If the path designates an existing key-value, only the bytes of its value
+// are replaced: comments and layout around it are preserved. Otherwise a new
+// `key = value` line is added at the end of the section of the closest
+// existing parent table, under new [table] headers or dotted keys as
+// appropriate. The value is rendered like toml.Marshal would, in inline
+// (single-line) form.
+//
+// Setting a path that designates or crosses an existing table, array of
+// tables, or non-table value is an error: Set never silently discards parts
+// of the document. Delete first to replace a whole table.
+func (d *Document) Set(key []string, value interface{}) error {
+	if len(key) == 0 {
+		return errors.New("toml/edit: key must have at least one element")
+	}
+
+	t := d.root
+	i := 0
+	for ; i < len(key); i++ {
+		it := t.items[key[i]]
+		if it == nil {
+			break
+		}
+		last := i == len(key)-1
+		switch {
+		case it.leaf != nil:
+			if !last {
+				return fmt.Errorf("toml/edit: cannot set %q: %q is not a table", pathString(key), pathString(key[:i+1]))
+			}
+			raw, err := d.renderValue(value)
+			if err != nil {
+				return err
+			}
+			return d.apply(splice{it.leaf.value, raw})
+		case it.arr != nil:
+			return fmt.Errorf("toml/edit: cannot set %q: %q is an array of tables", pathString(key), pathString(key[:i+1]))
+		default:
+			if last {
+				return fmt.Errorf("toml/edit: cannot set %q: it is a table; delete it first or set its keys individually", pathString(key))
+			}
+			t = it.tbl
+		}
+	}
+
+	// key[i:] does not exist and t is the deepest existing table on the path.
+	suffix := key[i:]
+	if len(suffix) == 0 {
+		return fmt.Errorf("toml/edit: internal error: no keys left to create for %q", pathString(key))
+	}
+
+	if t.dotted {
+		// t was defined by a dotted key in the section of t.host: extend it
+		// the same way, relative to the host table.
+		rel := make([]string, 0, len(t.path)-len(t.host.path)+len(suffix))
+		rel = append(rel, t.path[len(t.host.path):]...)
+		rel = append(rel, suffix...)
+		line, err := d.renderDottedKV(rel, value)
+		if err != nil {
+			return err
+		}
+		return d.apply(d.insertion(t.host.insertAt, line, false))
+	}
+
+	if (t.explicit || t.root) && len(suffix) == 1 {
+		line, err := d.renderKV(suffix[0], value)
+		if err != nil {
+			return err
+		}
+		return d.apply(d.insertion(t.insertAt, line, false))
+	}
+
+	// The remaining tables need a section of their own, placed right after
+	// everything that belongs to t. A single header with the full dotted
+	// path creates all of them. t may be an implicit table (only defined
+	// through the headers of its sub-tables): declaring its header afterwards
+	// is valid TOML.
+	headerPath := make([]string, 0, len(t.path)+len(suffix)-1)
+	headerPath = append(headerPath, t.path...)
+	headerPath = append(headerPath, suffix[:len(suffix)-1]...)
+	headerKey, err := d.renderKeyPath(headerPath)
+	if err != nil {
+		return err
+	}
+	kv, err := d.renderKV(suffix[len(suffix)-1], value)
+	if err != nil {
+		return err
+	}
+	text := append([]byte("["+headerKey+"]"), d.eol()...)
+	text = append(text, kv...)
+	return d.apply(d.insertion(subtreeEnd(t), text, true))
+}
+
+// Delete removes the key-value, table, or array of tables at the given key
+// path, along with the comments attached to it. It returns true if something
+// was deleted. Deleting a table removes all its content, including sections
+// defined elsewhere in the document.
+func (d *Document) Delete(key []string) bool {
+	if len(key) == 0 {
+		return false
+	}
+	t := d.root
+	for _, name := range key[:len(key)-1] {
+		it := t.items[name]
+		if it == nil || it.tbl == nil {
+			return false
+		}
+		t = it.tbl
+	}
+	it := t.items[key[len(key)-1]]
+	if it == nil {
+		return false
+	}
+
+	spans := mergeSpans(collectSpans(it, nil))
+	splices := make([]splice, len(spans))
+	for i, s := range spans {
+		splices[i] = splice{span: d.absorbTrailingBlanks(s)}
+	}
+	return d.apply(splices...) == nil
+}
+
+// collectSpans accumulates the byte ranges expressing an item: key-value
+// lines and whole sections. Ranges may overlap (a section contains the lines
+// of its key-values): mergeSpans resolves that.
+func collectSpans(it *item, spans []span) []span {
+	switch {
+	case it.leaf != nil:
+		spans = append(spans, it.leaf.line)
+	case it.tbl != nil:
+		spans = collectTableSpans(it.tbl, spans)
+	default:
+		for _, elem := range it.arr {
+			spans = collectTableSpans(elem, spans)
+		}
+	}
+	return spans
+}
+
+func collectTableSpans(t *table, spans []span) []span {
+	if t.explicit {
+		spans = append(spans, t.section)
+	}
+	for _, child := range t.items {
+		spans = collectSpans(child, spans)
+	}
+	return spans
+}
+
+func mergeSpans(spans []span) []span {
+	sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+	out := spans[:0]
+	for _, s := range spans {
+		if n := len(out); n > 0 && s.start <= out[n-1].end {
+			if s.end > out[n-1].end {
+				out[n-1].end = s.end
+			}
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// apply replaces the given byte ranges, then validates and re-indexes the
+// document. If the result is not a valid TOML document, no change is made.
+func (d *Document) apply(splices ...splice) error {
+	sort.Slice(splices, func(i, j int) bool { return splices[i].start < splices[j].start })
+	var buf bytes.Buffer
+	prev := 0
+	for _, s := range splices {
+		if s.start < prev {
+			return errors.New("toml/edit: internal error: overlapping edits")
+		}
+		buf.Write(d.data[prev:s.start])
+		buf.Write(s.repl)
+		prev = s.end
+	}
+	buf.Write(d.data[prev:])
+	data := buf.Bytes()
+
+	var v interface{}
+	if err := toml.Unmarshal(data, &v); err != nil {
+		return fmt.Errorf("toml/edit: edit would produce an invalid TOML document: %w", err)
+	}
+
+	oldData, oldRoot := d.data, d.root
+	d.data = data
+	if err := d.reindex(); err != nil {
+		d.data, d.root = oldData, oldRoot
+		return fmt.Errorf("toml/edit: edit would produce an invalid TOML document: %w", err)
+	}
+	return nil
+}
+
+// insertion builds the splice inserting text (one or more full lines, ending
+// with a newline) at pos, which is always a line boundary or the end of the
+// document. Sections get a blank line separating them from the surrounding
+// expressions.
+func (d *Document) insertion(pos int, text []byte, section bool) splice {
+	eol := d.eol()
+	var b []byte
+	freshLine := pos == 0 || d.data[pos-1] == '\n'
+	if !freshLine {
+		// Only possible at the end of a document with no final newline.
+		b = append(b, eol...)
+	}
+	if section && pos > 0 && (!freshLine || !d.blankLineBefore(pos)) {
+		b = append(b, eol...)
+	}
+	b = append(b, text...)
+	if section && pos < len(d.data) {
+		b = append(b, eol...)
+	}
+	return splice{span{pos, pos}, b}
+}
+
+// absorbTrailingBlanks extends a deletion reaching the end of the document
+// over the blank lines that separated it from the content above, so that the
+// document does not end with stray blank lines.
+func (d *Document) absorbTrailingBlanks(s span) span {
+	if s.end != len(d.data) {
+		return s
+	}
+	for s.start > 0 && d.data[s.start-1] == '\n' && d.blankLineBefore(s.start) {
+		i := s.start - 1
+		if i > 0 && d.data[i-1] == '\r' {
+			i--
+		}
+		s.start = i
+	}
+	return s
+}
+
+// blankLineBefore reports whether the line ending at pos (excluded) is
+// empty. Only meaningful when pos is a line boundary.
+func (d *Document) blankLineBefore(pos int) bool {
+	i := pos - 1 // d.data[i] == '\n'
+	if i > 0 && d.data[i-1] == '\r' {
+		i--
+	}
+	return i == 0 || d.data[i-1] == '\n'
+}
+
+// eol returns the line ending to use for inserted lines: CRLF if the
+// document already uses it, LF otherwise.
+func (d *Document) eol() []byte {
+	if bytes.Contains(d.data, []byte("\r\n")) {
+		return []byte("\r\n")
+	}
+	return []byte("\n")
+}
+
+// renderKVLine renders a complete `key = value` line (terminated by '\n')
+// with the toml encoder, so that key quoting and value formatting follow
+// Marshal conventions exactly. Values render in inline form; a value that
+// cannot render to a single line is an error.
+func renderKVLine(name string, value interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := toml.NewEncoder(&buf)
+	enc.SetTablesInline(true)
+	if err := enc.Encode(map[string]interface{}{name: value}); err != nil {
+		return nil, fmt.Errorf("toml/edit: cannot render value: %w", err)
+	}
+	line := buf.Bytes()
+	// A value the encoder omits instead of erroring on (e.g. a nil map
+	// value) renders to nothing.
+	if len(line) == 0 || line[len(line)-1] != '\n' || bytes.IndexByte(line, '\n') != len(line)-1 {
+		return nil, fmt.Errorf("toml/edit: cannot render value of type %T as a single key-value line", value)
+	}
+	return line, nil
+}
+
+// renderKV renders a `key = value` line ending with the document's line
+// ending.
+func (d *Document) renderKV(name string, value interface{}) ([]byte, error) {
+	line, err := renderKVLine(name, value)
+	if err != nil {
+		return nil, err
+	}
+	return d.withEOL(line), nil
+}
+
+// renderValue renders the bare TOML representation of a value.
+func (d *Document) renderValue(value interface{}) ([]byte, error) {
+	line, err := renderKVLine("v", value)
+	if err != nil {
+		return nil, err
+	}
+	prefix := []byte("v = ")
+	if !bytes.HasPrefix(line, prefix) {
+		return nil, errors.New("toml/edit: internal error: unexpected encoder output for value")
+	}
+	return line[len(prefix) : len(line)-1], nil
+}
+
+// renderDottedKV renders a `dotted.key = value` line ending with the
+// document's line ending.
+func (d *Document) renderDottedKV(parts []string, value interface{}) ([]byte, error) {
+	kp, err := d.renderKeyPath(parts)
+	if err != nil {
+		return nil, err
+	}
+	v, err := d.renderValue(value)
+	if err != nil {
+		return nil, err
+	}
+	line := make([]byte, 0, len(kp)+len(v)+5)
+	line = append(line, kp...)
+	line = append(line, " = "...)
+	line = append(line, v...)
+	return append(line, d.eol()...), nil
+}
+
+// renderKeyPath renders a dotted key path, quoting the parts that need it
+// the same way the toml encoder does.
+func (d *Document) renderKeyPath(parts []string) (string, error) {
+	rendered := make([]string, len(parts))
+	for i, part := range parts {
+		line, err := renderKVLine(part, 0)
+		if err != nil {
+			return "", err
+		}
+		suffix := []byte(" = 0\n")
+		if !bytes.HasSuffix(line, suffix) {
+			return "", errors.New("toml/edit: internal error: unexpected encoder output for key")
+		}
+		rendered[i] = string(line[:len(line)-len(suffix)])
+	}
+	return strings.Join(rendered, "."), nil
+}
+
+func (d *Document) withEOL(line []byte) []byte {
+	// line ends with '\n'; rewrite it as CRLF if the document uses CRLF.
+	eol := d.eol()
+	if len(eol) == 2 {
+		line = append(line[:len(line)-1], eol...)
+	}
+	return line
+}
+
+func pathString(key []string) string {
+	return strings.Join(key, ".")
+}


### PR DESCRIPTION
## Summary

New package `unstable/edit`: comment- and layout-preserving editing of TOML documents. Parse a document, then `Get`, `Set`, and `Delete` values by key path, and read/write comments — only the bytes expressing an edit are rewritten; everything else (comments, whitespace, ordering, line endings) is preserved byte-for-byte.

This is the capability go-toml v1 had (and v2 dropped) that keeps coming up (#822): the thing `toml_edit` (Rust, powers `cargo add`) and `tomlkit` (Python) exist for, with no Go equivalent today. Any CLI that wants to edit a user's config file without destroying their comments currently has no good option.

```go
d, _ := edit.Parse(src)
d.Set([]string{"server", "port"}, 5433)          // rewrites just the value bytes
d.Set([]string{"servers", "2", "ip"}, "10.0.0.4") // appends a [[servers]] element
d.SetComment([]string{"server"}, "Connection settings.")
d.Delete([]string{"old-option"})
out := d.Bytes()
```

## Design

Span-based splicing over the original bytes, not a CST: the `Document` keeps the source verbatim plus an index of where every table section and key-value lives, built with the existing `unstable.Parser` in `KeepComments` mode. Untouched regions are preserved exactly *by construction* rather than by careful re-rendering — that's where fidelity bugs live in CST-based editors.

- Every mutation is applied as byte-range splices, then **re-validated with `toml.Unmarshal` and re-indexed; on failure the document is left unchanged** and an error is returned.
- Values and keys are rendered through the regular `toml.Encoder` (inline mode), so quoting and formatting match `Marshal` exactly; `unstable.RawMessage` passes through verbatim for exact representations (multi-line strings, hex literals, ...).
- Comments travel with the expression they annotate: the attached leading block and the trailing comment move and are deleted with their key-value or header.
- Array elements (of tables or not) are addressed by decimal-index path elements — unambiguous since an array and a table cannot share a path; an index equal to the length appends, including new `[[table]]` sections.
- `Set`/`Delete` descend into inline tables and arrays with precise sub-splices (commas kept balanced, dotted keys inside inline tables supported).
- New tables get a single `[full.path]` header placed after their closest existing parent — except under array-of-tables elements or dotted-defined tables, where dotted keys are used (a header there would attach to the wrong element / be invalid TOML).
- `Set` onto an existing table or array of tables is an error by design: the API never silently discards parts of the document; `Delete` first to replace wholesale.

The package favors correctness over speed (documents are re-indexed after each mutation) and is documented as such: it is for editing config files, not hot paths.

## Performance

No existing file is modified (the only non-new-file change is a README paragraph), so the public API and the performance of existing benchmarks are unchanged by construction — benchmark binaries of the root package do not even link the new package.

## Testing

- 27 tests / ~180 cases: golden-output tables for every edit rule (replacement, insertion positions, section creation, comment attachment, CRLF, trailing commas, dotted groups, ...), plus round-trip fidelity over a corpus of gnarly documents and `benchmark/benchmark.toml`.
- An exhaustive sweep that Sets and Deletes **every addressable path of every corpus document** (array elements included) and checks validity and decoded results.
- Error-path tests asserting failed edits leave the document byte-identical.
- `go test -race ./...` green, new-package coverage 94.2% (uncovered lines are defensive internal-error branches), golangci-lint v2.8.0 clean, `./caps.sh check` clean (no new capabilities).

Related to #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
