### PR TITLE
perf: parse wide-significand floats exactly without strconv

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"math/bits"
 	"strconv"
 	"time"
 
@@ -249,17 +250,24 @@ exponent:
 		// Trailing bytes (an underscore, a hexadecimal marker, ...).
 		return 0, false
 	}
-	if mantissa > 1<<53 {
-		return 0, false
-	}
 
-	f := float64(mantissa)
+	var f float64
 	switch {
-	case exp == 0:
-	case exp > 0 && exp <= 22:
-		f *= float64pow10[exp]
-	case exp < 0 && exp >= -22:
-		f /= float64pow10[-exp]
+	case mantissa <= 1<<53 && exp == 0:
+		f = float64(mantissa)
+	case mantissa <= 1<<53 && exp > 0 && exp <= 22:
+		f = float64(mantissa) * float64pow10[exp]
+	case mantissa <= 1<<53 && exp < 0 && exp >= -22:
+		f = float64(mantissa) / float64pow10[-exp]
+	case exp >= -27 && exp <= 27:
+		// The significand does not fit in 53 bits (or the exponent is a bit
+		// past the exact float64 powers of ten): compute the correctly
+		// rounded result with exact 128-bit integer arithmetic.
+		var ok bool
+		f, ok = wideParseFloat(mantissa, exp)
+		if !ok {
+			return 0, false
+		}
 	default:
 		return 0, false
 	}
@@ -267,6 +275,82 @@ exponent:
 		f = -f
 	}
 	return f, true
+}
+
+// uint64pow5 holds the powers of five that fit in a uint64 (5^0 .. 5^27).
+var uint64pow5 = [...]uint64{
+	1, 5, 25, 125, 625, 3125, 15625, 78125, 390625, 1953125, 9765625,
+	48828125, 244140625, 1220703125, 6103515625, 30517578125, 152587890625,
+	762939453125, 3814697265625, 19073486328125, 95367431640625,
+	476837158203125, 2384185791015625, 11920928955078125, 59604644775390625,
+	298023223876953125, 1490116119384765625, 7450580596923828125,
+}
+
+// wideParseFloat returns the float64 nearest to mantissa * 10^exp for
+// exponents within [-27, 27], the range where 5^|exp| is an exact uint64. It
+// is exact: 10^exp = 5^exp * 2^exp, the power of two is folded into the
+// binary exponent, and the power of five is applied with exact 128-bit
+// integer arithmetic (a full multiply, or a divide keeping the remainder), so
+// the round-to-nearest-even decision is taken on the true value.
+func wideParseFloat(mantissa uint64, exp int) (float64, bool) {
+	switch {
+	case mantissa == 0:
+		return 0, true
+	case exp == 0:
+		// Go guarantees correctly rounded uint64 to float64 conversions.
+		return float64(mantissa), true
+	case exp > 0:
+		if exp >= len(uint64pow5) {
+			return 0, false
+		}
+		// value = (mantissa * 5^exp) * 2^exp, with the product exact on 128
+		// bits.
+		hi, lo := bits.Mul64(mantissa, uint64pow5[exp])
+		if hi == 0 {
+			return roundFloat64(lo, exp, false), true
+		}
+		sh := uint(bits.Len64(hi)) //nolint:gosec // Len64 is in [1, 64]
+		top := hi<<(64-sh) | lo>>sh
+		sticky := lo<<(64-sh) != 0
+		return roundFloat64(top, exp+int(sh), sticky), true //nolint:gosec // sh is in [1, 64]
+	default:
+		p := -exp
+		if p >= len(uint64pow5) {
+			return 0, false
+		}
+		// value = (mantissa / 5^p) * 2^exp. Shift the mantissa up so the
+		// 128/64-bit division yields a quotient with 55 to 63 significant
+		// bits, then round with the exact remainder.
+		d := uint64pow5[p]
+		t := bits.Len64(d) + 58 - bits.Len64(mantissa)
+		if t < 0 {
+			t = 0
+		}
+		var hi, lo uint64
+		if t >= 64 {
+			hi, lo = mantissa<<(t-64), 0
+		} else {
+			hi, lo = mantissa>>(64-t), mantissa<<t
+		}
+		q, r := bits.Div64(hi, lo, d)
+		return roundFloat64(q, exp-t, r != 0), true
+	}
+}
+
+// roundFloat64 returns the float64 nearest to (top + ε) * 2^exp2, where ε
+// stands for the value of extra bits strictly below top's last bit: zero when
+// sticky is false, in (0, 1) when it is true. top must have at least 54
+// significant bits, so that the mantissa and its rounding bit are all in-word.
+func roundFloat64(top uint64, exp2 int, sticky bool) float64 {
+	s := uint(bits.Len64(top) - 53) //nolint:gosec // top has at least 54 significant bits
+	mant := top >> s
+	rem := top & (1<<s - 1)
+	half := uint64(1) << (s - 1)
+	if rem > half || (rem == half && (sticky || mant&1 == 1)) {
+		// mant can reach 1<<53, which is still exactly representable.
+		mant++
+	}
+	return math.Ldexp(float64(mant), exp2+int(s)) //nolint:gosec // s is in [1, 11]
 }
 
 func isDecimalDigit(c byte) bool {

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,6 +1,9 @@
 package toml
 
 import (
+	"math"
+	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/pelletier/go-toml/v2/internal/assert"
@@ -25,4 +28,74 @@ func TestParseLocalDateTimeInvalidSeparator(t *testing.T) {
 func TestParseDateTimeMissingTimezone(t *testing.T) {
 	_, err := parseDateTime([]byte("2021-01-01T00:00:00"))
 	assert.Error(t, err)
+}
+
+// TestParseFloatWideSignificand exercises the exact 128-bit path used when the
+// significand does not fit in 53 bits or the exponent is outside the exact
+// float64 powers of ten, comparing bit patterns against strconv.
+func TestParseFloatWideSignificand(t *testing.T) {
+	cases := []string{
+		// 17 significant digits (coordinate-style data): > 2^53.
+		"45.302308000000002", "-65.613616999999977", "43.420273000000009",
+		// 19 digits, the maximum accumulated.
+		"9999999999999999999.0", "1234567890123456789.0",
+		"-9223372036854775809.5",
+		// Exponents just outside the Clinger range on both sides.
+		"1e23", "-1e23", "1e27", "1e-23", "1e-27", "7e26", "7e-26",
+		"123456789012345678e-27", "999999999999999999e27",
+		// Half-way and boundary cases around the 53-bit mantissa limit.
+		"9007199254740993.0", "9007199254740994.0", "9007199254740995.0",
+		"18014398509481985.0", "4503599627370497.5",
+		// Wide fractions with trailing digits forcing sticky-bit rounding.
+		"2.00000000000000011", "1.00000000000000033",
+		// Zero mantissa through the wide path.
+		"0.00000000000000000000000",
+	}
+	for _, s := range cases {
+		want, err := strconv.ParseFloat(s, 64)
+		assert.NoError(t, err)
+		got, err := parseFloat([]byte(s))
+		assert.NoError(t, err)
+		assert.Equal(t, math.Float64bits(want), math.Float64bits(got),
+			"parseFloat(%q) = %v, strconv gives %v", s, got, want)
+	}
+}
+
+// TestParseFloatWideRandomized cross-checks a deterministic sample of random
+// wide-significand floats against strconv.
+func TestParseFloatWideRandomized(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < 20000; i++ {
+		mantissa := rng.Uint64()>>uint(rng.Intn(11)) | 1<<53 // always > 2^53
+		exp := rng.Intn(55) - 27                             // [-27, 27]
+		s := strconv.FormatUint(mantissa, 10) + "e" + strconv.Itoa(exp)
+		want, err := strconv.ParseFloat(s, 64)
+		assert.NoError(t, err)
+		got, err := parseFloat([]byte(s))
+		assert.NoError(t, err)
+		assert.Equal(t, math.Float64bits(want), math.Float64bits(got),
+			"parseFloat(%q) = %v, strconv gives %v", s, got, want)
+	}
+}
+
+func TestWideParseFloatOutOfRange(t *testing.T) {
+	// Exponents beyond the exact uint64 powers of five defer to strconv.
+	_, ok := wideParseFloat(1<<54, 28)
+	assert.False(t, ok)
+	_, ok = wideParseFloat(1<<54, -28)
+	assert.False(t, ok)
+	// In-range sanity, both signs of the exponent and the zero mantissa.
+	f, ok := wideParseFloat(0, 5)
+	assert.True(t, ok)
+	assert.Equal(t, 0.0, f)
+	f, ok = wideParseFloat(9007199254740993, 0)
+	assert.True(t, ok)
+	assert.Equal(t, 9007199254740992.0, f)
+}
+
+func TestFastParseFloatRejects(t *testing.T) {
+	for _, s := range []string{"1..2", "-e1", "1e+"} {
+		_, ok := fastParseFloat([]byte(s))
+		assert.False(t, ok, "expected reject for %q", s)
+	}
 }


### PR DESCRIPTION
Splitting #1088: this PR carries one optimization technique so its impact and review surface stay isolated.

## What

17-significant-digit float values (coordinate-style data, e.g. the whole `canada.toml` dataset) overflow Clinger's 53-bit fast path and fell back to `strconv.ParseFloat`, paying a string conversion + allocation for each value.

For `|exp10| <= 27`, `5^|exp10|` is an exact `uint64`, so the correctly rounded value can be computed with exact 128-bit integer arithmetic: `10^q = 5^q * 2^q`, the power of two folds into the binary exponent, and the power of five is applied with a full 128-bit multiply (or a divide keeping the remainder), followed by an explicit round-to-nearest-even on the true value.

## Correctness

- Verified bit-exact against `strconv` over millions of randomized and directed cases during development; a deterministic 20k-case randomized sweep plus directed boundary cases (53-bit halfway points, exponent range edges, sticky-bit rounding) are in the tests.
- Out-of-range exponents still defer to `strconv`.

## Impact

On linux/amd64 (t2d) the full suite is neutral (sec/op geomean +0.08%): Go's `string(b)` conversion for the strconv fallback stays on the stack, and Eisel–Lemire is fast on that core. The win shows on darwin/arm64 (M1 Pro, interleaved A/B, n=10), where the dataset suite moves:

```
UnmarshalDataset/config        4.955m ± 1%   4.949m ± 3%        ~ (p=1.000 n=10)
UnmarshalDataset/canada        14.62m ± 1%   13.85m ± 1%   -5.28% (p=0.000 n=10)
UnmarshalDataset/citm_catalog  7.582m ± 1%   7.604m ± 1%        ~ (p=0.579 n=10)
UnmarshalDataset/twitter       1.941m ± 1%   1.819m ± 2%   -6.33% (p=0.000 n=10)
UnmarshalDataset/code          19.01m ± 1%   18.91m ± 1%        ~ (p=0.123 n=10)
UnmarshalDataset/example       41.31µ ± 2%   37.12µ ± 1%  -10.13% (p=0.000 n=10)
geomean                        3.070m        2.955m        -3.76%
```

linux/amd64 full-suite table for reference:

- sec/op geomean: **+0.08%**
- `UnmarshalDataset/example`: -3.72%
- `UnmarshalDataset/twitter`: -1.81%
- `Unmarshal/ReferenceFile/struct`: +2.55%
- `Marshal/HugoFrontMatter`: +3.79%
- `Marshal/SimpleDocument/map`: +3.92%

<details>
<summary>Full benchstat (sec/op, allocs/op)</summary>

#### sec/op
```
UnmarshalDataset/config  10.47m ± 1%  10.33m ± 4%  -1.31% (p=0.035 n=10)
UnmarshalDataset/canada  23.79m ± 4%  23.73m ± 3%  ~ (p=0.631 n=10)
UnmarshalDataset/citm_catalog  15.24m ± 3%  15.29m ± 1%  ~ (p=0.579 n=10)
UnmarshalDataset/twitter  3.605m ± 5%  3.540m ± 4%  -1.81% (p=0.005 n=10)
UnmarshalDataset/code  33.79m ± 2%  32.99m ± 3%  ~ (p=0.075 n=10)
UnmarshalDataset/example  77.53µ ± 3%  74.65µ ± 5%  -3.72% (p=0.009 n=10)
Unmarshal/SimpleDocument/struct  335.1n ± 1%  332.2n ± 1%  ~ (p=0.128 n=10)
Unmarshal/SimpleDocument/map  422.6n ± 2%  418.4n ± 4%  ~ (p=0.063 n=10)
Unmarshal/ReferenceFile/struct  38.95µ ± 2%  39.94µ ± 3%  +2.55% (p=0.023 n=10)
Unmarshal/ReferenceFile/map  31.54µ ± 1%  31.60µ ± 4%  ~ (p=0.631 n=10)
Unmarshal/HugoFrontMatter  5.654µ ± 4%  5.606µ ± 1%  ~ (p=0.159 n=10)
Marshal/SimpleDocument/struct  397.2n ± 1%  407.8n ± 6%  ~ (p=0.060 n=10)
Marshal/SimpleDocument/map  594.1n ± 1%  617.4n ± 5%  +3.92% (p=0.000 n=10)
Marshal/ReferenceFile/struct  20.83µ ± 2%  20.60µ ± 2%  ~ (p=0.436 n=10)
Marshal/ReferenceFile/map  39.80µ ± 4%  40.05µ ± 4%  ~ (p=0.424 n=10)
Marshal/HugoFrontMatter  7.939µ ± 2%  8.239µ ± 5%  +3.79% (p=0.009 n=10)
RealWorldContainerdConfig  39.77µ ± 2%  40.35µ ± 2%  +1.45% (p=0.023 n=10)
RealWorldViperRead  8.286µ ± 1%  8.209µ ± 2%  ~ (p=0.492 n=10)
RealWorldViperWrite  12.54µ ± 3%  12.52µ ± 3%  ~ (p=0.436 n=10)
RealWorldHugoFrontMatterBatch  95.41µ ± 3%  94.22µ ± 1%  ~ (p=0.218 n=10)
RealWorldGitleaksRules  64.85µ ± 1%  65.25µ ± 4%  ~ (p=0.197 n=10)
RealWorldPyproject  14.90µ ± 2%  15.02µ ± 3%  ~ (p=0.280 n=10)
RealWorldGolangciStrict  11.81µ ± 4%  11.92µ ± 3%  +0.88% (p=0.018 n=10)
geomean  46.69µ  46.72µ  +0.08%
```
#### allocs/op
```
UnmarshalDataset/config  70.19k ± 0%  70.19k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/canada  223.2k ± 0%  223.2k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog  49.98k ± 0%  49.98k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/twitter  15.78k ± 0%  15.78k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/code  129.5k ± 0%  129.5k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/example  399.0 ± 0%  399.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct  2.000 ± 0%  2.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map  5.000 ± 0%  5.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct  83.00 ± 0%  83.00 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map  194.0 ± 0%  194.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter  54.00 ± 0%  54.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map  91.00 ± 0%  91.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter  20.00 ± 0%  20.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldContainerdConfig  144.0 ± 0%  144.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperRead  65.00 ± 0%  65.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperWrite  33.00 ± 0%  33.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldHugoFrontMatterBatch  820.0 ± 0%  820.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGitleaksRules  259.0 ± 0%  259.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldPyproject  142.0 ± 0%  142.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGolangciStrict  48.00 ± 0%  48.00 ± 0%  ~ (p=1.000 n=10) ¹
geomean  211.1  211.1  +0.00%
¹ all samples are equal
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
