### PR TITLE
perf: scan strings eight bytes at a time when encoding

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -1669,19 +1669,79 @@ func (e *encoderState) appendString(b []byte, s string) []byte {
 // canBeLiteral returns true when the string can be represented as a TOML
 // literal string: no control characters, no single quote, no newline.
 func canBeLiteral(s string) bool {
-	for i := 0; i < len(s); i++ {
+	// Fast path: printable ASCII without a single quote needs no UTF-8
+	// validation, and is proven eight bytes at a time.
+	i := 0
+	for i+8 <= len(s) {
+		x := uint64(s[i]) | uint64(s[i+1])<<8 | uint64(s[i+2])<<16 |
+			uint64(s[i+3])<<24 | uint64(s[i+4])<<32 | uint64(s[i+5])<<40 |
+			uint64(s[i+6])<<48 | uint64(s[i+7])<<56
+		if (x&encMSB)|encHasByteBelow(x, 0x20)|encHasByteEqual(x, '\'')|encHasByteEqual(x, 0x7f) != 0 {
+			goto slow
+		}
+		i += 8
+	}
+	for ; i < len(s); i++ {
 		c := s[i]
+		if c == '\'' || c >= 0x7f || c < 0x20 {
+			goto slow
+		}
+	}
+	return true
+
+slow:
+	for j := i; j < len(s); j++ {
+		c := s[j]
 		if c == '\'' || c == 0x7f || c < 0x20 {
 			return false
 		}
 	}
-	return utf8.ValidString(s)
+	return utf8.ValidString(s[i:])
+}
+
+const encMSB = 0x8080808080808080
+
+// encHasByteBelow returns a non-zero value when any byte of x is strictly
+// below n, for n <= 0x80. Bytes with their high bit set do not trigger.
+func encHasByteBelow(x, n uint64) uint64 {
+	return (x - n*0x0101010101010101) &^ x & encMSB
+}
+
+// encHasByteEqual returns a non-zero value when any byte of x equals c, for
+// c < 0x80.
+func encHasByteEqual(x, c uint64) uint64 {
+	return encHasByteBelow(x^(c*0x0101010101010101), 1)
 }
 
 // appendBasicString encodes a string as a TOML basic (double-quoted) string.
 func appendBasicString(b []byte, s string) []byte {
 	b = append(b, '"')
+	start := 0
 	for i := 0; i < len(s); {
+		// Skip over a run of bytes that are emitted verbatim (printable
+		// ASCII except '"' and '\'), eight bytes at a time, and append it in
+		// one copy.
+		for i+8 <= len(s) {
+			x := uint64(s[i]) | uint64(s[i+1])<<8 | uint64(s[i+2])<<16 |
+				uint64(s[i+3])<<24 | uint64(s[i+4])<<32 | uint64(s[i+5])<<40 |
+				uint64(s[i+6])<<48 | uint64(s[i+7])<<56
+			if (x&encMSB)|encHasByteBelow(x, 0x20)|encHasByteEqual(x, '"')|encHasByteEqual(x, '\\')|encHasByteEqual(x, 0x7f) != 0 {
+				break
+			}
+			i += 8
+		}
+		for i < len(s) {
+			if c := s[i]; c >= 0x20 && c < 0x7f && c != '"' && c != '\\' {
+				i++
+				continue
+			}
+			break
+		}
+		b = append(b, s[start:i]...)
+		if i >= len(s) {
+			break
+		}
+
 		c := s[i]
 		switch {
 		case c == '"':
@@ -1714,11 +1774,12 @@ func appendBasicString(b []byte, s string) []byte {
 				// Replace invalid bytes by the replacement character.
 				b = append(b, fmt.Sprintf("\\u%04X", c)...)
 				i++
-				continue
+			} else {
+				b = append(b, s[i:i+size]...)
+				i += size
 			}
-			b = append(b, s[i:i+size]...)
-			i += size
 		}
+		start = i
 	}
 	return append(b, '"')
 }


### PR DESCRIPTION
Splitting #1088: this PR carries one optimization technique so its impact and review surface stay isolated.

## What

`canBeLiteral` and `appendBasicString` examined strings byte by byte. Printable ASCII free of quotes and escapes — the vast majority of encoded strings and keys — is now proven eight bytes at a time with word-wide bit tests (`encHasByteBelow`/`encHasByteEqual`, the classic SWAR "has zero byte" trick), and `appendBasicString` copies verbatim runs in one `append` instead of one byte at a time.

Strings that do need escaping or UTF-8 validation fall back to the original per-byte handling from the first offending byte, so output is identical.

## Impact

String-heavy marshaling benefits; this also feeds every key emission through `appendString`. Benchmarked on a dedicated linux/amd64 spot VM (t2d), go1.26.4, interleaved A/B vs the base of this PR, benchstat over 10 samples per side:

- sec/op geomean: **-1.05%**
- `Marshal/ReferenceFile/struct`: -6.85%
- `Marshal/SimpleDocument/struct`: -6.07%
- `Marshal/ReferenceFile/map`: -5.19%
- `Marshal/HugoFrontMatter`: -3.77%
- `Unmarshal/ReferenceFile/struct`: +1.59%
- `Unmarshal/SimpleDocument/map`: +3.83%

<details>
<summary>Full benchstat (sec/op, allocs/op)</summary>

#### sec/op
```
UnmarshalDataset/config  10.43m ± 5%  10.42m ±  5%  ~ (p=0.912 n=10)
UnmarshalDataset/canada  23.93m ± 3%  24.09m ±  4%  ~ (p=0.353 n=10)
UnmarshalDataset/citm_catalog  15.36m ± 5%  15.21m ±  5%  ~ (p=0.165 n=10)
UnmarshalDataset/twitter  3.645m ± 4%  3.631m ±  5%  ~ (p=0.631 n=10)
UnmarshalDataset/code  34.36m ± 2%  33.54m ±  4%  ~ (p=0.315 n=10)
UnmarshalDataset/example  77.87µ ± 3%  77.72µ ±  2%  ~ (p=1.000 n=10)
Unmarshal/SimpleDocument/struct  331.8n ± 3%  331.9n ±  1%  ~ (p=0.739 n=10)
Unmarshal/SimpleDocument/map  429.4n ± 1%  445.9n ±  3%  +3.83% (p=0.000 n=10)
Unmarshal/ReferenceFile/struct  39.79µ ± 2%  40.42µ ±  3%  +1.59% (p=0.019 n=10)
Unmarshal/ReferenceFile/map  32.39µ ± 1%  32.32µ ±  2%  ~ (p=0.739 n=10)
Unmarshal/HugoFrontMatter  5.802µ ± 2%  5.815µ ±  3%  ~ (p=0.617 n=10)
Marshal/SimpleDocument/struct  406.8n ± 2%  382.1n ±  4%  -6.07% (p=0.001 n=10)
Marshal/SimpleDocument/map  598.4n ± 1%  593.9n ±  5%  ~ (p=0.247 n=10)
Marshal/ReferenceFile/struct  20.76µ ± 2%  19.34µ ±  3%  -6.85% (p=0.000 n=10)
Marshal/ReferenceFile/map  40.80µ ± 3%  38.69µ ±  3%  -5.19% (p=0.001 n=10)
Marshal/HugoFrontMatter  8.122µ ± 2%  7.816µ ± 12%  -3.77% (p=0.022 n=10)
RealWorldContainerdConfig  40.62µ ± 0%  40.51µ ±  1%  ~ (p=0.987 n=10)
RealWorldViperRead  8.447µ ± 3%  8.469µ ±  3%  ~ (p=0.971 n=10)
RealWorldViperWrite  12.53µ ± 3%  12.52µ ±  2%  ~ (p=0.796 n=10)
RealWorldHugoFrontMatterBatch  96.16µ ± 2%  95.37µ ±  3%  ~ (p=0.353 n=10)
RealWorldGitleaksRules  65.26µ ± 3%  65.63µ ±  3%  ~ (p=0.796 n=10)
RealWorldPyproject  15.34µ ± 3%  14.94µ ±  7%  ~ (p=0.271 n=10)
RealWorldGolangciStrict  11.91µ ± 4%  11.91µ ±  3%  ~ (p=0.529 n=10)
geomean  47.28µ  46.78µ  -1.05%
```
#### allocs/op
```
UnmarshalDataset/config  70.19k ± 0%  70.19k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/canada  223.2k ± 0%  223.2k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog  49.98k ± 0%  49.98k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/twitter  15.78k ± 0%  15.78k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/code  129.5k ± 0%  129.5k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/example  399.0 ± 0%  399.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct  2.000 ± 0%  2.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map  5.000 ± 0%  5.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct  83.00 ± 0%  83.00 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map  194.0 ± 0%  194.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter  54.00 ± 0%  54.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map  91.00 ± 0%  91.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter  20.00 ± 0%  20.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldContainerdConfig  144.0 ± 0%  144.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperRead  65.00 ± 0%  65.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperWrite  33.00 ± 0%  33.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldHugoFrontMatterBatch  820.0 ± 0%  820.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGitleaksRules  259.0 ± 0%  259.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldPyproject  142.0 ± 0%  142.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGolangciStrict  48.00 ± 0%  48.00 ± 0%  ~ (p=1.000 n=10) ¹
geomean  211.1  211.1  +0.00%
¹ all samples are equal
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
