### PR TITLE
perf: index the seen-tracker with sibling chains and an adaptive hash spill

### DIFF
--- a/decode_paths_test.go
+++ b/decode_paths_test.go
@@ -1,0 +1,82 @@
+package toml
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2/internal/assert"
+)
+
+// TestUnmarshalManyKeysTable exercises the seen-tracker's spill to its hash
+// index (tables with more keys than fit the sibling chains), for both the
+// fused generic path and the reflection path, including duplicate detection
+// after the spill.
+func TestUnmarshalManyKeysTable(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 100; i++ {
+		fmt.Fprintf(&sb, "key%d = %d\n", i, i)
+	}
+	doc := sb.String()
+
+	t.Run("map", func(t *testing.T) {
+		m := map[string]interface{}{}
+		assert.NoError(t, Unmarshal([]byte(doc), &m))
+		assert.Equal(t, 100, len(m))
+		assert.Equal(t, interface{}(int64(99)), m["key99"])
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		var s struct {
+			Key0  int64
+			Key42 int64
+			Key99 int64
+		}
+		assert.NoError(t, Unmarshal([]byte(doc), &s))
+		assert.Equal(t, int64(42), s.Key42)
+		assert.Equal(t, int64(99), s.Key99)
+	})
+
+	t.Run("duplicate after spill", func(t *testing.T) {
+		m := map[string]interface{}{}
+		err := Unmarshal([]byte(doc+"key12 = 1\n"), &m)
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "already"), "unexpected error: %v", err)
+	})
+
+	t.Run("array table refresh under root", func(t *testing.T) {
+		var sb strings.Builder
+		for i := 0; i < 40; i++ {
+			fmt.Fprintf(&sb, "key%d = %d\n", i, i)
+		}
+		for i := 0; i < 3; i++ {
+			sb.WriteString("[[elem]]\nname = 'x'\n")
+		}
+		m := map[string]interface{}{}
+		assert.NoError(t, Unmarshal([]byte(sb.String()), &m))
+		assert.Equal(t, 3, len(m["elem"].([]interface{})))
+	})
+}
+
+// TestUnmarshalGenericValueShapes covers the generic decoding of every scalar
+// kind (through interface{} struct fields, which use the AST path), long
+
+// TestArrayTableRefreshUnderSpilledParent covers refreshing an array table
+// whose parent's children have spilled to the tracker's hash index, and the
+// sibling-chain swap when they have not.
+func TestArrayTableRefreshUnderSpilledParent(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 70; i++ {
+		fmt.Fprintf(&sb, "key%d = %d\n", i, i)
+	}
+	sb.WriteString("[[t]]\nx = 1\n[[t]]\nx = 2\n")
+	m := map[string]interface{}{}
+	assert.NoError(t, Unmarshal([]byte(sb.String()), &m))
+	assert.Equal(t, 2, len(m["t"].([]interface{})))
+
+	// Unspilled parent, refresh target not at the chain head.
+	doc := "a = 1\n[[t]]\nx = 1\nb = 2\n[[t]]\nx = 2\n"
+	m2 := map[string]interface{}{}
+	assert.NoError(t, Unmarshal([]byte(doc), &m2))
+	assert.Equal(t, 2, len(m2["t"].([]interface{})))
+}

--- a/internal/tracker/seen.go
+++ b/internal/tracker/seen.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"bytes"
 	"fmt"
+	"hash/maphash"
 
 	"github.com/pelletier/go-toml/v2/unstable"
 )
@@ -46,14 +47,32 @@ func (k keyKind) String() string {
 	panic("missing keyKind string mapping")
 }
 
+// spillThreshold is the number of children past which a parent's children are
+// moved from its sibling chain to the shared hash index. Chains keep small
+// and medium tables (the vast majority — including the ~40-key objects of
+// converted JSON documents) free of any hashing cost: their children are
+// created back to back, so walking the chain is a sequential scan. The index
+// only takes over for pathological tables, where it keeps lookups O(1).
+const spillThreshold = 64
+
 // entry represents a node that has been seen in the document. Its size has a
 // direct impact on the performance of unmarshaling documents: keep it as
 // small as possible.
 type entry struct {
-	parent   int32
-	kind     keyKind
-	explicit bool
-	name     []byte
+	name       []byte
+	parent     int32
+	firstChild int32  // head of the child chain, -1 when empty
+	next       int32  // next sibling in the parent's chain, -1 at the tail
+	childCount uint16 // saturating count of named children
+	kind       keyKind
+	explicit   bool
+}
+
+// spilled reports whether the children of an entry live in the hash index
+// instead of its sibling chain. Spilling happens exactly when the child count
+// crosses spillThreshold, so the count doubles as the flag.
+func (e *entry) spilled() bool {
+	return e.childCount > spillThreshold
 }
 
 // SeenTracker tracks which keys have been seen with which TOML type to flag
@@ -63,27 +82,32 @@ type entry struct {
 // an identifier, which is provided by a counter. Entries are stored in the
 // array entries. As new nodes are discovered (referenced for the first time
 // in the TOML document), entries are created and appended to the array. An
-// entry points to its parent using its id.
+// entry points to its parent using its id. The array is append-only: ids are
+// stable for the duration of a document.
 //
-// To find whether a given key (sequence of []byte) has already been visited,
-// the entries are linearly searched, looking for one with the right name and
-// parent id.
+// The named children of an entry are linked in a sibling chain, so looking a
+// key up costs at most the number of keys in its table. Parents whose child
+// count crosses spillThreshold have their children moved ("spilled") to a
+// shared open-addressing hash index keyed by (parent, name), which keeps
+// pathological tables with thousands of keys O(1) per lookup.
 //
-// Given that all keys appear in the document after their parent, it is
-// guaranteed that all descendants of a node are stored after the node, this
-// speeds up the search process.
-//
-// When encountering [[array tables]], the descendants of that node are removed
-// to allow that branch of the tree to be "rediscovered". To maintain the
-// invariant above, the deletion process needs to keep the order of entries.
-// This results in more copies in that case.
+// When encountering [[array tables]], the keys seen in the previous element
+// must not shadow the keys of the new element. Instead of deleting the
+// previous element's entries, the array table entry is replaced by a fresh
+// entry (with a fresh id): the previous descendants still exist but hang off
+// the old id, which no future lookup uses.
 type SeenTracker struct {
 	entries      []entry
 	currentTable int32
 
-	// scratch buffers for clear()
-	removedBuf []bool
-	remapBuf   []int32
+	// index is the open-addressing hash table of entry ids (stored as id+1,
+	// 0 meaning empty) for the children of spilled parents, keyed by
+	// hash(parent, name). Its size is always a power of two. inserted counts
+	// used slots for load-factor purposes.
+	index    []int32
+	inserted int
+	seed     maphash.Seed
+	seeded   bool
 }
 
 // Reset brings the tracker to its initial state, with just a root table, so
@@ -95,68 +119,198 @@ func (s *SeenTracker) Reset() {
 // reset brings the tracker to its initial state, with just a root table.
 func (s *SeenTracker) reset() {
 	s.entries = append(s.entries[:0], entry{
-		parent: -1,
-		kind:   tableKind,
+		parent:     -1,
+		firstChild: -1,
+		next:       -1,
+		kind:       tableKind,
 	})
 	s.currentTable = 0
+	if s.inserted > 0 {
+		clear(s.index)
+		s.inserted = 0
+	}
+}
+
+// hash computes the index hash of a (parent, name) pair. The seeded name hash
+// keeps probe sequences unpredictable for untrusted documents.
+func (s *SeenTracker) hash(parent int32, name []byte) uint64 {
+	h := maphash.Bytes(s.seed, name)
+	return h ^ uint64(uint32(parent))*0x9E3779B97F4A7C15 //nolint:gosec // ids are non-negative; the truncation only mixes bits
 }
 
 // find returns the id of the entry with the given parent and name, or -1.
-// Anonymous entries are never returned.
+// Anonymous entries are never returned (they are not linked nor indexed).
 func (s *SeenTracker) find(parent int32, name []byte) int32 {
-	// Children always appear after their parent.
-	for i := int(parent) + 1; i < len(s.entries); i++ {
-		e := &s.entries[i]
-		if e.parent == parent && e.kind != anonymousKind && bytes.Equal(e.name, name) {
-			return int32(i) //nolint:gosec // entry counts are bounded by document size
+	if len(s.entries) == 0 {
+		s.reset()
+	}
+	p := &s.entries[parent]
+	if p.spilled() {
+		return s.indexFind(parent, name)
+	}
+	for id := p.firstChild; id >= 0; id = s.entries[id].next {
+		if bytes.Equal(s.entries[id].name, name) {
+			return id
 		}
 	}
 	return -1
 }
 
-// create appends a new entry and returns its id.
+// create appends a new entry and returns its id. Anonymous entries cannot be
+// found; every other entry must not already exist under the same parent.
 func (s *SeenTracker) create(parent int32, name []byte, kind keyKind, explicit bool) int32 {
 	id := int32(len(s.entries)) //nolint:gosec // entry counts are bounded by document size
 	s.entries = append(s.entries, entry{
-		parent:   parent,
-		kind:     kind,
-		explicit: explicit,
-		name:     name,
+		parent:     parent,
+		firstChild: -1,
+		next:       -1,
+		name:       name,
+		kind:       kind,
+		explicit:   explicit,
 	})
+	if kind != anonymousKind {
+		s.link(parent, name, id)
+	}
 	return id
 }
 
-// clear removes all the descendants of the entry with the given id, keeping
-// the order of the remaining entries.
-func (s *SeenTracker) clear(id int32) {
-	// Compute which entries are removed. Given that children always appear
-	// after their parent, a single forward pass is enough.
-	if cap(s.removedBuf) < len(s.entries) {
-		s.removedBuf = make([]bool, len(s.entries))
-		s.remapBuf = make([]int32, len(s.entries))
+// link attaches a new named child to its parent: to the sibling chain for
+// regular parents, or to the hash index for spilled ones. Children are
+// prepended to the chain, so no tail pointer is needed.
+func (s *SeenTracker) link(parent int32, name []byte, id int32) {
+	p := &s.entries[parent]
+	if p.childCount < 0xFFFF {
+		p.childCount++
 	}
-	removed := s.removedBuf[:len(s.entries)]
-	remap := s.remapBuf[:len(s.entries)]
-	for i := range removed {
-		removed[i] = false
+	if p.spilled() {
+		if p.childCount == spillThreshold+1 {
+			// The parent just crossed the threshold: move its chain to the
+			// hash index. The chain links are left dangling; they are never
+			// read again.
+			s.spill(parent)
+		}
+		s.indexInsert(parent, name, id)
+		return
 	}
+	s.entries[id].next = p.firstChild
+	p.firstChild = id
+}
 
-	n := int32(0)
-	for i := 0; i < len(s.entries); i++ {
-		parent := s.entries[i].parent
-		if parent >= 0 && (parent == id && s.entries[i].kind != invalidKind || removed[parent]) {
-			removed[i] = true
+// spill moves the children of a parent from its sibling chain to the hash
+// index.
+func (s *SeenTracker) spill(parent int32) {
+	if !s.seeded {
+		s.seed = maphash.MakeSeed()
+		s.seeded = true
+	}
+	if s.index == nil {
+		s.index = make([]int32, 128)
+	}
+	p := &s.entries[parent]
+	for id := p.firstChild; id >= 0; id = s.entries[id].next {
+		s.indexInsert(parent, s.entries[id].name, id)
+	}
+}
+
+// indexFind probes the hash index for the child of a spilled parent.
+func (s *SeenTracker) indexFind(parent int32, name []byte) int32 {
+	mask := uint64(len(s.index) - 1) //nolint:gosec // the index is never empty here, so len-1 >= 0
+	for i := s.hash(parent, name) & mask; ; i = (i + 1) & mask {
+		v := s.index[i]
+		if v == 0 {
+			return -1
+		}
+		e := &s.entries[v-1]
+		if e.parent == parent && bytes.Equal(e.name, name) {
+			return v - 1
+		}
+	}
+}
+
+// indexInsert adds an id to the index under (parent, name), growing the table
+// when its load factor reaches 3/4.
+func (s *SeenTracker) indexInsert(parent int32, name []byte, id int32) {
+	if (s.inserted+1)*4 > len(s.index)*3 {
+		s.grow()
+	}
+	mask := uint64(len(s.index) - 1) //nolint:gosec // the index is never empty here, so len-1 >= 0
+	i := s.hash(parent, name) & mask
+	for s.index[i] != 0 {
+		i = (i + 1) & mask
+	}
+	s.index[i] = id + 1
+	s.inserted++
+}
+
+// indexReplace overwrites the index slot of (parent, name) with a new id. The
+// slot must exist.
+func (s *SeenTracker) indexReplace(parent int32, name []byte, id int32) {
+	mask := uint64(len(s.index) - 1) //nolint:gosec // the index is never empty here, so len-1 >= 0
+	for i := s.hash(parent, name) & mask; ; i = (i + 1) & mask {
+		v := s.index[i]
+		if v == 0 {
+			panic("toml: internal error: indexReplace on missing entry")
+		}
+		e := &s.entries[v-1]
+		if e.parent == parent && bytes.Equal(e.name, name) {
+			s.index[i] = id + 1
+			return
+		}
+	}
+}
+
+// grow doubles the index and rehashes every used slot.
+func (s *SeenTracker) grow() {
+	old := s.index
+	n := len(old) * 2
+	if n == 0 {
+		n = 128
+	}
+	s.index = make([]int32, n)
+	mask := uint64(len(s.index) - 1) //nolint:gosec // the index is never empty here, so len-1 >= 0
+	for _, v := range old {
+		if v == 0 {
 			continue
 		}
-		remap[i] = n
-		if int32(i) != n { //nolint:gosec // entry counts are bounded by document size
-			e := s.entries[i]
-			e.parent = remap[e.parent]
-			s.entries[n] = e
+		e := &s.entries[v-1]
+		i := s.hash(e.parent, e.name) & mask
+		for s.index[i] != 0 {
+			i = (i + 1) & mask
 		}
-		n++
+		s.index[i] = v
 	}
-	s.entries = s.entries[:n]
+}
+
+// refreshArrayTable replaces the array table entry id with a fresh entry (and
+// id), so that the descendants recorded by the previous element no longer
+// shadow the keys of the new element. Returns the new id.
+func (s *SeenTracker) refreshArrayTable(id int32) int32 {
+	old := s.entries[id]
+	nid := int32(len(s.entries)) //nolint:gosec // entry counts are bounded by document size
+	s.entries = append(s.entries, entry{
+		parent:     old.parent,
+		firstChild: -1,
+		next:       old.next,
+		name:       old.name,
+		kind:       arrayTableKind,
+		explicit:   true,
+	})
+	p := &s.entries[old.parent]
+	if p.spilled() {
+		s.indexReplace(old.parent, old.name, nid)
+		return nid
+	}
+	// Swap the id for nid in the parent's chain.
+	if p.firstChild == id {
+		p.firstChild = nid
+	} else {
+		prev := p.firstChild
+		for s.entries[prev].next != id {
+			prev = s.entries[prev].next
+		}
+		s.entries[prev].next = nid
+	}
+	return nid
 }
 
 // CheckExpression takes a top-level node and checks that it does not contain
@@ -249,8 +403,7 @@ func (s *SeenTracker) CheckArrayTable(parts [][]byte) (bool, error) {
 			}
 			// Make the descendants of this array table re-discoverable for
 			// the new element.
-			s.clear(i)
-			s.currentTable = i
+			s.currentTable = s.refreshArrayTable(i)
 			return false, nil
 		}
 
@@ -374,10 +527,7 @@ func (s *SeenTracker) checkArrayTable(node *unstable.Node) (bool, error) {
 			}
 			// Make the descendants of this array table re-discoverable for
 			// the new element.
-			s.clear(i)
-			// Note: clear cannot move i because i comes before all its
-			// descendants.
-			s.currentTable = i
+			s.currentTable = s.refreshArrayTable(i)
 			return false, nil
 		}
 
@@ -437,9 +587,19 @@ func (s *SeenTracker) checkValue(id int32, value *unstable.Node) error {
 		it := value.Children()
 		for it.Next() {
 			elem := it.Node()
-			if elem.Kind == unstable.InlineTable || elem.Kind == unstable.Array {
+			switch elem.Kind { //nolint:exhaustive // scalar elements declare no keys
+			case unstable.InlineTable:
+				// Each inline table is its own key scope: it needs a fresh
+				// anonymous parent so that identical keys in sibling tables
+				// do not collide.
 				elemID := s.create(id, nil, anonymousKind, false)
 				if err := s.checkValue(elemID, elem); err != nil {
+					return err
+				}
+			case unstable.Array:
+				// Arrays declare no keys themselves: pass through without
+				// creating an entry.
+				if err := s.checkValue(id, elem); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
Splitting #1088: this PR carries one optimization technique so its impact and review surface stay isolated.

## What

The seen-tracker (duplicate-key and type-consistency validation) looked keys up by scanning every entry recorded after the parent — quadratic for many-key tables. `find` was 33% of citm_catalog decoding.

- **Sibling chains**: entries now keep their named children in an intrusive sibling chain, so a lookup costs at most the number of keys in its own table, with zero hashing for small and medium tables (including the ~40-key objects of converted-JSON documents).
- **Adaptive hash spill**: parents whose child count crosses 64 have their children moved to a shared seeded open-addressing index keyed by (parent, name), keeping pathological tables with thousands of keys O(1) per lookup. This also removes the quadratic decode DoS surface of the linear scan.
- **O(1) array-table refresh**: `[[array table]]` elements previously compacted the entry array to delete the previous element's descendants (more quadratic work). The array-table entry is now replaced by a fresh entry with a fresh id; the old descendants still exist but hang off an id no future lookup can reach.
- **Arrays of scalars create no tracker entries at all** (only inline tables declare keys).

## Impact

Benchmarked on a dedicated linux/amd64 spot VM (t2d), go1.26.4, interleaved A/B vs the base of this PR, benchstat over 10 samples per side:

- sec/op geomean: **-1.47%**
- `UnmarshalDataset/citm_catalog`: -41.87%
- `UnmarshalDataset/code`: -9.79%
- `Unmarshal/ReferenceFile/struct`: -5.09%
- `Unmarshal/ReferenceFile/map`: -3.51%
- `UnmarshalDataset/config`: -2.48%
- `Marshal/ReferenceFile/struct`: -2.09%
- `Marshal/SimpleDocument/struct`: -1.95%
- `RealWorldContainerdConfig`: -1.57%
- `RealWorldPyproject`: +1.74%
- `RealWorldViperRead`: +2.41%
- `Unmarshal/HugoFrontMatter`: +3.08%
- `RealWorldHugoFrontMatterBatch`: +3.77%
- `RealWorldGolangciStrict`: +3.78%
- `UnmarshalDataset/example`: +4.70%
- `Marshal/SimpleDocument/map`: +5.45%
- `UnmarshalDataset/twitter`: +5.46%
- `Unmarshal/SimpleDocument/struct`: +6.75%
- `Unmarshal/SimpleDocument/map`: +8.08%

<details>
<summary>Full benchstat (sec/op, allocs/op)</summary>

#### sec/op
```
UnmarshalDataset/config  10.32m ± 1%  10.06m ± 3%  -2.48% (p=0.015 n=10)
UnmarshalDataset/canada  23.76m ± 2%  23.49m ± 2%  ~ (p=0.315 n=10)
UnmarshalDataset/citm_catalog  15.331m ± 2%  8.912m ± 3%  -41.87% (p=0.000 n=10)
UnmarshalDataset/twitter  3.621m ± 1%  3.819m ± 3%  +5.46% (p=0.002 n=10)
UnmarshalDataset/code  33.45m ± 1%  30.17m ± 1%  -9.79% (p=0.000 n=10)
UnmarshalDataset/example  77.52µ ± 1%  81.16µ ± 4%  +4.70% (p=0.000 n=10)
Unmarshal/SimpleDocument/struct  335.3n ± 1%  358.0n ± 1%  +6.75% (p=0.000 n=10)
Unmarshal/SimpleDocument/map  425.2n ± 1%  459.6n ± 1%  +8.08% (p=0.000 n=10)
Unmarshal/ReferenceFile/struct  40.01µ ± 4%  37.97µ ± 2%  -5.09% (p=0.001 n=10)
Unmarshal/ReferenceFile/map  31.74µ ± 2%  30.63µ ± 2%  -3.51% (p=0.000 n=10)
Unmarshal/HugoFrontMatter  5.665µ ± 3%  5.840µ ± 1%  +3.08% (p=0.001 n=10)
Marshal/SimpleDocument/struct  403.2n ± 2%  395.4n ± 2%  -1.95% (p=0.014 n=10)
Marshal/SimpleDocument/map  595.3n ± 0%  627.8n ± 1%  +5.45% (p=0.000 n=10)
Marshal/ReferenceFile/struct  20.78µ ± 2%  20.34µ ± 1%  -2.09% (p=0.007 n=10)
Marshal/ReferenceFile/map  39.77µ ± 3%  40.27µ ± 3%  ~ (p=0.247 n=10)
Marshal/HugoFrontMatter  8.091µ ± 3%  8.149µ ± 2%  ~ (p=0.123 n=10)
RealWorldContainerdConfig  40.33µ ± 1%  39.70µ ± 2%  -1.57% (p=0.007 n=10)
RealWorldViperRead  8.329µ ± 2%  8.530µ ± 2%  +2.41% (p=0.000 n=10)
RealWorldViperWrite  12.38µ ± 4%  12.50µ ± 2%  ~ (p=0.853 n=10)
RealWorldHugoFrontMatterBatch  94.76µ ± 2%  98.33µ ± 3%  +3.77% (p=0.000 n=10)
RealWorldGitleaksRules  64.45µ ± 3%  65.49µ ± 1%  ~ (p=0.052 n=10)
RealWorldPyproject  15.04µ ± 5%  15.30µ ± 1%  +1.74% (p=0.035 n=10)
RealWorldGolangciStrict  11.81µ ± 1%  12.25µ ± 2%  +3.78% (p=0.000 n=10)
geomean  46.81µ  46.12µ  -1.47%
```
#### allocs/op
```
UnmarshalDataset/config  70.19k ± 0%  70.19k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/canada  223.2k ± 0%  223.2k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog  49.98k ± 0%  49.98k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/twitter  15.78k ± 0%  15.78k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/code  129.5k ± 0%  129.5k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/example  399.0 ± 0%  399.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct  2.000 ± 0%  2.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map  5.000 ± 0%  5.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct  83.00 ± 0%  83.00 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map  194.0 ± 0%  194.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter  54.00 ± 0%  54.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map  91.00 ± 0%  91.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter  20.00 ± 0%  20.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldContainerdConfig  144.0 ± 0%  144.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperRead  65.00 ± 0%  65.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperWrite  33.00 ± 0%  33.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldHugoFrontMatterBatch  820.0 ± 0%  820.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGitleaksRules  259.0 ± 0%  259.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldPyproject  142.0 ± 0%  142.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGolangciStrict  48.00 ± 0%  48.00 ± 0%  ~ (p=1.000 n=10) ¹
geomean  211.1  211.1  +0.00%
¹ all samples are equal
```

</details>

Read in isolation: the entry struct grows (chain links + child count), which costs a few percent on tiny documents (`Unmarshal/SimpleDocument/*`, twitter's many small tables) while eliminating the quadratic behavior on large ones (citm −42%, code −10%). The follow-up decode-chain PRs (native containers, fused struct decoding) win the small-document cases back several times over — see the combined numbers in the #1088 close-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
