### PR TITLE
perf: decode container values natively in the fused generic path

### DIFF
--- a/decode_fused.go
+++ b/decode_fused.go
@@ -10,11 +10,12 @@ import (
 )
 
 // unmarshalFused decodes a whole document into a native map[string]interface{}
-// tree with no reflection on the document structure, and without building an
-// AST for table headers and scalar key-values. Only container values (arrays
-// and inline tables) are parsed into the parser arena, so that the seen-tracker
-// can validate them and decodeAny can presize the resulting slices and maps —
-// the AST is what makes that cheap O(1) presizing possible.
+// tree with no reflection on the document structure and no AST at all: table
+// headers, keys, scalars, arrays, and inline tables are all scanned directly
+// into their native representation. Scratch stacks make the containers
+// exact-size, and the keys declared inside a container value are logged and
+// replayed through the seen-tracker once the expression has fully parsed (see
+// fusedOp), so validation and error precedence match the AST path.
 //
 // It is used when the target is a fully generic value (interface{} or
 // map[string]interface{}) and the unmarshaler interface is disabled. The
@@ -35,6 +36,14 @@ func (d *decoder) unmarshalFused(root reflect.Value, data []byte) error {
 	}
 
 	if err := d.fusedDocument(m, data); err != nil {
+		// An error may have unwound partially-built containers: drop the
+		// references still held by the scratch stacks so the pooled decoder
+		// does not retain user data. (On success both stacks are empty and
+		// already zeroed by their copy-outs.)
+		clear(d.anyStack[:cap(d.anyStack)])
+		d.anyStack = d.anyStack[:0]
+		clear(d.kvStack[:cap(d.kvStack)])
+		d.kvStack = d.kvStack[:0]
 		return d.wrapFusedError(data, err)
 	}
 
@@ -159,27 +168,25 @@ func (d *decoder) fusedKeyVal(b []byte, cur map[string]interface{}) ([]byte, err
 	}
 
 	if c := b[0]; c == '[' || c == '{' {
-		// Container value: build its AST so the seen-tracker can validate it
-		// and decodeAny can presize the resulting slices and maps.
-		nodeAny, rest, err := parserbridge.ParseValue(&d.p, b)
+		// Container value: build the native value directly, recording the keys
+		// declared inside it. They are validated only after the whole line has
+		// parsed and the outer key has been checked, so that error precedence
+		// is identical to the AST path.
+		d.fusedParts = d.fusedParts[:0]
+		d.fusedOps = d.fusedOps[:0]
+		av, rest, err := d.fusedContainerValue(b)
 		if err != nil {
 			return nil, err
 		}
-		node := nodeAny.(*unstable.Node)
 		rest, err = d.fusedFinishLine(rest)
 		if err != nil {
 			return nil, err
 		}
-		leafID, err := d.seen.CheckKeyValue(d.keyParts)
-		if err != nil {
+		if _, err := d.seen.CheckKeyValue(d.keyParts); err != nil {
 			return nil, d.fusedSeenError(rawKey, d.keyParts, err)
 		}
-		if err := d.seen.CheckValueUnder(leafID, node); err != nil {
+		if err := d.replayFusedOps(); err != nil {
 			return nil, d.fusedSeenError(rawKey, d.keyParts, err)
-		}
-		av, err := d.decodeAny(node)
-		if err != nil {
-			return nil, err
 		}
 		d.setFusedLeaf(cur, d.keyParts, av)
 		return rest, nil
@@ -205,6 +212,274 @@ func (d *decoder) fusedKeyVal(b []byte, cur map[string]interface{}) ([]byte, err
 	}
 	d.setFusedLeaf(cur, d.keyParts, av)
 	return rest, nil
+}
+
+// fusedOp is one step of the deferred key validation of a container value.
+// The keys declared inside an array or inline table cannot be checked while
+// the value parses (a syntax error later on the line must win, as must a
+// duplicate of the outer key), so parsing logs the declarations and
+// replayFusedOps runs them through the seen-tracker afterwards.
+type fusedOp struct {
+	lo, hi int32 // fusedOpKey: the parts d.fusedParts[lo:hi] of the key
+	op     uint8
+}
+
+const (
+	// fusedOpKey declares a (possibly dotted) key of an inline table; the
+	// scopes of the value it introduces follow until the matching fusedOpPop.
+	fusedOpKey = iota
+	// fusedOpAnon enters an inline table stored in an array, which is its own
+	// anonymous key scope, until the matching fusedOpPop.
+	fusedOpAnon
+	// fusedOpPop leaves the scope entered by fusedOpKey or fusedOpAnon.
+	fusedOpPop
+)
+
+// replayFusedOps validates the keys recorded by the last container value.
+// The value is stored under a leaf key, which no later expression can extend
+// or redefine, so its internals never enter the main seen-tracker: a second,
+// per-value tracker validates them with the same rules and messages, and is
+// reset for every container value (which reuses its storage).
+func (d *decoder) replayFusedOps() error {
+	if len(d.fusedOps) == 0 {
+		return nil
+	}
+	d.valSeen.Reset()
+	d.idStack = d.idStack[:0]
+	top := int32(0)
+	for _, op := range d.fusedOps {
+		switch op.op {
+		case fusedOpKey:
+			id, err := d.valSeen.CheckKeyValueUnder(top, d.fusedParts[op.lo:op.hi])
+			if err != nil {
+				return err
+			}
+			d.idStack = append(d.idStack, top)
+			top = id
+		case fusedOpAnon:
+			d.idStack = append(d.idStack, top)
+			top = d.valSeen.CreateAnonymous(top)
+		default: // fusedOpPop
+			top = d.idStack[len(d.idStack)-1]
+			d.idStack = d.idStack[:len(d.idStack)-1]
+		}
+	}
+	return nil
+}
+
+// maxFusedNesting is the maximum depth of nested arrays and inline tables
+// the fused decoder accepts. It mirrors maxValueNesting in unstable/parser.go
+// (the two limits must stay in sync so both decode paths reject the same
+// documents): fusedArray and fusedInlineTable recurse for each nested
+// container, and a document with thousands of open brackets would otherwise
+// overflow the goroutine stack — an unrecoverable fatal error.
+const maxFusedNesting = 10000
+
+// fusedContainerValue parses an array or inline table (b starts at '[' or
+// '{') directly into its native generic representation, without building an
+// AST. The keys declared inside are appended to the d.fusedOps log for later
+// validation. It is the single entry point of the container recursion, and
+// bounds its depth.
+func (d *decoder) fusedContainerValue(b []byte) (interface{}, []byte, error) {
+	if d.fusedNesting >= maxFusedNesting {
+		return nil, nil, unstable.NewParserError(b[:1], "arrays and inline tables are nested more than the maximum of %d levels deep", maxFusedNesting)
+	}
+	d.fusedNesting++
+	var (
+		v    interface{}
+		rest []byte
+		err  error
+	)
+	if b[0] == '[' {
+		v, rest, err = d.fusedArray(b)
+	} else {
+		v, rest, err = d.fusedInlineTable(b)
+	}
+	d.fusedNesting--
+	return v, rest, err
+}
+
+// fusedValue parses any TOML value nested in a container. b is not empty.
+func (d *decoder) fusedValue(b []byte) (interface{}, []byte, error) {
+	switch b[0] {
+	case '[', '{':
+		return d.fusedContainerValue(b)
+	default:
+		k, _, value, rest, err := parserbridge.ScanScalar(&d.p, b)
+		if err != nil {
+			return nil, nil, err
+		}
+		av, err := d.fusedScalar(unstable.Kind(k), value)
+		if err != nil {
+			return nil, nil, err
+		}
+		return av, rest, nil
+	}
+}
+
+// fusedArray parses an array value natively. b starts at '['. It mirrors the
+// grammar (and error messages) of Parser.parseValArray. Elements accumulate
+// on d.anyStack and are copied out to an exact-size slice on ']'.
+func (d *decoder) fusedArray(b []byte) (interface{}, []byte, error) {
+	b = b[1:]
+	base := len(d.anyStack)
+	afterValue := false
+	for {
+		b = fusedSkipWS(b)
+		if len(b) == 0 {
+			return nil, nil, unstable.NewParserError(b, "array is incomplete")
+		}
+		switch b[0] {
+		case ']':
+			elems := d.anyStack[base:]
+			out := make([]interface{}, len(elems))
+			copy(out, elems)
+			clear(elems)
+			d.anyStack = d.anyStack[:base]
+			return out, b[1:], nil
+		case '\n':
+			b = b[1:]
+		case '\r':
+			if len(b) > 1 && b[1] == '\n' {
+				b = b[2:]
+				continue
+			}
+			return nil, nil, unstable.NewParserError(b[:1], "expected newline but got %#U", b[0])
+		case '#':
+			_, rest, err := parserbridge.ScanComment(b)
+			if err != nil {
+				return nil, nil, err
+			}
+			b = rest
+		case ',':
+			if !afterValue {
+				return nil, nil, unstable.NewParserError(b[:1], "expected value but got %#U", b[0])
+			}
+			afterValue = false
+			b = b[1:]
+		default:
+			if afterValue {
+				return nil, nil, unstable.NewParserError(b[:1], "expected ',' or ']' after array value")
+			}
+			var (
+				v   interface{}
+				err error
+			)
+			if b[0] == '{' {
+				// An inline table in an array is its own key scope. It enters
+				// through fusedContainerValue so the nesting bound applies.
+				d.fusedOps = append(d.fusedOps, fusedOp{op: fusedOpAnon})
+				v, b, err = d.fusedContainerValue(b)
+				if err == nil {
+					d.fusedOps = append(d.fusedOps, fusedOp{op: fusedOpPop})
+				}
+			} else {
+				v, b, err = d.fusedValue(b)
+			}
+			if err != nil {
+				return nil, nil, err
+			}
+			d.anyStack = append(d.anyStack, v)
+			afterValue = true
+		}
+	}
+}
+
+// fusedInlineTable parses an inline table value natively. b starts at '{'.
+// It mirrors the grammar (and error messages) of Parser.parseInlineTable.
+// Key-values accumulate on d.kvStack so that the map is created with its
+// exact size on '}'. Key declarations are logged for deferred validation:
+// conflicting keys may temporarily build garbage into the result, but the
+// replay rejects the document before the value is used.
+func (d *decoder) fusedInlineTable(b []byte) (interface{}, []byte, error) {
+	b = b[1:]
+	base := len(d.kvStack)
+	afterValue := false
+	for {
+		b = fusedSkipWS(b)
+		if len(b) == 0 {
+			return nil, nil, unstable.NewParserError(b, "inline table is incomplete")
+		}
+		switch b[0] {
+		case '}':
+			pairs := d.kvStack[base:]
+			m := make(map[string]interface{}, len(pairs))
+			for i := range pairs {
+				kv := &pairs[i]
+				parts := d.fusedParts[kv.lo:kv.hi]
+				cur := m
+				for j := 0; j < len(parts)-1; j++ {
+					cur = d.anyChildTable(cur, d.intern(parts[j]))
+				}
+				cur[d.intern(parts[len(parts)-1])] = kv.v
+			}
+			clear(pairs)
+			d.kvStack = d.kvStack[:base]
+			return m, b[1:], nil
+		case '\n':
+			b = b[1:]
+		case '\r':
+			if len(b) > 1 && b[1] == '\n' {
+				b = b[2:]
+				continue
+			}
+			return nil, nil, unstable.NewParserError(b[:1], "expected newline but got %#U", b[0])
+		case '#':
+			_, rest, err := parserbridge.ScanComment(b)
+			if err != nil {
+				return nil, nil, err
+			}
+			b = rest
+		case ',':
+			if !afterValue {
+				return nil, nil, unstable.NewParserError(b[:1], "unexpected comma in inline table")
+			}
+			afterValue = false
+			b = b[1:]
+		default:
+			if afterValue {
+				return nil, nil, unstable.NewParserError(b[:1], "expected ',' or '}' after inline table key-value")
+			}
+			var err error
+			b, err = d.fusedInlineKeyval(b)
+			if err != nil {
+				return nil, nil, err
+			}
+			afterValue = true
+		}
+	}
+}
+
+// fusedInlineKeyval parses one `key = value` pair of an inline table onto
+// d.kvStack. b starts at the first character of the key.
+func (d *decoder) fusedInlineKeyval(b []byte) ([]byte, error) {
+	save := len(d.fusedParts)
+	var err error
+	d.fusedParts, _, b, err = parserbridge.ScanKey(&d.p, b, d.fusedParts)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 || b[0] != '=' {
+		return nil, unstable.NewParserError(fusedHL1(b), "expected '=' after key")
+	}
+	b = fusedSkipWS(b[1:])
+	if len(b) == 0 {
+		return nil, unstable.NewParserError(b, "expected value, not end of input")
+	}
+
+	// The parts range must be pinned before parsing the value: the keys of a
+	// nested inline table extend d.fusedParts.
+	lo := int32(save)              //nolint:gosec // part counts are bounded by document size
+	hi := int32(len(d.fusedParts)) //nolint:gosec // part counts are bounded by document size
+	d.fusedOps = append(d.fusedOps, fusedOp{op: fusedOpKey, lo: lo, hi: hi})
+	v, b, err := d.fusedValue(b)
+	if err != nil {
+		return nil, err
+	}
+	d.fusedOps = append(d.fusedOps, fusedOp{op: fusedOpPop})
+
+	d.kvStack = append(d.kvStack, fusedKV{v: v, lo: lo, hi: hi})
+	return b, nil
 }
 
 // fusedSeenError turns a bare error returned by a SeenTracker parts-method

--- a/decode_paths_test.go
+++ b/decode_paths_test.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pelletier/go-toml/v2/internal/assert"
+	"github.com/pelletier/go-toml/v2/unstable"
 )
 
 // TestUnmarshalManyKeysTable exercises the seen-tracker's spill to its hash
@@ -79,4 +81,276 @@ func TestArrayTableRefreshUnderSpilledParent(t *testing.T) {
 	m2 := map[string]interface{}{}
 	assert.NoError(t, Unmarshal([]byte(doc), &m2))
 	assert.Equal(t, 2, len(m2["t"].([]interface{})))
+}
+
+// TestUnmarshalGenericValueShapes covers the generic decoding of every scalar
+// kind (through interface{} struct fields, which use the AST path), long
+// strings beyond the slab limit, and arrays larger than the slab cutoff.
+func TestUnmarshalGenericValueShapes(t *testing.T) {
+	long := strings.Repeat("x", 600)
+	var arr strings.Builder
+	for i := 0; i < 40; i++ {
+		fmt.Fprintf(&arr, "%d,", i)
+	}
+	doc := fmt.Sprintf(`
+str = "hello"
+longstr = "%s"
+int = 42
+bigint = 123456
+negint = -7
+float = 1.25
+bool = true
+date = 2021-03-30
+time = 11:21:00
+datetime = 2021-03-30T11:21:00Z
+localdt = 2021-03-30T11:21:00
+bigarray = [%s]
+nested = { a.b = 1, c = [{ d = 2 }, { d = 3 }] }
+`, long, arr.String())
+
+	type target struct {
+		Str      interface{}
+		Longstr  interface{}
+		Int      interface{}
+		Bigint   interface{}
+		Negint   interface{}
+		Float    interface{}
+		Bool     interface{}
+		Date     interface{}
+		Time     interface{}
+		Datetime interface{}
+		Localdt  interface{}
+		Bigarray interface{}
+		Nested   interface{}
+	}
+
+	check := func(t *testing.T, get func(string) interface{}) {
+		t.Helper()
+		assert.Equal(t, interface{}("hello"), get("str"))
+		assert.Equal(t, interface{}(long), get("longstr"))
+		assert.Equal(t, interface{}(int64(42)), get("int"))
+		assert.Equal(t, interface{}(int64(123456)), get("bigint"))
+		assert.Equal(t, interface{}(int64(-7)), get("negint"))
+		assert.Equal(t, interface{}(1.25), get("float"))
+		assert.Equal(t, interface{}(true), get("bool"))
+		assert.Equal(t, interface{}(LocalDate{2021, 3, 30}), get("date"))
+		assert.Equal(t, 40, len(get("bigarray").([]interface{})))
+		nested := get("nested").(map[string]interface{})
+		assert.Equal(t, interface{}(int64(1)), nested["a"].(map[string]interface{})["b"])
+		cs := nested["c"].([]interface{})
+		assert.Equal(t, interface{}(int64(3)), cs[1].(map[string]interface{})["d"])
+		dt := get("datetime").(time.Time)
+		assert.Equal(t, 2021, dt.Year())
+	}
+
+	t.Run("map target (fused path)", func(t *testing.T) {
+		m := map[string]interface{}{}
+		assert.NoError(t, Unmarshal([]byte(doc), &m))
+		check(t, func(k string) interface{} { return m[k] })
+	})
+
+	t.Run("map target with unmarshaler interface (AST path)", func(t *testing.T) {
+		m := map[string]interface{}{}
+		d := NewDecoder(strings.NewReader(doc))
+		d.EnableUnmarshalerInterface()
+		assert.NoError(t, d.Decode(&m))
+		check(t, func(k string) interface{} { return m[k] })
+	})
+
+	t.Run("struct with interface fields (AST path)", func(t *testing.T) {
+		var s target
+		d := NewDecoder(strings.NewReader(doc))
+		d.EnableUnmarshalerInterface()
+		assert.NoError(t, d.Decode(&s))
+		byName := map[string]interface{}{
+			"str": s.Str, "longstr": s.Longstr, "int": s.Int,
+			"bigint": s.Bigint, "negint": s.Negint, "float": s.Float,
+			"bool": s.Bool, "date": s.Date, "time": s.Time,
+			"datetime": s.Datetime, "localdt": s.Localdt,
+			"bigarray": s.Bigarray, "nested": s.Nested,
+		}
+		check(t, func(k string) interface{} { return byName[k] })
+	})
+}
+
+// TestUnmarshalFusedLineEndings covers CRLF and comment handling inside the
+// natively decoded containers, and bare-CR rejection.
+func TestUnmarshalFusedLineEndings(t *testing.T) {
+	m := map[string]interface{}{}
+	doc := "a = [ # comment\r\n1, # c\r\n2 ]\r\nb = { # comment\r\nx = 1, # c\r\n}\r\n"
+	assert.NoError(t, Unmarshal([]byte(doc), &m))
+	assert.Equal(t, 2, len(m["a"].([]interface{})))
+	assert.Equal(t, interface{}(int64(1)), m["b"].(map[string]interface{})["x"])
+
+	for _, bad := range []string{"a = [1,\r2]", "a = {x = 1,\ry = 2}"} {
+		assert.Error(t, Unmarshal([]byte(bad), &map[string]interface{}{}))
+	}
+}
+
+// TestSetAnyKeyValueError covers error propagation through the AST generic
+// inline-table walk (an impossible date inside a nested inline table).
+func TestSetAnyKeyValueError(t *testing.T) {
+	var s struct{ V interface{} }
+	d := NewDecoder(strings.NewReader("v = { nested = { d = 2021-13-45 } }"))
+	d.EnableUnmarshalerInterface()
+	assert.Error(t, d.Decode(&s))
+}
+
+// tables reached through struct-held maps): dotted keys and error
+// propagation.
+func TestSetAnyKeyBranches(t *testing.T) {
+	type target struct {
+		M map[string]interface{} `toml:"m"`
+	}
+
+	var s target
+	assert.NoError(t, Unmarshal([]byte("[m]\nv = { a.b = 1, c = 2 }"), &s))
+	v := s.M["v"].(map[string]interface{})
+	assert.Equal(t, interface{}(int64(1)),
+		v["a"].(map[string]interface{})["b"])
+	assert.Equal(t, interface{}(int64(2)), v["c"])
+
+	var s2 target
+	assert.Error(t, Unmarshal([]byte("[m]\nv = { d = 2021-13-45 }"), &s2))
+}
+
+// TestRawValueWithSpan covers the fused-path branch of rawValue, which
+
+func TestUnmarshalInlineTableErrors(t *testing.T) {
+	cases := []string{
+		"a = {x 1}",          // missing '='
+		"a = {x =",           // EOF after '='
+		"a = {x = 1",         // unterminated
+		"a = {, x = 1}",      // leading comma
+		"a = {x = 1 y = 2}",  // missing comma
+		"a = [1,, 2]",        // double comma
+		"a = [1 2]",          // missing comma in array
+		"a = [",              // unterminated array
+		"a = {x = 1, x = 2}", // duplicate key
+	}
+	for _, doc := range cases {
+		m := map[string]interface{}{}
+		err := Unmarshal([]byte(doc), &m)
+		assert.Error(t, err, "expected error for %q", doc)
+	}
+}
+
+// TestUnmarshalerInterfaceDottedGeneric covers setAnyKey's dotted-key walk
+// and error propagation on the AST generic path.
+func TestUnmarshalerInterfaceDottedGeneric(t *testing.T) {
+	m := map[string]interface{}{}
+	d := NewDecoder(strings.NewReader("a.b.c = 1\na.b.d = 'x'"))
+	d.EnableUnmarshalerInterface()
+	assert.NoError(t, d.Decode(&m))
+	ab := m["a"].(map[string]interface{})["b"].(map[string]interface{})
+	assert.Equal(t, interface{}(int64(1)), ab["c"])
+
+	m2 := map[string]interface{}{}
+	d2 := NewDecoder(strings.NewReader("a.b = 2021-13-45"))
+	d2.EnableUnmarshalerInterface()
+	assert.Error(t, d2.Decode(&m2))
+}
+
+// TestUnmarshalerInterfaceNodePaths drives the node-driven expression loop
+// (only used with the unmarshaler interface) through its error and
+// line-ending branches, raw captures stored under maps, and pre-existing
+// interface values replaced by tables.
+func TestUnmarshalerInterfaceNodePaths(t *testing.T) {
+	bad := []string{
+		"\rx = 1",             // bare CR at expression level
+		"[a]\n[a]",            // duplicate table
+		"[[a]]\n[a]",          // table after array table
+		"a.b = 1\n[a.b]",      // table over dotted key
+		"a = 1\n[a]",          // table over value
+		"[a]\n[[a]]",          // array table over table
+		"a = {x = 1,\rb = 2}", // bare CR in inline table
+	}
+	for _, doc := range bad {
+		var s struct{ A int64 }
+		d := NewDecoder(strings.NewReader(doc))
+		d.EnableUnmarshalerInterface()
+		assert.Error(t, d.Decode(&s), "expected error for %q", doc)
+	}
+
+	t.Run("crlf in inline table", func(t *testing.T) {
+		m := map[string]interface{}{}
+		d := NewDecoder(strings.NewReader("a = {x = 1,\r\ny = 2}"))
+		d.EnableUnmarshalerInterface()
+		assert.NoError(t, d.Decode(&m))
+		assert.Equal(t, 2, len(m["a"].(map[string]interface{})))
+	})
+
+	t.Run("raw capture under map", func(t *testing.T) {
+		var s struct {
+			M map[string]unstable.RawMessage `toml:"m"`
+		}
+		d := NewDecoder(strings.NewReader("[m.x]\na = 1\n[m.y]\nb = 2"))
+		d.EnableUnmarshalerInterface()
+		assert.NoError(t, d.Decode(&s))
+		assert.True(t, strings.Contains(string(s.M["x"]), "a = 1"), "got %q", s.M["x"])
+	})
+
+	t.Run("table replaces scalar interface via node walk", func(t *testing.T) {
+		var s struct{ T interface{} }
+		s.T = "old"
+		d := NewDecoder(strings.NewReader("[t]\nk = 1"))
+		d.EnableUnmarshalerInterface()
+		assert.NoError(t, d.Decode(&s))
+		m, ok := s.T.(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, interface{}(int64(1)), m["k"])
+	})
+}
+
+// TestParseIntegerOverflows covers the radix-specific overflow guards
+// directly (the scanner accepts the tokens; conversion rejects them).
+func TestParseIntegerOverflows(t *testing.T) {
+	for _, s := range []string{
+		"0xFFFFFFFFFFFFFFFF",
+		"0o1777777777777777777777",
+		"0b" + strings.Repeat("1", 64),
+	} {
+		_, err := parseInteger([]byte(s))
+		assert.Error(t, err, "expected overflow for %q", s)
+	}
+}
+
+// TestUnmarshalTypedContainerEdges mirrors TestUnmarshalFusedLineEndings with
+// a typed target: generic targets decode containers natively, so these keep
+// the expression parser's container branches (comments, CRLF, empty and
+// trailing-comma forms) covered through the arena path.
+func TestUnmarshalTypedContainerEdges(t *testing.T) {
+	type target struct {
+		A []int64          `toml:"a"`
+		M map[string]int64 `toml:"m"`
+	}
+
+	good := []string{
+		"a = [ # comment\r\n1, # c\r\n2 ]\r\n",
+		"a = [\n]",
+		"a = [1, 2,]",
+		"a = [\r\n1,\r\n2]",
+		"m = { # comment\r\nx = 1, # c\r\n}\r\n",
+		"m = {}",
+	}
+	for _, doc := range good {
+		var s target
+		assert.NoError(t, Unmarshal([]byte(doc), &s), "expected success for %q", doc)
+	}
+
+	bad := []string{
+		"a = [1,\r2]",
+		"a = [1 2]",
+		"a = [,]",
+		"a = [1",
+		"m = {x = 1,\ry = 2}",
+		"m = {x = 1 y = 2}",
+		"m = {,}",
+		"m = {x = 1",
+		"m = {x 1}",
+	}
+	for _, doc := range bad {
+		var s target
+		assert.Error(t, Unmarshal([]byte(doc), &s), "expected error for %q", doc)
+	}
 }

--- a/internal/tracker/seen.go
+++ b/internal/tracker/seen.go
@@ -425,10 +425,25 @@ func (s *SeenTracker) CheckArrayTable(parts [][]byte) (bool, error) {
 }
 
 // CheckKeyValue validates the (possibly dotted) key of a key-value under the
-// current table, WITHOUT validating its value. It returns the id of the leaf
-// entry, so the caller can validate a container value with CheckValueUnder.
+// current table, WITHOUT validating its value: the keys declared inside a
+// container value are validated separately (see CheckKeyValueUnder and the
+// decoder's per-value replay). It returns the id of the leaf entry.
 func (s *SeenTracker) CheckKeyValue(parts [][]byte) (int32, error) {
-	parent := s.currentTable
+	return s.CheckKeyValueUnder(s.currentTable, parts)
+}
+
+// CreateAnonymous creates an anonymous entry under parent and returns its id.
+// It gives each inline table stored in an array its own key scope, so that
+// identical keys in sibling tables do not collide.
+func (s *SeenTracker) CreateAnonymous(parent int32) int32 {
+	return s.create(parent, nil, anonymousKind, false)
+}
+
+// CheckKeyValueUnder validates the (possibly dotted) key of a key-value under
+// the given parent entry, WITHOUT validating its value. It mirrors
+// checkKeyValue but is driven directly from the key parts, for callers that
+// decode without building an AST.
+func (s *SeenTracker) CheckKeyValueUnder(parent int32, parts [][]byte) (int32, error) {
 	for k := 0; k < len(parts); k++ {
 		name := parts[k]
 		if k == len(parts)-1 {
@@ -447,14 +462,6 @@ func (s *SeenTracker) CheckKeyValue(parts [][]byte) (int32, error) {
 		parent = i
 	}
 	panic("unreachable: key-value expression without key")
-}
-
-// CheckValueUnder validates the content of a value stored under the given
-// entry (typically the leaf returned by CheckKeyValue): inline tables cannot
-// contain duplicate keys, including in the inline tables and arrays they
-// contain.
-func (s *SeenTracker) CheckValueUnder(parent int32, value *unstable.Node) error {
-	return s.checkValue(parent, value)
 }
 
 func (s *SeenTracker) checkTable(node *unstable.Node) (bool, error) {

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -62,6 +62,11 @@ func (d *decoder) reset() {
 	d.tableFlush = d.tableFlush[:0]
 	d.tableParentSlot = slotWriter{}
 	d.keyParts = d.keyParts[:0]
+	d.fusedParts = d.fusedParts[:0]
+	d.fusedOps = d.fusedOps[:0]
+	d.idStack = d.idStack[:0]
+	// A decode aborted by an error may leave the count non-zero.
+	d.fusedNesting = 0
 	d.strict.Reset()
 }
 
@@ -287,6 +292,35 @@ type decoder struct {
 	// keyParts is the reusable buffer holding the decoded parts of the key of
 	// the current expression in the fused generic decode path.
 	keyParts [][]byte
+
+	// Scratch buffers of the fused generic decode path for container values:
+	// anyStack accumulates array elements (and kvStack inline-table pairs)
+	// before the exact-size copy-out; fusedParts and fusedOps record the keys
+	// seen inside a container value so they can be validated by the
+	// seen-tracker after the whole expression has parsed (preserving error
+	// precedence); idStack is the scope stack used during that replay.
+	anyStack   []interface{}
+	kvStack    []fusedKV
+	fusedParts [][]byte
+	fusedOps   []fusedOp
+	idStack    []int32
+
+	// fusedNesting is the current depth of nested containers being decoded
+	// natively, bounded by maxFusedNesting (see fusedContainerValue).
+	fusedNesting int
+
+	// valSeen validates the keys declared inside a single container value,
+	// which no later expression can reach: keeping them out of d.seen means
+	// the main tracker only ever holds reachable keys. Reset (cheaply) for
+	// every container value.
+	valSeen tracker.SeenTracker
+}
+
+// fusedKV is a deferred key-value of an inline table being decoded natively:
+// the parts d.fusedParts[lo:hi] of its key, and its decoded value.
+type fusedKV struct {
+	v      interface{}
+	lo, hi int32
 }
 
 // slotWriter remembers how to store a value at some location of the target


### PR DESCRIPTION
Splitting #1088: this PR carries one optimization technique so its impact and review surface stay isolated. Stacked on the seen-tracker PR (#1100): merge that one first.

## What

Arrays and inline tables of generic targets (`interface{}` / `map[string]interface{}`) were parsed into the AST arena so the seen-tracker could validate them, then converted by `decodeAny`. They now decode straight into native Go values: elements accumulate on reusable scratch stacks and are copied out exact-size, so no AST node is built at all.

## Error precedence

The keys declared inside a container value cannot be checked while the value parses (a syntax error later on the line must win, as must a duplicate of the outer key), so parsing logs the key declarations (`fusedOp`) and replays them through the tracker once the expression has fully parsed — error precedence is identical to the AST path, and the error messages are the same by construction.

The replay runs against a second, per-value tracker (`valSeen`): a container value is stored under a leaf key that no later expression can extend or redefine, so its internals stay out of the main tracker for the rest of the document (less memory, shorter chains).

## DoS parity with #1092

The native recursion is bounded by the same nesting limit as the expression parser (`maxFusedNesting`, mirroring `maxValueNesting`), with the same error message, so the stack-overflow protection of #1092 holds on this path — the existing `TestUnmarshalDeeplyNestedValues` exercises it.

## Impact

Benchmarked on a dedicated linux/amd64 spot VM (t2d), go1.26.4, interleaved A/B vs the base of this PR (the seen-tracker branch), benchstat over 10 samples per side:

- sec/op geomean: **-1.13%**
- `UnmarshalDataset/example`: -6.04%
- `RealWorldPyproject`: -4.62%
- `UnmarshalDataset/citm_catalog`: -3.91%
- `UnmarshalDataset/canada`: -3.50%
- `Unmarshal/SimpleDocument/struct`: -3.26%
- `Unmarshal/SimpleDocument/map`: -2.55%
- `UnmarshalDataset/twitter`: -2.08%
- `Unmarshal/HugoFrontMatter`: -2.07%
- `RealWorldHugoFrontMatterBatch`: -1.99%
- `UnmarshalDataset/code`: +7.22%

<details>
<summary>Full benchstat (sec/op, allocs/op)</summary>

#### sec/op
```
UnmarshalDataset/config  10.42m ±  72%  10.38m ±  1%  ~ (p=0.481 n=10)
UnmarshalDataset/canada  24.99m ± 215%  24.12m ±  1%  -3.50% (p=0.000 n=10)
UnmarshalDataset/citm_catalog  9.576m ± 145%  9.202m ±  1%  -3.91% (p=0.000 n=10)
UnmarshalDataset/twitter  3.924m ±  69%  3.842m ±  1%  -2.08% (p=0.000 n=10)
UnmarshalDataset/code  30.67m ±  71%  32.88m ±  1%  +7.22% (p=0.023 n=10)
UnmarshalDataset/example  84.72µ ±  50%  79.60µ ±  1%  -6.04% (p=0.000 n=10)
Unmarshal/SimpleDocument/struct  360.9n ±  11%  349.2n ±  1%  -3.26% (p=0.000 n=10)
Unmarshal/SimpleDocument/map  465.0n ±  21%  453.2n ±  2%  -2.55% (p=0.000 n=10)
Unmarshal/ReferenceFile/struct  39.06µ ±  10%  39.17µ ±  4%  ~ (p=0.529 n=10)
Unmarshal/ReferenceFile/map  31.29µ ±  17%  30.92µ ±  1%  -1.17% (p=0.023 n=10)
Unmarshal/HugoFrontMatter  6.028µ ±  17%  5.902µ ±  1%  -2.07% (p=0.022 n=10)
Marshal/SimpleDocument/struct  408.8n ±  46%  407.6n ±  1%  ~ (p=0.684 n=10)
Marshal/SimpleDocument/map  646.5n ±  37%  645.8n ±  1%  ~ (p=0.796 n=10)
Marshal/ReferenceFile/struct  20.77µ ±  4%  21.10µ ±  3%  ~ (p=0.105 n=10)
Marshal/ReferenceFile/map  41.50µ ±  2%  41.54µ ±  6%  ~ (p=0.971 n=10)
Marshal/HugoFrontMatter  8.550µ ±  9%  8.463µ ± 11%  ~ (p=0.424 n=10)
RealWorldContainerdConfig  40.96µ ±  13%  40.66µ ± 14%  ~ (p=0.280 n=10)
RealWorldViperRead  8.954µ ±  18%  8.728µ ± 27%  ~ (p=0.393 n=10)
RealWorldViperWrite  12.45µ ±  4%  12.75µ ±  5%  ~ (p=0.579 n=10)
RealWorldHugoFrontMatterBatch  102.2µ ±  0%  100.2µ ± 22%  -1.99% (p=0.029 n=10)
RealWorldGitleaksRules  67.86µ ±  1%  68.01µ ± 14%  ~ (p=0.089 n=10)
RealWorldPyproject  15.81µ ±  2%  15.08µ ± 29%  -4.62% (p=0.023 n=10)
RealWorldGolangciStrict  12.82µ ±  1%  12.73µ ± 11%  ~ (p=0.853 n=10)
geomean  47.65µ  47.11µ  -1.13%
```
#### allocs/op
```
UnmarshalDataset/config  70.19k ± 0%  70.19k ± 0%  ~ (p=0.474 n=10)
UnmarshalDataset/canada  223.2k ± 0%  223.2k ± 0%  +0.00% (p=0.000 n=10)
UnmarshalDataset/citm_catalog  49.98k ± 0%  49.98k ± 0%  +0.00% (p=0.000 n=10)
UnmarshalDataset/twitter  15.78k ± 0%  15.78k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/code  129.5k ± 0%  129.5k ± 0%  +0.00% (p=0.000 n=10)
UnmarshalDataset/example  399.0 ± 0%  399.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct  2.000 ± 0%  2.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map  5.000 ± 0%  5.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct  83.00 ± 0%  83.00 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map  194.0 ± 0%  194.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter  54.00 ± 0%  54.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map  91.00 ± 0%  91.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter  20.00 ± 0%  20.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldContainerdConfig  144.0 ± 0%  144.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperRead  65.00 ± 0%  65.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperWrite  33.00 ± 0%  33.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldHugoFrontMatterBatch  820.0 ± 0%  820.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGitleaksRules  259.0 ± 0%  259.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldPyproject  142.0 ± 0%  142.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGolangciStrict  48.00 ± 0%  48.00 ± 0%  ~ (p=1.000 n=10) ¹
geomean  211.1  211.1  +0.00%
¹ all samples are equal
```

</details>

`UnmarshalDataset/code` (+7%) regresses in isolation — it is dominated by scalar key-values in tables, which still pay the expression parser here; the next PR in the chain (fused struct/scalar decoding) takes it −20%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
