### PR TITLE
perf: decode scalar key-values of reflection targets without an AST

### DIFF
--- a/decode_paths_test.go
+++ b/decode_paths_test.go
@@ -1,6 +1,7 @@
 package toml
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -353,4 +354,262 @@ func TestUnmarshalTypedContainerEdges(t *testing.T) {
 		var s target
 		assert.Error(t, Unmarshal([]byte(doc), &s), "expected error for %q", doc)
 	}
+}
+
+// TestUnmarshalFusedStructErrors covers the scanning error branches of the
+// fused document loop for reflection targets, and the strict-mode reporting
+// on both the fused path and the AST path (unmarshaler interface enabled).
+func TestUnmarshalFusedStructErrors(t *testing.T) {
+	type target struct {
+		A int64 `toml:"a"`
+	}
+
+	bad := []string{
+		"a = 1\rb = 2",   // bare CR between expressions
+		"# comment\rx",   // bare CR terminating a comment
+		"[tbl\na = 1",    // header syntax error through the delegated parser
+		"a = 1 trailing", // garbage after a scalar value
+		"a.b = 1",        // dotted key descending into an integer field
+	}
+	for _, doc := range bad {
+		var s target
+		assert.Error(t, Unmarshal([]byte(doc), &s), "expected error for %q", doc)
+	}
+
+	t.Run("strict unknown field fused", func(t *testing.T) {
+		var s target
+		d := NewDecoder(strings.NewReader("a = 1\nunknown = 2\nun.known = 3\n"))
+		d.DisallowUnknownFields()
+		err := d.Decode(&s)
+		assert.Error(t, err)
+		var missing *StrictMissingError
+		assert.True(t, errors.As(err, &missing))
+		assert.Equal(t, 2, len(missing.Errors))
+	})
+
+	t.Run("strict unknown field with unmarshaler interface", func(t *testing.T) {
+		var s target
+		d := NewDecoder(strings.NewReader("a = 1\nunknown = 2\n"))
+		d.DisallowUnknownFields()
+		d.EnableUnmarshalerInterface()
+		err := d.Decode(&s)
+		assert.Error(t, err)
+		var missing *StrictMissingError
+		assert.True(t, errors.As(err, &missing))
+		assert.Equal(t, 1, len(missing.Errors))
+	})
+
+	t.Run("fixed array overflow via dotted key", func(t *testing.T) {
+		var s struct {
+			Elem [1]struct{ V int64 }
+		}
+		err := Unmarshal([]byte("[[elem]]\nv = 1\n[[elem]]\nv = 2\n"), &s)
+		assert.Error(t, err)
+	})
+}
+
+// TestUnmarshalMoreErrorBranches sweeps assorted error and edge branches of
+// the fused paths and integer parsing.
+func TestUnmarshalMoreErrorBranches(t *testing.T) {
+	type target struct {
+		A []int64                     `toml:"a"`
+		M map[string]int64            `toml:"m"`
+		N map[string]map[string]int64 `toml:"n"`
+	}
+
+	bad := []string{
+		"\rx = 1",            // CR at start of expression (struct loop)
+		"a = [1,",            // container syntax error (struct target)
+		"a = [1] x",          // garbage after container
+		"b = 1\nb = [1]",     // duplicate key with container value
+		"m = {x = 1, x = 2}", // duplicate inside container (struct target)
+	}
+	for _, doc := range bad {
+		var s target
+		assert.Error(t, Unmarshal([]byte(doc), &s), "expected error for %q", doc)
+	}
+
+	overflow := []string{
+		"i = 0xFFFFFFFFFFFFFFFF",           // hex overflow
+		"i = 0o7777777777777777777777",     // octal overflow
+		"i = 0b" + strings.Repeat("1", 65), // binary overflow
+	}
+	for _, doc := range overflow {
+		m := map[string]interface{}{}
+		assert.Error(t, Unmarshal([]byte(doc), &m), "expected error for %q", doc)
+	}
+
+	good := []string{
+		"\r\na = [1]\r\n",            // CRLF blank line handling in the struct loop
+		"[m]\r\nk = 1",               // CRLF after header
+		"[n.x]\nk = 1\n[n.y]\nk = 2", // dotted headers into nested maps
+	}
+	for _, doc := range good {
+		var s target
+		assert.NoError(t, Unmarshal([]byte(doc), &s), "expected success for %q", doc)
+	}
+
+	t.Run("unmarshaler interface without strict ignores unknowns", func(t *testing.T) {
+		var s struct{ A int64 }
+		d := NewDecoder(strings.NewReader("a = 1\nunknown = 2"))
+		d.EnableUnmarshalerInterface()
+		assert.NoError(t, d.Decode(&s))
+		assert.Equal(t, int64(1), s.A)
+	})
+
+	t.Run("nil map field filled through cached table", func(t *testing.T) {
+		var s struct {
+			M map[string]int64 `toml:"m"`
+		}
+		assert.NoError(t, Unmarshal([]byte("[m]\nk = 1\nl = 2"), &s))
+		assert.Equal(t, int64(2), s.M["l"])
+	})
+}
+
+// TestUnmarshalReplacePreexistingValues covers replacing pre-existing values
+// held in interface fields and AST-path assignment errors.
+func TestUnmarshalReplacePreexistingValues(t *testing.T) {
+	t.Run("table replaces scalar in interface field", func(t *testing.T) {
+		var s struct{ T interface{} }
+		s.T = "old scalar"
+		assert.NoError(t, Unmarshal([]byte("[t]\nk = 1"), &s))
+		m, ok := s.T.(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, interface{}(int64(1)), m["k"])
+	})
+
+	t.Run("type mismatch through unmarshaler interface path", func(t *testing.T) {
+		var s struct{ A int64 }
+		d := NewDecoder(strings.NewReader(`a = "not an int"`))
+		d.EnableUnmarshalerInterface()
+		assert.Error(t, d.Decode(&s))
+	})
+
+	t.Run("duplicate key through unmarshaler interface path", func(t *testing.T) {
+		var s struct{ A int64 }
+		d := NewDecoder(strings.NewReader("a = 1\na = 2"))
+		d.EnableUnmarshalerInterface()
+		assert.Error(t, d.Decode(&s))
+	})
+}
+
+// TestUnmarshalCommentAndDottedStrictEdges covers comment scanning errors in
+// the fused loops and dotted-key strict reporting through the AST path.
+func TestUnmarshalCommentAndDottedStrictEdges(t *testing.T) {
+	for _, doc := range []string{"# c\rx = 1", "a = {#\x01\nx = 1}"} {
+		m := map[string]interface{}{}
+		assert.Error(t, Unmarshal([]byte(doc), &m), "expected error for %q", doc)
+	}
+
+	var s struct{ A int64 }
+	d := NewDecoder(strings.NewReader("un.known.key = 1"))
+	d.DisallowUnknownFields()
+	d.EnableUnmarshalerInterface()
+	err := d.Decode(&s)
+	var missing *StrictMissingError
+	assert.True(t, errors.As(err, &missing))
+}
+
+// TestUnmarshalerInterfaceLoopBranches covers the expression-loop branches
+// that only the unmarshaler-interface path uses: parser error wrapping and
+// the empty-document epilogue for generic roots.
+func TestUnmarshalerInterfaceLoopBranches(t *testing.T) {
+	t.Run("syntax error", func(t *testing.T) {
+		var s struct{ A int64 }
+		d := NewDecoder(strings.NewReader("[unclosed\na = 1"))
+		d.EnableUnmarshalerInterface()
+		assert.Error(t, d.Decode(&s))
+	})
+
+	t.Run("empty document into nil map", func(t *testing.T) {
+		var m map[string]interface{}
+		d := NewDecoder(strings.NewReader(""))
+		d.EnableUnmarshalerInterface()
+		assert.NoError(t, d.Decode(&m))
+		assert.True(t, m != nil)
+	})
+
+	t.Run("empty document into interface", func(t *testing.T) {
+		var v interface{}
+		d := NewDecoder(strings.NewReader(""))
+		d.EnableUnmarshalerInterface()
+		assert.NoError(t, d.Decode(&v))
+		_, ok := v.(map[string]interface{})
+		assert.True(t, ok)
+	})
+}
+
+// TestValidateValueNodeScalar covers the guard for non-container nodes: only
+// containers declare keys, so scalars validate trivially.
+func TestValidateValueNodeScalar(t *testing.T) {
+	d := getDecoder(false, false)
+	defer putDecoder(d)
+	assert.NoError(t, d.validateValueNode(&unstable.Node{Kind: unstable.String}))
+	assert.NoError(t, d.validateValueNode(&unstable.Node{Kind: unstable.Integer}))
+}
+
+// TestRawValueWithoutSpan covers the fallback of rawValue when neither an
+// expression node nor a fused value span is available.
+func TestRawValueWithoutSpan(t *testing.T) {
+	d := getDecoder(false, false)
+	defer putDecoder(d)
+	doc := []byte("x = [1]")
+	d.p.Reset(doc)
+	d.fusedValueSpan = nil
+	node := &unstable.Node{Kind: unstable.Array, Raw: d.p.Range(doc[4:7])}
+	assert.Equal(t, "[1]", string(d.rawValue(nil, node)))
+}
+
+// TestRawValueWithSpan covers the fused-path branch of rawValue, which
+// returns the exact span of the current key-value's container.
+func TestRawValueWithSpan(t *testing.T) {
+	d := getDecoder(false, false)
+	defer putDecoder(d)
+	doc := []byte("x = [1]")
+	d.p.Reset(doc)
+	d.fusedValueSpan = doc[4:7]
+	node := &unstable.Node{Kind: unstable.Array, Raw: d.p.Range(doc[4:7])}
+	assert.Equal(t, "[1]", string(d.rawValue(nil, node)))
+	d.fusedValueSpan = nil
+
+	// A non-key-value expression context takes the best-effort span.
+	arrExpr := &unstable.Node{Kind: unstable.Array}
+	assert.Equal(t, "[1]", string(d.rawValue(arrExpr, node)))
+}
+
+// TestMoreLineEndingAndHeaderEdges sweeps remaining line-ending and header
+// branches on both document loops.
+func TestMoreLineEndingAndHeaderEdges(t *testing.T) {
+	t.Run("crlf blank line, interface loop", func(t *testing.T) {
+		m := map[string]interface{}{}
+		d := NewDecoder(strings.NewReader("\r\na = 1\r\n"))
+		d.EnableUnmarshalerInterface()
+		assert.NoError(t, d.Decode(&m))
+		assert.Equal(t, interface{}(int64(1)), m["a"])
+	})
+
+	t.Run("invalid comment, fused generic loop", func(t *testing.T) {
+		m := map[string]interface{}{}
+		assert.Error(t, Unmarshal([]byte("# \x01\nx = 1"), &m))
+	})
+
+	t.Run("array table over scalar interface", func(t *testing.T) {
+		var s struct{ T interface{} }
+		s.T = "old"
+		assert.NoError(t, Unmarshal([]byte("[[t]]\nk = 1\n[[t]]\nk = 2"), &s))
+		arr, ok := s.T.([]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, 2, len(arr))
+	})
+}
+
+// TestTableThroughScalarInterface covers replacing a scalar held in an
+// interface when it is an intermediate step of a deeper table header.
+func TestTableThroughScalarInterface(t *testing.T) {
+	var s struct{ T interface{} }
+	s.T = "old scalar"
+	assert.NoError(t, Unmarshal([]byte("[t.sub]\nk = 1"), &s))
+	m := s.T.(map[string]interface{})
+	sub := m["sub"].(map[string]interface{})
+	assert.Equal(t, interface{}(int64(1)), sub["k"])
 }

--- a/decode_struct_fused.go
+++ b/decode_struct_fused.go
@@ -1,0 +1,198 @@
+package toml
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/pelletier/go-toml/v2/internal/parserbridge"
+	"github.com/pelletier/go-toml/v2/unstable"
+)
+
+// fusedStructDocument drives the top-level expression loop for reflection
+// targets (structs, typed maps, ...) without building an AST for scalar
+// key-values, which are the bulk of a document: their key and value are
+// scanned directly and dispatched through the same descend/assign machinery
+// as the AST path. Table headers and container values still go through the
+// expression parser, so array-table bookkeeping, strict-mode reporting and
+// error rendering stay identical.
+//
+// It is used whenever the unmarshaler interface is disabled (captures need
+// the raw expression ranges of the AST); fully generic targets take the
+// unmarshalFused path instead.
+func (d *decoder) fusedStructDocument(root reflect.Value, data []byte) error {
+	b := data
+	for {
+		b = fusedSkipWS(b)
+		if len(b) == 0 {
+			return nil
+		}
+		switch b[0] {
+		case '\n':
+			b = b[1:]
+		case '\r':
+			if len(b) > 1 && b[1] == '\n' {
+				b = b[2:]
+				continue
+			}
+			return d.wrapFusedError(data, unstable.NewParserError(b[:1], "expected newline but got %#U", b[0]))
+		case '#':
+			_, rest, err := parserbridge.ScanComment(b)
+			if err == nil {
+				rest, err = fusedConsumeEOL(rest)
+			}
+			if err != nil {
+				return d.wrapFusedError(data, err)
+			}
+			b = rest
+		case '[':
+			// Table headers run through the expression parser and the
+			// regular handling (seen-tracking, strict bookkeeping, walk).
+			parserbridge.SetCursor(&d.p, b)
+			if !d.p.NextExpression() {
+				if err := d.p.Error(); err != nil {
+					var perr *unstable.ParserError
+					if errors.As(err, &perr) {
+						return wrapDecodeError(data, perr)
+					}
+					return err
+				}
+				return nil
+			}
+			if err := d.handleRootExpression(d.p.Expression(), root); err != nil {
+				return d.wrapError(data, err)
+			}
+			b = parserbridge.Cursor(&d.p)
+		default:
+			rest, err := d.fusedStructKeyVal(b, root)
+			if err != nil {
+				return d.wrapFusedError(data, err)
+			}
+			b = rest
+		}
+	}
+}
+
+// fusedStructKeyVal handles one `key = value` expression for a reflection
+// target. b starts at the first character of the key. Scalar values are
+// scanned without any AST node; container values are parsed into the arena
+// as usual, so typed arrays and inline tables decode identically to the AST
+// path.
+func (d *decoder) fusedStructKeyVal(b []byte, root reflect.Value) ([]byte, error) {
+	var err error
+	var rawKey []byte
+	d.keyParts, d.keyRaws, rawKey, b, err = parserbridge.ScanKeyRaws(&d.p, b, d.keyParts[:0], d.keyRaws[:0])
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 || b[0] != '=' {
+		return nil, unstable.NewParserError(fusedHL1(b), "expected '=' after key")
+	}
+	b = fusedSkipWS(b[1:])
+	if len(b) == 0 {
+		return nil, unstable.NewParserError(b, "expected value, not end of input")
+	}
+
+	if c := b[0]; c == '[' || c == '{' {
+		valStart := b
+		nodeAny, rest, err := parserbridge.ParseValue(&d.p, b)
+		if err != nil {
+			return nil, err
+		}
+		node := nodeAny.(*unstable.Node)
+		valSpan := valStart[:len(valStart)-len(rest)]
+		rest, err = d.fusedFinishLine(rest)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := d.seen.CheckKeyValue(d.keyParts); err != nil {
+			return nil, d.fusedSeenError(rawKey, d.keyParts, err)
+		}
+		if err := d.validateValueNode(node); err != nil {
+			return nil, d.fusedSeenError(rawKey, d.keyParts, err)
+		}
+		if d.skipUntilTable {
+			return rest, nil
+		}
+		d.fusedValueSpan = valSpan
+		err = d.fusedHandleKeyValue(root, rawKey, node)
+		d.fusedValueSpan = nil
+		return rest, err
+	}
+
+	// Scalar value: no AST at all. The stack node carries the same kind,
+	// data, and raw range an arena node would; nothing retains it.
+	k, rawVal, value, rest, err := parserbridge.ScanScalar(&d.p, b)
+	if err != nil {
+		return nil, err
+	}
+	rest, err = d.fusedFinishLine(rest)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := d.seen.CheckKeyValue(d.keyParts); err != nil {
+		return nil, d.fusedSeenError(rawKey, d.keyParts, err)
+	}
+	if d.skipUntilTable {
+		return rest, nil
+	}
+	node := unstable.Node{
+		Kind: unstable.Kind(k),
+		Raw:  d.p.Range(rawVal),
+		Data: value,
+	}
+	return rest, d.fusedHandleKeyValue(root, rawKey, &node)
+}
+
+// fusedHandleKeyValue mirrors handleKeyValueExpression, driven by the scanned
+// key parts (d.keyParts/d.keyRaws) instead of an expression node.
+func (d *decoder) fusedHandleKeyValue(root reflect.Value, rawKey []byte, value *unstable.Node) error {
+	d.path = d.path[:0]
+
+	target := root
+	useCache := d.tableTargetValid && len(d.tableKey) > 0
+	if useCache {
+		target = d.tableTarget
+	} else {
+		for _, name := range d.tableKey {
+			d.path = append(d.path, pathPart{name: name})
+		}
+	}
+	for i := range d.keyParts {
+		d.path = append(d.path, pathPart{data: d.keyParts[i], rng: d.p.Range(d.keyRaws[i])})
+	}
+	d.fusedKVParts = d.keyParts
+	d.fusedKVKeyRange = d.p.Range(rawKey)
+
+	nv, err := d.descend(target, d.path, 0, nil, value)
+	if err != nil {
+		return d.contextualizeError(err, useCache)
+	}
+	if !nv.IsValid() {
+		return nil
+	}
+	if useCache {
+		// The target may have been replaced (e.g. a nil map allocated):
+		// re-link it into its parent.
+		if nv.Kind() == reflect.Map && nv.Pointer() != d.tableTarget.Pointer() {
+			d.storeSlot(&d.tableParentSlot, nv)
+			d.tableTarget = nv
+		}
+	} else {
+		if root.CanSet() {
+			root.Set(nv)
+		}
+	}
+	return nil
+}
+
+// validateValueNode checks the keys declared inside a container value node
+// (an inline table or array from the expression parser). The value is stored
+// under a leaf key no later expression can reach, so a second, per-value
+// tracker validates it instead of the main one, with identical rules.
+func (d *decoder) validateValueNode(value *unstable.Node) error {
+	if value.Kind != unstable.InlineTable && value.Kind != unstable.Array {
+		return nil
+	}
+	d.valSeen.Reset()
+	return d.valSeen.CheckValueUnder(0, value)
+}

--- a/internal/parserbridge/parserbridge.go
+++ b/internal/parserbridge/parserbridge.go
@@ -30,8 +30,18 @@ var (
 	// needs no parser state.
 	ScanComment func(b []byte) (comment, rest []byte, err error)
 
+	// ScanKeyRaws is ScanKey, additionally collecting the raw span of each
+	// part (undecoded, quotes included) into raws.
+	ScanKeyRaws func(p any, b []byte, dst, raws [][]byte) (parts, rawsOut [][]byte, raw, rest []byte, err error)
+
 	// ParseValue parses a single value (including arrays and inline tables) into
 	// the parser arena, returning the root *unstable.Node and the rest of the
 	// input.
 	ParseValue func(p any, b []byte) (node any, rest []byte, err error)
+
+	// SetCursor repositions the parser's expression cursor, so that a caller
+	// scanning the document itself can delegate the next expression to
+	// Parser.NextExpression. Cursor reads it back.
+	SetCursor func(p any, rest []byte)
+	Cursor    func(p any) []byte
 )

--- a/internal/tracker/key.go
+++ b/internal/tracker/key.go
@@ -39,6 +39,17 @@ func (t *KeyTracker) Pop(node *unstable.Node) {
 	}
 }
 
+// PushParts pushes already-decoded key parts on the stack, for callers that
+// track keys without an AST.
+func (t *KeyTracker) PushParts(parts [][]byte) {
+	t.k = append(t.k, parts...)
+}
+
+// PopN pops n parts from the stack.
+func (t *KeyTracker) PopN(n int) {
+	t.k = t.k[:len(t.k)-n]
+}
+
 // Key returns the current key.
 func (t *KeyTracker) Key() []string {
 	k := make([]string, len(t.k))

--- a/internal/tracker/seen.go
+++ b/internal/tracker/seen.go
@@ -439,6 +439,15 @@ func (s *SeenTracker) CreateAnonymous(parent int32) int32 {
 	return s.create(parent, nil, anonymousKind, false)
 }
 
+// CheckValueUnder validates the content of a value node stored under the
+// given entry: inline tables cannot contain duplicate keys, including in the
+// inline tables and arrays they contain. The fused struct path uses it to
+// validate container values (which it still parses into the arena) against a
+// per-value tracker.
+func (s *SeenTracker) CheckValueUnder(parent int32, value *unstable.Node) error {
+	return s.checkValue(parent, value)
+}
+
 // CheckKeyValueUnder validates the (possibly dotted) key of a key-value under
 // the given parent entry, WITHOUT validating its value. It mirrors
 // checkKeyValue but is driven directly from the key parts, for callers that

--- a/strict.go
+++ b/strict.go
@@ -66,6 +66,21 @@ func (s *strict) MissingField(node *unstable.Node) {
 	s.key.Pop(node)
 }
 
+// MissingFieldParts is MissingField for callers that decode without an AST:
+// rng is the location of the whole (dotted) key and parts its decoded parts.
+func (s *strict) MissingFieldParts(rng unstable.Range, parts [][]byte) {
+	if !s.Enabled {
+		return
+	}
+	s.key.PushParts(parts)
+	s.missing = append(s.missing, decodeError{
+		highlight: rng,
+		key:       s.key.Key(),
+		message:   "unknown field",
+	})
+	s.key.PopN(len(parts))
+}
+
 // Error returns the cumulated StrictMissingError for the document, or nil.
 func (s *strict) Error(document []byte) error {
 	if !s.Enabled || len(s.missing) == 0 {

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -62,9 +62,12 @@ func (d *decoder) reset() {
 	d.tableFlush = d.tableFlush[:0]
 	d.tableParentSlot = slotWriter{}
 	d.keyParts = d.keyParts[:0]
+	d.keyRaws = d.keyRaws[:0]
 	d.fusedParts = d.fusedParts[:0]
 	d.fusedOps = d.fusedOps[:0]
 	d.idStack = d.idStack[:0]
+	d.fusedKVParts = nil
+	d.fusedValueSpan = nil
 	// A decode aborted by an error may leave the count non-zero.
 	d.fusedNesting = 0
 	d.strict.Reset()
@@ -187,17 +190,23 @@ func (d *Decoder) Decode(v interface{}) error {
 
 // pathPart is one part of the key path leading to a value. Parts that come
 // from the current table header only carry a name; parts that come from the
-// key of the current key-value expression also carry the AST node, and their
-// name is materialized lazily to avoid allocations.
+// key of the current key-value expression also carry the AST node — or, on
+// the fused (AST-free) path, the decoded part bytes and the range of its raw
+// span — and their name is materialized lazily to avoid allocations.
 type pathPart struct {
 	name string
 	node *unstable.Node
+	data []byte
+	rng  unstable.Range
 }
 
 // bytes returns the raw bytes of the key part.
 func (p *pathPart) bytes() []byte {
 	if p.node != nil {
 		return p.node.Data
+	}
+	if p.data != nil {
+		return p.data
 	}
 	return []byte(p.name)
 }
@@ -206,6 +215,9 @@ func (p *pathPart) bytes() []byte {
 func (p *pathPart) str() string {
 	if p.node != nil {
 		return string(p.node.Data)
+	}
+	if p.data != nil {
+		return string(p.data)
 	}
 	return p.name
 }
@@ -309,6 +321,15 @@ type decoder struct {
 	// natively, bounded by maxFusedNesting (see fusedContainerValue).
 	fusedNesting int
 
+	// Fused struct-path state: keyRaws is the reusable buffer of raw key-part
+	// spans matching keyParts; fusedKVParts/fusedKVKeyRange describe the key
+	// of the key-value being decoded (for strict-mode reporting) and
+	// fusedValueSpan the exact raw span of its value (for error highlights).
+	keyRaws         [][]byte
+	fusedKVParts    [][]byte
+	fusedKVKeyRange unstable.Range
+	fusedValueSpan  []byte
+
 	// valSeen validates the keys declared inside a single container value,
 	// which no later expression can reach: keeping them out of d.seen means
 	// the main tracker only ever holds reachable keys. Reset (cheaply) for
@@ -390,6 +411,9 @@ func (d *decoder) intern(b []byte) string {
 func (d *decoder) partString(p *pathPart) string {
 	if p.node != nil {
 		return d.intern(p.node.Data)
+	}
+	if p.data != nil {
+		return d.intern(p.data)
 	}
 	return p.name
 }
@@ -546,27 +570,36 @@ func (d *decoder) unmarshal(data []byte, v interface{}) error {
 		}
 	}
 
-	// When the root target itself implements the Unmarshaler interface, the
-	// whole document decodes into it. Open a capture spanning the entire
-	// document up front: the top-level key-values then flow through the
-	// existing capture branch and any tables attach to it via resumeCapture,
-	// so UnmarshalTOML receives the assembled document exactly once.
-	if d.unmarshalerInterface && hasUnmarshaler(root) {
-		d.startRootCapture()
-	}
+	if !d.unmarshalerInterface {
+		// Reflection targets without the unmarshaler interface use the fused
+		// document loop: scalar key-values decode without an AST.
+		if err := d.fusedStructDocument(root, data); err != nil {
+			return err
+		}
+	} else {
+		// When the root target itself implements the Unmarshaler interface,
+		// the whole document decodes into it. Open a capture spanning the
+		// entire document up front: the top-level key-values then flow
+		// through the existing capture branch and any tables attach to it via
+		// resumeCapture, so UnmarshalTOML receives the assembled document
+		// exactly once.
+		if hasUnmarshaler(root) {
+			d.startRootCapture()
+		}
 
-	for d.p.NextExpression() {
-		err := d.handleRootExpression(d.p.Expression(), root)
-		if err != nil {
-			return d.wrapError(data, err)
+		for d.p.NextExpression() {
+			err := d.handleRootExpression(d.p.Expression(), root)
+			if err != nil {
+				return d.wrapError(data, err)
+			}
 		}
-	}
-	if err := d.p.Error(); err != nil {
-		var perr *unstable.ParserError
-		if errors.As(err, &perr) {
-			return wrapDecodeError(data, perr)
+		if err := d.p.Error(); err != nil {
+			var perr *unstable.ParserError
+			if errors.As(err, &perr) {
+				return wrapDecodeError(data, perr)
+			}
+			return err
 		}
-		return err
 	}
 
 	d.flushTable()
@@ -1527,6 +1560,8 @@ func (d *decoder) descend(v reflect.Value, path []pathPart, idx int, expr *unsta
 		if !found {
 			if part.node != nil {
 				d.strict.MissingField(expr)
+			} else if part.data != nil {
+				d.strict.MissingFieldParts(d.fusedKVKeyRange, d.fusedKVParts)
 			}
 			return v, nil
 		}
@@ -1592,7 +1627,7 @@ func (d *decoder) descend(v reflect.Value, path []pathPart, idx int, expr *unsta
 		}
 		elemIdx := cnt - 1
 		if elemIdx >= v.Len() {
-			return reflect.Value{}, unstable.NewParserError(keyHighlight(d.p.Data(), part.node),
+			return reflect.Value{}, unstable.NewParserError(partHighlight(d.p.Data(), &part),
 				"cannot reach element %d of array of size %d", elemIdx, v.Len())
 		}
 		elem := v.Index(elemIdx)
@@ -1605,7 +1640,7 @@ func (d *decoder) descend(v reflect.Value, path []pathPart, idx int, expr *unsta
 		}
 		return v, nil
 	default:
-		return reflect.Value{}, d.typeMismatchError("table", v.Type(), keyHighlight(d.p.Data(), part.node))
+		return reflect.Value{}, d.typeMismatchError("table", v.Type(), partHighlight(d.p.Data(), &part))
 	}
 }
 
@@ -1654,12 +1689,28 @@ func keyHighlight(doc []byte, node *unstable.Node) []byte {
 	return doc[node.Raw.Offset : node.Raw.Offset+node.Raw.Length]
 }
 
+// partHighlight returns a highlight for a key path part, whether it carries
+// an AST node or raw bytes from the fused path.
+func partHighlight(doc []byte, part *pathPart) []byte {
+	if part.node == nil && part.data != nil {
+		return doc[part.rng.Offset : part.rng.Offset+part.rng.Length]
+	}
+	return keyHighlight(doc, part.node)
+}
+
 // rawValue returns the raw bytes of the value of a key-value expression.
 func (d *decoder) rawValue(expr *unstable.Node, value *unstable.Node) []byte {
 	if value.Kind != unstable.InlineTable && value.Kind != unstable.Array {
 		return d.p.Raw(value.Raw)
 	}
-	if expr == nil || expr.Kind != unstable.KeyValue {
+	if expr == nil {
+		if d.fusedValueSpan != nil {
+			// Fused path: the exact span of the current key-value's value.
+			return d.fusedValueSpan
+		}
+		return d.p.Raw(value.Raw)
+	}
+	if expr.Kind != unstable.KeyValue {
 		// Inline container nested in another container: best effort.
 		return d.p.Raw(value.Raw)
 	}

--- a/unstable/bridge.go
+++ b/unstable/bridge.go
@@ -14,8 +14,17 @@ func init() {
 	parserbridge.ScanKey = func(p any, b []byte, dst [][]byte) (parts [][]byte, raw, rest []byte, err error) {
 		return p.(*Parser).scanKey(b, dst)
 	}
+	parserbridge.ScanKeyRaws = func(p any, b []byte, dst, raws [][]byte) (parts, rawsOut [][]byte, raw, rest []byte, err error) {
+		return p.(*Parser).scanKeyRaws(b, dst, raws)
+	}
 	parserbridge.ScanComment = scanComment
 	parserbridge.ParseValue = func(p any, b []byte) (node any, rest []byte, err error) {
 		return p.(*Parser).parseValue(b)
+	}
+	parserbridge.SetCursor = func(p any, rest []byte) {
+		p.(*Parser).left = rest
+	}
+	parserbridge.Cursor = func(p any) []byte {
+		return p.(*Parser).left
 	}
 }

--- a/unstable/parser.go
+++ b/unstable/parser.go
@@ -640,6 +640,37 @@ func (p *Parser) scanKey(b []byte, dst [][]byte) (parts [][]byte, raw, rest []by
 	}
 }
 
+// scanKeyRaws is scanKey, additionally appending the raw span of each part
+// (undecoded, quotes included — the same bytes a Key node's Raw range covers)
+// to raws.
+//
+// It is exposed to the root toml package through internal/parserbridge for the
+// fused decode paths; it is not part of the public API.
+func (p *Parser) scanKeyRaws(b []byte, dst, raws [][]byte) (parts, rawsOut [][]byte, raw, rest []byte, err error) {
+	parts = dst
+	rawsOut = raws
+	start := b
+	for {
+		praw, value, r, err := p.scanSimpleKey(b)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
+		parts = append(parts, value)
+		rawsOut = append(rawsOut, praw)
+
+		// r points just past the current part: the key spans from start to
+		// here, ignoring any whitespace that follows.
+		raw = start[:len(start)-len(r)]
+
+		b = skipWhitespace(r)
+		if len(b) > 0 && b[0] == '.' {
+			b = skipWhitespace(b[1:])
+			continue
+		}
+		return parts, rawsOut, raw, b, nil
+	}
+}
+
 // parseValue parses a single TOML value, which may be an array or inline table,
 // into the parser's arena. It returns the root node of the value and the rest
 // of the input. It resets the arena, so any node returned by a previous call to


### PR DESCRIPTION
Splitting #1088: this PR carries one optimization technique so its impact and review surface stay isolated. Stacked on #1102: merge the decode chain in order.

## What

Reflection targets (structs, typed maps, ...) parsed every expression into the AST arena. Scalar key-values — the bulk of a document — now scan their key and value directly (`fusedStructDocument` / `fusedStructKeyVal`) and dispatch through the existing descend/assign machinery via path parts carrying the scanned bytes and ranges (`pathPart.data`/`rng`).

What deliberately stays on the expression parser:

- **Table headers and container values** — a two-function cursor bridge (`SetCursor`/`Cursor`) hands the document position to `Parser.NextExpression` and back, so array-table bookkeeping, seen-tracking, and error rendering are byte-identical. Container values are validated by the per-value tracker with the same rules.
- **The unmarshaler-interface mode** keeps the full AST loop: captures need the raw expression ranges.

Strict mode reports missing fields through parts with the same key spans an AST node would produce (`MissingFieldParts`), so `StrictMissingError` output is unchanged.

## Impact

Benchmarked on a dedicated linux/amd64 spot VM (t2d), go1.26.4, interleaved A/B vs the base of this PR, benchstat over 10 samples per side:

- sec/op geomean: **-7.31%**
- `Marshal/SimpleDocument/struct`: -26.87%
- `UnmarshalDataset/code`: -20.42%
- `Marshal/SimpleDocument/map`: -20.33%
- `UnmarshalDataset/example`: -13.26%
- `Unmarshal/SimpleDocument/map`: -9.81%
- `Unmarshal/SimpleDocument/struct`: -9.53%
- `RealWorldGolangciStrict`: -2.25%
- `RealWorldViperWrite`: +2.35%
- `Unmarshal/ReferenceFile/struct`: +5.64%
- `Unmarshal/HugoFrontMatter`: +9.49%
- `Marshal/ReferenceFile/struct`: +11.05%

<details>
<summary>Full benchstat (sec/op, allocs/op)</summary>

#### sec/op
```
UnmarshalDataset/config  17.55m ± 32%  12.67m ± 47%  ~ (p=0.971 n=10)
UnmarshalDataset/canada  33.87m ± 20%  29.60m ± 19%  ~ (p=0.631 n=10)
UnmarshalDataset/citm_catalog  15.89m ± 28%  11.67m ± 50%  ~ (p=0.315 n=10)
UnmarshalDataset/twitter  5.768m ± 13%  5.016m ± 35%  ~ (p=0.218 n=10)
UnmarshalDataset/code  51.29m ± 17%  40.82m ± 28%  -20.42% (p=0.043 n=10)
UnmarshalDataset/example  116.8µ ± 11%  101.3µ ± 12%  -13.26% (p=0.005 n=10)
Unmarshal/SimpleDocument/struct  393.4n ±  3%  355.9n ±  3%  -9.53% (p=0.000 n=10)
Unmarshal/SimpleDocument/map  636.1n ± 15%  573.8n ±  3%  -9.81% (p=0.029 n=10)
Unmarshal/ReferenceFile/struct  40.00µ ±  5%  42.26µ ±  2%  +5.64% (p=0.001 n=10)
Unmarshal/ReferenceFile/map  40.09µ ±  4%  39.43µ ±  4%  ~ (p=0.052 n=10)
Unmarshal/HugoFrontMatter  7.673µ ±  6%  8.401µ ± 10%  +9.49% (p=0.019 n=10)
Marshal/SimpleDocument/struct  676.2n ±  3%  494.5n ± 41%  -26.87% (p=0.023 n=10)
Marshal/SimpleDocument/map  909.3n ±  3%  724.4n ± 25%  -20.33% (p=0.001 n=10)
Marshal/ReferenceFile/struct  22.24µ ± 13%  24.70µ ±  4%  +11.05% (p=0.008 n=10)
Marshal/ReferenceFile/map  43.76µ ±  6%  44.14µ ±  1%  ~ (p=0.529 n=10)
Marshal/HugoFrontMatter  9.335µ ±  5%  9.692µ ±  6%  ~ (p=0.190 n=10)
RealWorldContainerdConfig  47.13µ ±  9%  47.01µ ±  5%  ~ (p=0.579 n=10)
RealWorldViperRead  11.41µ ±  7%  11.39µ ±  4%  ~ (p=0.684 n=10)
RealWorldViperWrite  13.43µ ±  3%  13.75µ ±  6%  +2.35% (p=0.002 n=10)
RealWorldHugoFrontMatterBatch  132.8µ ±  3%  133.1µ ±  7%  ~ (p=0.631 n=10)
RealWorldGitleaksRules  79.00µ ±  1%  77.62µ ±  5%  ~ (p=0.143 n=10)
RealWorldPyproject  20.86µ ±  9%  21.19µ ±  5%  ~ (p=0.481 n=10)
RealWorldGolangciStrict  13.58µ ± 11%  13.27µ ± 11%  -2.25% (p=0.035 n=10)
geomean  61.11µ  56.64µ  -7.31%
```
#### allocs/op
```
UnmarshalDataset/config  70.19k ± 0%  70.19k ± 0%  ~ (p=1.000 n=10)
UnmarshalDataset/canada  223.2k ± 0%  223.2k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog  49.98k ± 0%  49.98k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/twitter  15.78k ± 0%  15.78k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/code  129.5k ± 0%  129.5k ± 0%  ~ (p=0.211 n=10)
UnmarshalDataset/example  399.0 ± 0%  399.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct  2.000 ± 0%  2.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map  5.000 ± 0%  5.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct  83.00 ± 0%  83.00 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map  194.0 ± 0%  194.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter  54.00 ± 0%  54.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map  91.00 ± 0%  91.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter  20.00 ± 0%  20.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldContainerdConfig  144.0 ± 0%  144.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperRead  65.00 ± 0%  65.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperWrite  33.00 ± 0%  33.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldHugoFrontMatterBatch  820.0 ± 0%  820.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGitleaksRules  259.0 ± 0%  259.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldPyproject  142.0 ± 0%  142.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGolangciStrict  34.00 ± 0%  34.00 ± 0%  ~ (p=1.000 n=10) ¹
geomean  207.9  207.9  +0.00%
¹ all samples are equal
```

</details>

This is a decode-only change: the `Marshal/*` rows moving in both directions are code-alignment noise (the encoder is untouched byte-for-byte). Within decode, scalar-heavy documents win big (code −20%, example −13%, SimpleDocument −10%); `ReferenceFile/struct`/`HugoFrontMatter` give some back on this host — table-header-heavy shapes where the cursor bridge round-trips dominate — and net out ahead across the chain (see the combined numbers in the #1088 close-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
