### PR TITLE
perf: classify encoder table entries once

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -321,6 +321,7 @@ type entry struct {
 	key     string
 	value   reflect.Value
 	options valueOptions
+	class   entryClass
 }
 
 // rawShape classifies the bytes produced by an unstable.Marshaler.
@@ -338,6 +339,45 @@ const (
 	// shapeTable is one or more key-value lines, emitted as a `[key]` body.
 	shapeTable
 )
+
+// entryClass tells how an entry of a table is emitted: as a `key = value`
+// line, a [table], or an [[array of tables]]. It is computed at most once per
+// entry and cached: classifying requires resolving the value's type (and for
+// arrays, the type of every element), which was previously repeated by each
+// of the encoding passes — up to three times per entry.
+type entryClass uint8
+
+const (
+	// classUnknown means the entry has not been classified yet.
+	classUnknown entryClass = iota
+	classKeyValue
+	classTable
+	classArrayTable
+)
+
+// classify computes the entryClass of an entry.
+func (e *encoderState) classify(ent *entry) entryClass {
+	if e.tablesInline || ent.options.inline {
+		return classKeyValue
+	}
+	if e.isArrayOfTables(ent.value) {
+		return classArrayTable
+	}
+	if e.isTableLike(ent.value) {
+		return classTable
+	}
+	return classKeyValue
+}
+
+// classOf returns the entry's class, computing and caching it on first use.
+// Marshaler-shaped entries are classified by their rawShape routing instead
+// and never reach classify.
+func (e *encoderState) classOf(ent *entry) entryClass {
+	if ent.class == classUnknown {
+		ent.class = e.classify(ent)
+	}
+	return ent.class
+}
 
 func (e *encoderState) encodeRoot(v interface{}) error {
 	if v == nil {
@@ -684,32 +724,32 @@ func (e *encoderState) encodeTableEntries(entries []entry, commented bool, inden
 	// pass.
 	for i := range entries {
 		ent := &entries[i]
-		if mOn {
-			switch ent.options.rawShape {
-			case shapeUnknown:
-				// Not a Marshaler: handled by the baseline logic below.
+		if mOn && ent.options.rawShape != shapeUnknown {
+			switch ent.options.rawShape { //nolint:exhaustive // shapeUnknown is excluded by the guard
 			case shapeEmpty:
-				// No TOML representation: omit the key.
-				continue
+				// No TOML representation: omit the key (the key-value class
+				// keeps the second pass away from it too).
+				ent.class = classKeyValue
 			case shapeValue:
+				ent.class = classKeyValue
 				if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
 					return err
 				}
-				continue
 			case shapeTable:
 				// A table body is emitted in the second pass, unless it is
 				// forced inline (SetTablesInline / inline tag), which has no
 				// valid inline form and is reported as an error by
 				// encodeKeyValue.
+				ent.class = classTable
 				if e.tablesInline || ent.options.inline {
 					if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
 						return err
 					}
 				}
-				continue
 			}
+			continue
 		}
-		if e.entryIsTable(ent) {
+		if e.classOf(ent) != classKeyValue {
 			continue
 		}
 		if err := e.encodeKeyValue(*ent, commented, indent); err != nil {
@@ -718,34 +758,29 @@ func (e *encoderState) encodeTableEntries(entries []entry, commented bool, inden
 	}
 
 	// Second pass: emit the sub-tables, extending the shared key stack.
+	// Every entry was classified by the first pass (or earlier), so the
+	// class routes it without resolving any type again.
 	for i := range entries {
 		ent := entries[i]
-		if mOn {
-			switch ent.options.rawShape {
-			case shapeUnknown:
-				// Not a Marshaler: handled by the baseline logic below.
-			case shapeValue, shapeEmpty:
-				// Not a table: already handled (or omitted) in the first pass.
-				continue
-			case shapeTable:
-				// Emit the raw body verbatim under the freshly pushed header.
-				// (The forced-inline case already errored in the first pass.)
-				entCommented := commented || ent.options.commented
-				e.keyStack = append(e.keyStack, ent.key)
-				if err := e.encodeMarshalerTable(&ent, entCommented, indent); err != nil {
-					return err
-				}
-				e.keyStack = e.keyStack[:len(e.keyStack)-1]
-				continue
+		if mOn && ent.options.rawShape == shapeTable {
+			// Emit the raw body verbatim under the freshly pushed header.
+			// (The forced-inline case already errored in the first pass;
+			// value- and empty-shaped entries carry the key-value class.)
+			entCommented := commented || ent.options.commented
+			e.keyStack = append(e.keyStack, ent.key)
+			if err := e.encodeMarshalerTable(&ent, entCommented, indent); err != nil {
+				return err
 			}
+			e.keyStack = e.keyStack[:len(e.keyStack)-1]
+			continue
 		}
-		if !e.entryIsTable(&ent) {
+		if ent.class == classKeyValue {
 			continue
 		}
 		entCommented := commented || ent.options.commented
 		e.keyStack = append(e.keyStack, ent.key)
 
-		if e.isArrayOfTables(ent.value) {
+		if ent.class == classArrayTable {
 			err := e.encodeArrayTable(ent, entCommented, indent)
 			if err != nil {
 				return err
@@ -754,7 +789,7 @@ func (e *encoderState) encodeTableEntries(entries []entry, commented bool, inden
 			continue
 		}
 
-		// The value is resolvable: entryIsTable already resolved it.
+		// The value is resolvable: classify already resolved it.
 		tv, _ := resolve(ent.value)
 
 		subEntries, err := e.collectEntries(tv)
@@ -815,7 +850,7 @@ func (e *encoderState) onlySubTables(entries []entry) bool {
 			}
 			continue
 		}
-		if !e.entryIsTable(ent) {
+		if e.classOf(ent) == classKeyValue {
 			return false
 		}
 	}
@@ -856,13 +891,6 @@ func (e *encoderState) spliceRawTableBody(raw []byte, commented bool) {
 	}
 	e.buf = append(e.buf, '\n')
 	e.lastWasHeader = false
-}
-
-// entryIsTable reports whether the entry is emitted as a (sub-)table rather
-// than a key-value. Marshaler entries are routed by encodeTable before this is
-// reached, so it carries no marshaler-specific cost.
-func (e *encoderState) entryIsTable(ent *entry) bool {
-	return !e.tablesInline && !ent.options.inline && (e.isTableLike(ent.value) || e.isArrayOfTables(ent.value))
 }
 
 // getEntries returns a reusable entry slice.


### PR DESCRIPTION
Splitting #1088: this PR carries one optimization technique so its impact and review surface stay isolated. First of the encoder chain.

## What

Deciding whether an entry is a key-value, a table, or an array of tables requires resolving the value's type — and for arrays, resolving the type of every element. That decision was re-derived by each encoding pass (and a third time by `SetOmitEmptySuperTables`'s super-table check), up to three times per entry.

Entries now carry an `entryClass`, computed at most once and cached on the entry: the first pass classifies while emitting key-values, the second pass routes on the stored class, and `onlySubTables` reuses whatever the entries already know (`classOf` computes lazily for the entries it sees first). `entryIsTable` disappears.

Marshaler-shaped entries keep their `rawShape` routing and are assigned their class by it, so the opt-in `unstable.Marshaler` semantics are untouched.

## Impact

Benchmarked on a dedicated linux/amd64 spot VM (t2d), go1.26.4, interleaved A/B vs the base of this PR, benchstat over 10 samples per side:

- sec/op geomean: **-2.45%**
- `Marshal/HugoFrontMatter`: -9.85%
- `Marshal/ReferenceFile/struct`: -9.63%
- `RealWorldViperWrite`: -8.13%
- `Marshal/SimpleDocument/map`: -7.63%
- `Marshal/SimpleDocument/struct`: -7.23%
- `Marshal/ReferenceFile/map`: -7.02%

<details>
<summary>Full benchstat (sec/op, allocs/op)</summary>

#### sec/op
```
UnmarshalDataset/config  10.24m ± 1%  10.27m ± 1%  ~ (p=0.529 n=10)
UnmarshalDataset/canada  23.26m ± 1%  23.16m ± 1%  ~ (p=0.912 n=10)
UnmarshalDataset/citm_catalog  14.91m ± 1%  14.79m ± 1%  ~ (p=0.143 n=10)
UnmarshalDataset/twitter  3.572m ± 0%  3.566m ± 0%  ~ (p=0.075 n=10)
UnmarshalDataset/code  33.32m ± 1%  33.45m ± 1%  ~ (p=0.631 n=10)
UnmarshalDataset/example  77.10µ ± 0%  77.01µ ± 2%  ~ (p=0.529 n=10)
Unmarshal/SimpleDocument/struct  332.0n ± 1%  328.6n ± 3%  ~ (p=0.159 n=10)
Unmarshal/SimpleDocument/map  423.1n ± 1%  423.4n ± 1%  ~ (p=0.542 n=10)
Unmarshal/ReferenceFile/struct  39.04µ ± 2%  38.87µ ± 2%  ~ (p=0.853 n=10)
Unmarshal/ReferenceFile/map  31.21µ ± 1%  31.15µ ± 1%  ~ (p=0.853 n=10)
Unmarshal/HugoFrontMatter  5.602µ ± 1%  5.615µ ± 1%  ~ (p=0.448 n=10)
Marshal/SimpleDocument/struct  397.4n ± 1%  368.7n ± 3%  -7.23% (p=0.000 n=10)
Marshal/SimpleDocument/map  592.4n ± 1%  547.2n ± 2%  -7.63% (p=0.000 n=10)
Marshal/ReferenceFile/struct  20.44µ ± 1%  18.47µ ± 4%  -9.63% (p=0.000 n=10)
Marshal/ReferenceFile/map  38.89µ ± 2%  36.16µ ± 3%  -7.02% (p=0.000 n=10)
Marshal/HugoFrontMatter  7.941µ ± 3%  7.158µ ± 2%  -9.85% (p=0.000 n=10)
RealWorldContainerdConfig  39.67µ ± 1%  39.26µ ± 2%  ~ (p=0.089 n=10)
RealWorldViperRead  8.241µ ± 1%  8.210µ ± 0%  ~ (p=0.160 n=10)
RealWorldViperWrite  12.67µ ± 3%  11.64µ ± 3%  -8.13% (p=0.000 n=10)
RealWorldHugoFrontMatterBatch  93.86µ ± 2%  92.58µ ± 1%  -1.36% (p=0.000 n=10)
RealWorldGitleaksRules  63.43µ ± 3%  63.74µ ± 1%  ~ (p=0.971 n=10)
RealWorldPyproject  14.85µ ± 1%  14.71µ ± 1%  -0.96% (p=0.029 n=10)
RealWorldGolangciStrict  11.73µ ± 1%  11.75µ ± 1%  ~ (p=0.753 n=10)
geomean  46.26µ  45.13µ  -2.45%
```
#### allocs/op
```
UnmarshalDataset/config  70.19k ± 0%  70.19k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/canada  223.2k ± 0%  223.2k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog  49.98k ± 0%  49.98k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/twitter  15.78k ± 0%  15.78k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/code  129.5k ± 0%  129.5k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/example  399.0 ± 0%  399.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct  2.000 ± 0%  2.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map  5.000 ± 0%  5.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct  83.00 ± 0%  83.00 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map  194.0 ± 0%  194.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter  54.00 ± 0%  54.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map  91.00 ± 0%  91.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter  20.00 ± 0%  20.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldContainerdConfig  144.0 ± 0%  144.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperRead  65.00 ± 0%  65.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperWrite  33.00 ± 0%  33.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldHugoFrontMatterBatch  820.0 ± 0%  820.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGitleaksRules  259.0 ± 0%  259.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldPyproject  142.0 ± 0%  142.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGolangciStrict  48.00 ± 0%  48.00 ± 0%  ~ (p=1.000 n=10) ¹
geomean  211.1  211.1  +0.00%
¹ all samples are equal
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
