### PR TITLE
perf: fast-path encoder type properties

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -298,6 +298,37 @@ type encoderState struct {
 	// the per-value hot path checks a direct field instead of dereferencing the
 	// embedded *Encoder on every value.
 	marshalerOn bool
+
+	// propsMemo is a small MRU memo of encPropsForType lookups: the values
+	// of a document hit the same few named types over and over, and the
+	// global cache lookup costs an interface hash every time.
+	propsMemo [16]struct {
+		t reflect.Type
+		p typeEncProps
+	}
+}
+
+// propsFor returns the encoding properties of t, memoizing recent lookups of
+// the types the builtin fast path of encPropsForType does not cover.
+func (e *encoderState) propsFor(t reflect.Type) typeEncProps {
+	if p, ok := builtinEncProps(t); ok {
+		return p
+	}
+	if e.propsMemo[0].t == t {
+		return e.propsMemo[0].p
+	}
+	for i := 1; i < len(e.propsMemo); i++ {
+		if e.propsMemo[i].t == t {
+			m := e.propsMemo[i]
+			copy(e.propsMemo[1:i+1], e.propsMemo[:i])
+			e.propsMemo[0] = m
+			return m.p
+		}
+	}
+	p := encPropsForType(t)
+	copy(e.propsMemo[1:], e.propsMemo[:len(e.propsMemo)-1])
+	e.propsMemo[0].t, e.propsMemo[0].p = t, p
+	return p
 }
 
 // valueOptions are the encoding options attached to one entry of a table.
@@ -469,7 +500,48 @@ var marshalerType = reflect.TypeOf(new(unstable.Marshaler)).Elem()
 
 var typeEncPropsCache sync.Map // reflect.Type -> typeEncProps
 
+// builtinEncProps resolves the encoding properties of the handful of builtin
+// types that make up generic documents (map[string]interface{} trees), none
+// of which can implement TextMarshaler, with a kind dispatch and one pointer
+// comparison instead of a cache lookup.
+func builtinEncProps(t reflect.Type) (typeEncProps, bool) {
+	switch t.Kind() { //nolint:exhaustive // other kinds take the cached path
+	case reflect.String:
+		if t == stringType {
+			return typeEncProps{isValue: true}, true
+		}
+	case reflect.Bool:
+		if t == boolType {
+			return typeEncProps{isValue: true}, true
+		}
+	case reflect.Int:
+		if t == intType {
+			return typeEncProps{isValue: true}, true
+		}
+	case reflect.Int64:
+		if t == int64Type {
+			return typeEncProps{isValue: true}, true
+		}
+	case reflect.Float64:
+		if t == float64Type {
+			return typeEncProps{isValue: true}, true
+		}
+	case reflect.Slice:
+		if t == sliceInterfaceType {
+			return typeEncProps{isValue: true}, true
+		}
+	case reflect.Map:
+		if t == mapStringInterfaceType {
+			return typeEncProps{isValue: false}, true
+		}
+	}
+	return typeEncProps{}, false
+}
+
 func encPropsForType(t reflect.Type) typeEncProps {
+	if p, ok := builtinEncProps(t); ok {
+		return p
+	}
 	if p, ok := typeEncPropsCache.Load(t); ok {
 		return p.(typeEncProps)
 	}
@@ -520,7 +592,7 @@ func (e *encoderState) isTableLike(v reflect.Value) bool {
 		// the zero value of their element type by the value path.
 		return false
 	}
-	return !isValueKind(v)
+	return !e.propsFor(v.Type()).isValue
 }
 
 // isArrayOfTables returns true when the value is a non-empty slice or array
@@ -543,7 +615,7 @@ func (e *encoderState) isArrayOfTables(v reflect.Value) bool {
 	}
 	for i := 0; i < v.Len(); i++ {
 		elem, ok := resolve(v.Index(i))
-		if !ok || isValueKind(elem) {
+		if !ok || e.propsFor(elem.Type()).isValue {
 			return false
 		}
 	}
@@ -1482,20 +1554,31 @@ func isUnquotedKeyByte(c byte) bool {
 
 // appendValue emits a TOML value.
 func (e *encoderState) appendValue(b []byte, v reflect.Value, opts valueOptions, indent int) ([]byte, error) {
+	return e.appendValueProps(b, v, e.propsFor(v.Type()), opts, indent)
+}
+
+// appendValueProps is appendValue for callers that already know the type
+// properties.
+func (e *encoderState) appendValueProps(b []byte, v reflect.Value, props typeEncProps, opts valueOptions, indent int) ([]byte, error) {
 	t := v.Type()
 
-	// Special types take precedence over their kind.
-	switch t {
-	case timeType:
-		return v.Interface().(time.Time).AppendFormat(b, "2006-01-02T15:04:05.999999999Z07:00"), nil
-	case localDateType:
-		return append(b, v.Interface().(LocalDate).String()...), nil
-	case localTimeType:
-		return append(b, v.Interface().(LocalTime).String()...), nil
-	case localDateTimeType:
-		return append(b, v.Interface().(LocalDateTime).String()...), nil
-	case jsonNumberType:
-		if e.marshalJSONNumbers {
+	// Special types take precedence over their kind. All of them are structs
+	// except json.Number: dispatching on the kind first keeps the common
+	// scalars away from the interface comparisons.
+	switch v.Kind() { //nolint:exhaustive // only these kinds have special types
+	case reflect.Struct:
+		switch t {
+		case timeType:
+			return v.Interface().(time.Time).AppendFormat(b, "2006-01-02T15:04:05.999999999Z07:00"), nil
+		case localDateType:
+			return append(b, v.Interface().(LocalDate).String()...), nil
+		case localTimeType:
+			return append(b, v.Interface().(LocalTime).String()...), nil
+		case localDateTimeType:
+			return append(b, v.Interface().(LocalDateTime).String()...), nil
+		}
+	case reflect.String:
+		if e.marshalJSONNumbers && t == jsonNumberType {
 			return appendJSONNumber(b, v.Interface().(json.Number))
 		}
 	}
@@ -1510,7 +1593,7 @@ func (e *encoderState) appendValue(b []byte, v reflect.Value, opts valueOptions,
 		}
 	}
 
-	switch encPropsForType(t).text {
+	switch props.text {
 	case 1:
 		if t.Kind() != reflect.String {
 			return e.appendTextMarshaler(b, v.Interface().(encoding.TextMarshaler))

--- a/marshaler_paths_test.go
+++ b/marshaler_paths_test.go
@@ -1,0 +1,42 @@
+package toml
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pelletier/go-toml/v2/internal/assert"
+)
+
+// tmText has a pointer-receiver TextMarshaler; tmRawVal/tmRawPtr implement
+// unstable.Marshaler with value and pointer receivers.
+type tmText struct{ s string }
+
+func (t *tmText) MarshalText() ([]byte, error) { return []byte(t.s), nil }
+
+type tmRawVal struct{}
+
+func (tmRawVal) MarshalTOML() ([]byte, error) { return []byte("1"), nil }
+
+type tmRawPtr struct{}
+
+func (*tmRawPtr) MarshalTOML() ([]byte, error) { return []byte("2"), nil }
+
+// TestEncPropsReceiverVariants covers the pointer-receiver classification
+// branches of the encoder's type properties.
+func TestEncPropsReceiverVariants(t *testing.T) {
+	out, err := Marshal(map[string]tmText{"a": {s: "x"}})
+	assert.NoError(t, err)
+	assert.True(t, strings.Contains(string(out), "'x'"), "got %q", out)
+
+	var buf strings.Builder
+	enc := NewEncoder(&buf)
+	enc.EnableMarshalerInterface()
+	assert.NoError(t, enc.Encode(map[string]interface{}{
+		"v": tmRawVal{},
+		"p": &tmRawPtr{},
+	}))
+	back := map[string]interface{}{}
+	assert.NoError(t, Unmarshal([]byte(buf.String()), &back))
+	assert.Equal(t, interface{}(int64(1)), back["v"])
+	assert.Equal(t, interface{}(int64(2)), back["p"])
+}

--- a/types.go
+++ b/types.go
@@ -21,4 +21,8 @@ var (
 	mapStringInterfaceType = reflect.TypeOf(map[string]interface{}(nil))
 	sliceInterfaceType     = reflect.TypeOf([]interface{}(nil))
 	stringType             = reflect.TypeOf("")
+	boolType               = reflect.TypeOf(false)
+	intType                = reflect.TypeOf(int(0))
+	int64Type              = reflect.TypeOf(int64(0))
+	float64Type            = reflect.TypeOf(float64(0))
 )


### PR DESCRIPTION
Splitting #1088: this PR carries one optimization technique so its impact and review surface stay isolated. Stacked on #1104.

## What

Every encoded value consults its type's cached properties (TextMarshaler and unstable.Marshaler receivers, value-vs-table), paying a `sync.Map` lookup — an interface hash — per consultation; this was ~20% of struct marshaling. Three layers shortcut it:

- **`builtinEncProps`** resolves the handful of builtin types generic documents are made of (`string`, `bool`, `int`, `int64`, `float64`, `[]interface{}`, `map[string]interface{}`) with a kind dispatch and one pointer comparison — none of them can implement TextMarshaler.
- **A small MRU memo** (16 entries) on the encoder state catches the few named types a document actually uses; the global `sync.Map` stays as the shared cold cache.
- **`appendValue` dispatches special types kind-first** (they are all structs except `json.Number`), keeping common scalars away from four interface comparisons, and the new `appendValueProps` lets callers that already hold the properties skip the lookup entirely (used by the plan-facts PR next in the chain).

## Impact

Benchmarked on a dedicated linux/amd64 spot VM (t2d), go1.26.4, interleaved A/B vs the base of this PR, benchstat over 10 samples per side:

- sec/op geomean: **-2.58%**
- `RealWorldViperWrite`: -15.13%
- `Marshal/HugoFrontMatter`: -13.55%
- `Marshal/ReferenceFile/map`: -13.53%
- `Marshal/SimpleDocument/map`: -7.10%
- `Marshal/ReferenceFile/struct`: -4.25%
- `Marshal/SimpleDocument/struct`: -3.87%
- `UnmarshalDataset/code`: -2.64%
- `Unmarshal/SimpleDocument/struct`: +2.55%

<details>
<summary>Full benchstat (sec/op, allocs/op)</summary>

#### sec/op
```
UnmarshalDataset/config  10.27m ± 1%  10.25m ± 2%  ~ (p=0.739 n=10)
UnmarshalDataset/canada  23.06m ± 1%  23.33m ± 3%  ~ (p=0.529 n=10)
UnmarshalDataset/citm_catalog  14.91m ± 1%  15.02m ± 1%  +0.76% (p=0.043 n=10)
UnmarshalDataset/twitter  3.569m ± 0%  3.571m ± 0%  ~ (p=0.436 n=10)
UnmarshalDataset/code  33.92m ± 3%  33.03m ± 2%  -2.64% (p=0.009 n=10)
UnmarshalDataset/example  77.08µ ± 2%  77.16µ ± 1%  ~ (p=0.684 n=10)
Unmarshal/SimpleDocument/struct  325.2n ± 4%  333.5n ± 1%  +2.55% (p=0.020 n=10)
Unmarshal/SimpleDocument/map  428.9n ± 1%  433.1n ± 1%  +0.96% (p=0.000 n=10)
Unmarshal/ReferenceFile/struct  39.20µ ± 4%  39.30µ ± 2%  ~ (p=0.739 n=10)
Unmarshal/ReferenceFile/map  31.24µ ± 1%  31.33µ ± 0%  ~ (p=0.118 n=10)
Unmarshal/HugoFrontMatter  5.617µ ± 1%  5.647µ ± 1%  ~ (p=0.165 n=10)
Marshal/SimpleDocument/struct  373.3n ± 1%  358.9n ± 1%  -3.87% (p=0.000 n=10)
Marshal/SimpleDocument/map  556.0n ± 3%  516.4n ± 1%  -7.10% (p=0.000 n=10)
Marshal/ReferenceFile/struct  18.55µ ± 3%  17.76µ ± 4%  -4.25% (p=0.004 n=10)
Marshal/ReferenceFile/map  36.39µ ± 2%  31.47µ ± 4%  -13.53% (p=0.000 n=10)
Marshal/HugoFrontMatter  7.268µ ± 2%  6.283µ ± 1%  -13.55% (p=0.000 n=10)
RealWorldContainerdConfig  39.78µ ± 1%  39.27µ ± 2%  -1.29% (p=0.001 n=10)
RealWorldViperRead  8.342µ ± 1%  8.314µ ± 1%  -0.34% (p=0.041 n=10)
RealWorldViperWrite  11.763µ ± 2%  9.984µ ± 2%  -15.13% (p=0.000 n=10)
RealWorldHugoFrontMatterBatch  94.68µ ± 1%  94.38µ ± 1%  ~ (p=0.393 n=10)
RealWorldGitleaksRules  64.77µ ± 1%  64.87µ ± 1%  ~ (p=0.853 n=10)
RealWorldPyproject  15.03µ ± 1%  14.93µ ± 1%  ~ (p=0.052 n=10)
RealWorldGolangciStrict  11.81µ ± 0%  11.77µ ± 0%  -0.30% (p=0.037 n=10)
geomean  45.51µ  44.33µ  -2.58%
```
#### allocs/op
```
UnmarshalDataset/config  70.19k ± 0%  70.19k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/canada  223.2k ± 0%  223.2k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog  49.98k ± 0%  49.98k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/twitter  15.78k ± 0%  15.78k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/code  129.5k ± 0%  129.5k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/example  399.0 ± 0%  399.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct  2.000 ± 0%  2.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map  5.000 ± 0%  5.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct  83.00 ± 0%  83.00 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map  194.0 ± 0%  194.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter  54.00 ± 0%  54.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map  91.00 ± 0%  91.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/HugoFrontMatter  20.00 ± 0%  20.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldContainerdConfig  144.0 ± 0%  144.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperRead  65.00 ± 0%  65.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperWrite  33.00 ± 0%  33.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldHugoFrontMatterBatch  820.0 ± 0%  820.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGitleaksRules  259.0 ± 0%  259.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldPyproject  142.0 ± 0%  142.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGolangciStrict  48.00 ± 0%  48.00 ± 0%  ~ (p=1.000 n=10) ¹
geomean  211.1  211.1  +0.00%
¹ all samples are equal
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
