### PR TITLE
perf: encode generic map trees without reflection

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -351,10 +351,14 @@ type valueOptions struct {
 // zeroValueOptions is the shared options of entries that have no tags.
 var zeroValueOptions valueOptions
 
-// entry is a deferred key-value of a table being encoded.
+// entry is a deferred key-value of a table being encoded. Entries collected
+// from a generic map[string]interface{} carry the value as anyValue (with a
+// zero reflect.Value): the whole generic tree then encodes through concrete
+// type switches, without reflection.
 type entry struct {
-	key   string
-	value reflect.Value
+	key      string
+	value    reflect.Value
+	anyValue interface{}
 	// options points into the encoder plan (or at zeroValueOptions for map
 	// entries): entries are copied around, and the options are the widest
 	// part of them.
@@ -412,6 +416,39 @@ func (e *encoderState) classify(ent *entry) entryClass {
 	if ent.pf != nil && ent.pf.classKnown && !e.marshalerOn {
 		return ent.pf.staticClass
 	}
+	if ent.anyValue != nil {
+		switch v := ent.anyValue.(type) {
+		case map[string]interface{}:
+			return classTable
+		case []interface{}:
+			if len(v) == 0 {
+				return classKeyValue
+			}
+			for _, elem := range v {
+				if _, ok := elem.(map[string]interface{}); !ok {
+					// Mixed or exotic elements: decide like the reflection
+					// path would (resolving pointers and interfaces).
+					if e.isArrayOfTables(reflect.ValueOf(ent.anyValue)) {
+						return classArrayTable
+					}
+					return classKeyValue
+				}
+			}
+			return classArrayTable
+		case time.Time, LocalDate, LocalTime, LocalDateTime:
+			return classKeyValue
+		default:
+			// Not a generic container: classify through reflection.
+			v2 := reflect.ValueOf(ent.anyValue)
+			if e.isArrayOfTables(v2) {
+				return classArrayTable
+			}
+			if e.isTableLike(v2) {
+				return classTable
+			}
+			return classKeyValue
+		}
+	}
 	if e.isArrayOfTables(ent.value) {
 		return classArrayTable
 	}
@@ -434,6 +471,25 @@ func (e *encoderState) classOf(ent *entry) entryClass {
 func (e *encoderState) encodeRoot(v interface{}) error {
 	if v == nil {
 		return errors.New("toml: cannot encode a nil interface")
+	}
+
+	if m, ok := v.(map[string]interface{}); ok {
+		// Generic documents skip reflection entirely: their entries are
+		// collected natively and every value encodes by type switch.
+		entries := e.getEntries()
+		for key, value := range m {
+			if value == nil {
+				// nil interface values are skipped
+				continue
+			}
+			entries = append(entries, entry{key: key, anyValue: value, options: &zeroValueOptions})
+		}
+		if len(entries) > 1 {
+			slices.SortFunc(entries, func(a, b entry) int {
+				return strings.Compare(a.key, b.key)
+			})
+		}
+		return e.encodeTableEntries(entries, false, 0)
 	}
 
 	rv := reflect.ValueOf(v)
@@ -741,6 +797,16 @@ func (e *encoderState) resolveMarshalerEntries(entries []entry) error {
 			// entries early to route them by shape.
 			continue
 		}
+		if ent.anyValue != nil {
+			// Generic entries hold their value as an interface; only named
+			// types can implement Marshaler, so materialize a value to check.
+			ent.value = reflect.ValueOf(ent.anyValue)
+			if encPropsForType(ent.value.Type()).marshaler == 0 {
+				ent.value = reflect.Value{}
+				continue
+			}
+			ent.anyValue = nil
+		}
 		v, ok := resolve(ent.value)
 		if !ok || encPropsForType(v.Type()).marshaler == 0 {
 			continue
@@ -869,6 +935,12 @@ func (e *encoderState) encodeTableEntries(entries []entry, commented bool, inden
 		}
 		if ent.class == classKeyValue {
 			continue
+		}
+		if ent.anyValue != nil {
+			// Tables recurse through the reflection walk; their own entries
+			// are collected natively again at the next level.
+			ent.value = reflect.ValueOf(ent.anyValue)
+			ent.anyValue = nil
 		}
 		entCommented := commented || ent.options.commented
 		bare := ent.pf != nil && ent.pf.bareKey
@@ -1151,6 +1223,8 @@ func (e *encoderState) encodeKeyValue(ent *entry, commented bool, indent int) er
 		// the default path (rawShape stays shapeUnknown when the interface is
 		// off). It shares the commented/newline handling below.
 		e.buf, err = e.appendMarshalerInlineValue(e.buf, ent)
+	case ent.anyValue != nil:
+		e.buf, err = e.appendAnyValue(e.buf, ent.anyValue, *ent.options, valueIndent)
 	case ent.pf != nil && ent.pf.propsKnown:
 		// The plan already knows the field type's properties.
 		e.buf, err = e.appendValueProps(e.buf, ent.value, ent.pf.props, *ent.options, valueIndent)
@@ -1222,6 +1296,23 @@ func (e *encoderState) collectEntries(v reflect.Value) ([]entry, error) {
 
 func (e *encoderState) collectMapEntries(v reflect.Value) ([]entry, error) {
 	entries := e.getEntries()
+
+	// Generic maps iterate natively: no per-entry reflect values at all.
+	if v.Type() == mapStringInterfaceType {
+		for key, value := range v.Interface().(map[string]interface{}) {
+			if value == nil {
+				// nil interface values are skipped
+				continue
+			}
+			entries = append(entries, entry{key: key, anyValue: value, options: &zeroValueOptions})
+		}
+		if len(entries) > 1 {
+			slices.SortFunc(entries, func(a, b entry) int {
+				return strings.Compare(a.key, b.key)
+			})
+		}
+		return entries, nil
+	}
 
 	// Keys are converted to strings right away: read them into a reusable
 	// buffer to avoid one allocation per key.
@@ -1677,6 +1768,87 @@ func isUnquotedKeyByte(c byte) bool {
 	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_'
 }
 
+// appendAnyValue emits a TOML value held in an interface, dispatching on the
+// concrete types a generic document is made of without going through
+// reflection. Anything else falls back to the reflection encoder.
+func (e *encoderState) appendAnyValue(b []byte, v interface{}, opts valueOptions, indent int) ([]byte, error) {
+	if v == nil {
+		return nil, errors.New("toml: cannot encode a nil interface")
+	}
+	switch tv := v.(type) {
+	case string:
+		if opts.multiline && strings.IndexByte(tv, '\n') >= 0 {
+			return e.appendMultilineString(b, tv), nil
+		}
+		return e.appendString(b, tv), nil
+	case bool:
+		if tv {
+			return append(b, "true"...), nil
+		}
+		return append(b, "false"...), nil
+	case int64:
+		return strconv.AppendInt(b, tv, 10), nil
+	case int:
+		return strconv.AppendInt(b, int64(tv), 10), nil
+	case float64:
+		return appendFloat(b, tv, 64), nil
+	case time.Time:
+		return tv.AppendFormat(b, "2006-01-02T15:04:05.999999999Z07:00"), nil
+	case LocalDate:
+		return append(b, tv.String()...), nil
+	case LocalTime:
+		return append(b, tv.String()...), nil
+	case LocalDateTime:
+		return append(b, tv.String()...), nil
+	case []interface{}:
+		return e.appendAnyArray(b, tv, opts, indent)
+	case map[string]interface{}:
+		return e.appendInlineTable(b, reflect.ValueOf(tv), indent)
+	default:
+		return e.appendValue(b, reflect.ValueOf(v), opts, indent)
+	}
+}
+
+// appendAnyArray is appendArray for a native []interface{}, with the exact
+// same layout decisions.
+func (e *encoderState) appendAnyArray(b []byte, v []interface{}, opts valueOptions, indent int) ([]byte, error) {
+	multiline := opts.multiline || e.arraysMultiline
+
+	b = append(b, '[')
+	if multiline && len(v) > 0 {
+		for i, elem := range v {
+			if i > 0 {
+				b = append(b, ',')
+			}
+			b = append(b, '\n')
+			for j := 0; j <= indent; j++ {
+				b = append(b, e.indentSymbol...)
+			}
+			var err error
+			b, err = e.appendAnyValue(b, elem, valueOptions{}, indent+1)
+			if err != nil {
+				return nil, err
+			}
+		}
+		b = append(b, '\n')
+		for j := 0; j < indent; j++ {
+			b = append(b, e.indentSymbol...)
+		}
+	} else {
+		for i, elem := range v {
+			if i > 0 {
+				b = append(b, ", "...)
+			}
+			var err error
+			b, err = e.appendAnyValue(b, elem, valueOptions{}, indent)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return append(b, ']'), nil
+}
+
 // appendValue emits a TOML value.
 func (e *encoderState) appendValue(b []byte, v reflect.Value, opts valueOptions, indent int) ([]byte, error) {
 	return e.appendValueProps(b, v, e.propsFor(v.Type()), opts, indent)
@@ -1882,7 +2054,11 @@ func (e *encoderState) appendInlineTable(b []byte, v reflect.Value, indent int) 
 		// would break the single-line requirement.
 		opts := *ent.options
 		opts.multiline = false
-		b, err = e.appendValue(b, ent.value, opts, indent)
+		if ent.anyValue != nil {
+			b, err = e.appendAnyValue(b, ent.anyValue, opts, indent)
+		} else {
+			b, err = e.appendValue(b, ent.value, opts, indent)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/marshaler_paths_test.go
+++ b/marshaler_paths_test.go
@@ -1,11 +1,14 @@
 package toml
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pelletier/go-toml/v2/internal/assert"
+	"github.com/pelletier/go-toml/v2/unstable"
 )
 
 // tmText has a pointer-receiver TextMarshaler; tmRawVal/tmRawPtr implement
@@ -54,4 +57,236 @@ func TestMarshalLargeTypedMap(t *testing.T) {
 	back := map[string]int64{}
 	assert.NoError(t, Unmarshal(out, &back))
 	assert.Equal(t, m, back)
+}
+
+// TestMarshalGenericTree covers the reflection-free encoding of generic
+// map[string]interface{} documents: every native scalar type, nested arrays
+// and tables, multiline arrays, and fallback to the reflection encoder for
+// non-generic values held in interfaces.
+func TestMarshalGenericTree(t *testing.T) {
+	doc := map[string]interface{}{
+		"str":      "hello",
+		"lit":      "with \"quotes\" and\ttab",
+		"bool_t":   true,
+		"bool_f":   false,
+		"int64":    int64(42),
+		"int":      7,
+		"float":    1.5,
+		"time":     time.Date(2021, 3, 30, 11, 21, 0, 0, time.UTC),
+		"date":     LocalDate{2021, 3, 30},
+		"ltime":    LocalTime{11, 21, 0, 0, 0},
+		"ldt":      LocalDateTime{LocalDate{2021, 3, 30}, LocalTime{11, 21, 0, 0, 0}},
+		"arr":      []interface{}{int64(1), "two", 3.0},
+		"nested":   []interface{}{[]interface{}{int64(1)}, []interface{}{int64(2)}},
+		"typed":    uint16(9),
+		"tbl":      map[string]interface{}{"a": int64(1), "sub": map[string]interface{}{"b": "c"}},
+		"arrtbl":   []interface{}{map[string]interface{}{"x": int64(1)}, map[string]interface{}{"x": int64(2)}},
+		"mixedarr": []interface{}{map[string]interface{}{"x": int64(1)}, int64(2)},
+	}
+
+	out, err := Marshal(doc)
+	assert.NoError(t, err)
+
+	back := map[string]interface{}{}
+	assert.NoError(t, Unmarshal(out, &back))
+	assert.Equal(t, interface{}("hello"), back["str"])
+	assert.Equal(t, interface{}(int64(42)), back["int64"])
+	assert.Equal(t, interface{}(int64(7)), back["int"])
+	assert.Equal(t, interface{}(int64(9)), back["typed"])
+	assert.Equal(t, interface{}(1.5), back["float"])
+	assert.Equal(t, 3, len(back["arr"].([]interface{})))
+	assert.Equal(t, 2, len(back["arrtbl"].([]interface{})))
+	assert.Equal(t, 2, len(back["mixedarr"].([]interface{})))
+	assert.Equal(t, interface{}("c"),
+		back["tbl"].(map[string]interface{})["sub"].(map[string]interface{})["b"])
+
+	t.Run("multiline arrays and inline tables", func(t *testing.T) {
+		var buf strings.Builder
+		enc := NewEncoder(&buf)
+		enc.SetArraysMultiline(true)
+		enc.SetTablesInline(true)
+		assert.NoError(t, enc.Encode(doc))
+		back := map[string]interface{}{}
+		assert.NoError(t, Unmarshal([]byte(buf.String()), &back))
+		assert.Equal(t, 3, len(back["arr"].([]interface{})))
+	})
+
+	t.Run("nil in inline table errors", func(t *testing.T) {
+		_, err := Marshal(map[string]interface{}{
+			"a": []interface{}{nil},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("indented tables", func(t *testing.T) {
+		var buf strings.Builder
+		enc := NewEncoder(&buf)
+		enc.SetIndentTables(true)
+		assert.NoError(t, enc.Encode(doc))
+		back := map[string]interface{}{}
+		assert.NoError(t, Unmarshal([]byte(buf.String()), &back))
+		assert.Equal(t, interface{}(int64(1)),
+			back["tbl"].(map[string]interface{})["a"])
+	})
+}
+
+// TestMarshalerInterfaceGenericMap covers unstable.Marshaler values held in
+// generic maps: the resolver materializes the interface value to classify it.
+func TestMarshalerInterfaceGenericMap(t *testing.T) {
+	doc := map[string]interface{}{
+		"raw":   unstable.RawMessage("1"),
+		"table": unstable.RawMessage("a = 1"),
+		"plain": "hello",
+		"num":   int64(3),
+	}
+	var buf strings.Builder
+	enc := NewEncoder(&buf)
+	enc.EnableMarshalerInterface()
+	assert.NoError(t, enc.Encode(doc))
+
+	back := map[string]interface{}{}
+	assert.NoError(t, Unmarshal([]byte(buf.String()), &back))
+	assert.Equal(t, interface{}(int64(1)), back["raw"])
+	assert.Equal(t, interface{}("hello"), back["plain"])
+	assert.Equal(t, interface{}(int64(1)), back["table"].(map[string]interface{})["a"])
+}
+
+type tmRawErr struct{}
+
+func (tmRawErr) MarshalTOML() ([]byte, error) { return nil, errors.New("nope") }
+
+// TestMarshalerInterfaceMoreEdges covers the root single-value error, a
+// failing MarshalTOML inside an array classification, and the fused scalar
+// kind guard.
+func TestMarshalerInterfaceMoreEdges(t *testing.T) {
+	var buf strings.Builder
+	enc := NewEncoder(&buf)
+	enc.EnableMarshalerInterface()
+	err := enc.Encode(unstable.RawMessage("42"))
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "document root"), "got %v", err)
+
+	var buf2 strings.Builder
+	enc2 := NewEncoder(&buf2)
+	enc2.EnableMarshalerInterface()
+	assert.Error(t, enc2.Encode(map[string]interface{}{
+		"arr": []interface{}{tmRawErr{}, tmRawErr{}},
+	}))
+
+	d := getDecoder(false, false)
+	defer putDecoder(d)
+	_, err = d.fusedScalar(unstable.Comment, []byte("#"))
+	assert.Error(t, err)
+}
+
+// TestMarshalGenericEdgeCoverage sweeps branches of the generic encoder that
+// the reflection tests no longer reach: classification of exotic interface
+// values, error propagation from nested tables, and nil-value skipping.
+func TestMarshalGenericEdgeCoverage(t *testing.T) {
+	t.Run("empty generic array", func(t *testing.T) {
+		out, err := Marshal(map[string]interface{}{"a": []interface{}{}})
+		assert.NoError(t, err)
+		assert.Equal(t, "a = []\n", string(out))
+	})
+
+	t.Run("mixed table-like array elements", func(t *testing.T) {
+		out, err := Marshal(map[string]interface{}{"a": []interface{}{
+			map[string]interface{}{"x": int64(1)},
+			map[string]int64{"y": 2},
+		}})
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(string(out), "[[a]]"), "got %q", out)
+	})
+
+	t.Run("typed containers in interface", func(t *testing.T) {
+		out, err := Marshal(map[string]interface{}{
+			"arr": []map[string]int64{{"x": 1}},
+			"tbl": map[string]int64{"y": 2},
+		})
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(string(out), "[[arr]]"), "got %q", out)
+		assert.True(t, strings.Contains(string(out), "[tbl]"), "got %q", out)
+	})
+
+	t.Run("bad key type in nested table", func(t *testing.T) {
+		_, err := Marshal(map[string]interface{}{"t": map[complex128]int64{1: 2}})
+		assert.Error(t, err)
+	})
+
+	t.Run("bad key type in array table element", func(t *testing.T) {
+		_, err := Marshal(map[string]interface{}{"arr": []map[complex128]int64{{1: 2}}})
+		assert.Error(t, err)
+	})
+
+	t.Run("nil values skipped in nested and typed maps", func(t *testing.T) {
+		out, err := Marshal(map[string]interface{}{"t": map[string]interface{}{"a": nil, "b": int64(1)}})
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(string(out), "b = 1"), "got %q", out)
+		assert.True(t, !strings.Contains(string(out), "a ="), "got %q", out)
+
+		out, err = Marshal(map[string]error{"a": nil})
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(string(out), "[a]") == false, "got %q", out)
+	})
+
+	t.Run("named string key type", func(t *testing.T) {
+		type K string
+		out, err := Marshal(map[K]int64{"k": 1})
+		assert.NoError(t, err)
+		assert.Equal(t, "k = 1\n", string(out))
+	})
+
+	t.Run("multiline array element error", func(t *testing.T) {
+		var buf strings.Builder
+		enc := NewEncoder(&buf)
+		enc.SetArraysMultiline(true)
+		assert.Error(t, enc.Encode(map[string]interface{}{"a": []interface{}{nil}}))
+	})
+
+	t.Run("local date and datetime struct fields", func(t *testing.T) {
+		var s struct {
+			D  LocalDate     `toml:"d"`
+			DT LocalDateTime `toml:"dt"`
+		}
+		s.D = LocalDate{Year: 2021, Month: 3, Day: 30}
+		s.DT = LocalDateTime{LocalDate: s.D, LocalTime: LocalTime{Hour: 11}}
+		out, err := Marshal(s)
+		assert.NoError(t, err)
+		assert.True(t, strings.Contains(string(out), "d = 2021-03-30"), "got %q", out)
+		assert.True(t, strings.Contains(string(out), "dt = 2021-03-30T11:00:00"), "got %q", out)
+	})
+}
+
+// flipFlopMarshaler returns a table body on its first call and empty bytes on
+// the second, exercising the emit-time revalidation of table-shaped entries.
+type flipFlopMarshaler struct{ n *int }
+
+func (f flipFlopMarshaler) MarshalTOML() ([]byte, error) {
+	*f.n++
+	if *f.n == 1 {
+		return []byte("x = 1"), nil
+	}
+	return nil, nil
+}
+
+// TestMarshalerInterfaceEmptyReemit covers a Marshaler that returns a table
+// body during classification and empty bytes at emit time: the header is
+// still written, with an empty body.
+func TestMarshalerInterfaceEmptyReemit(t *testing.T) {
+	var buf strings.Builder
+	n := 0
+	enc := NewEncoder(&buf)
+	enc.EnableMarshalerInterface()
+	assert.NoError(t, enc.Encode(map[string]interface{}{"a": flipFlopMarshaler{n: &n}}))
+	assert.True(t, strings.Contains(buf.String(), "[a]"), "got %q", buf.String())
+}
+
+// TestMarshalerInterfaceOmitSuperTablesError covers MarshalTOML errors
+// surfaced through the early entry resolution of SetOmitEmptySuperTables.
+func TestMarshalerInterfaceOmitSuperTablesError(t *testing.T) {
+	var buf strings.Builder
+	enc := NewEncoder(&buf)
+	enc.EnableMarshalerInterface()
+	enc.SetOmitEmptySuperTables(true)
+	assert.Error(t, enc.Encode(map[string]interface{}{"a": map[string]interface{}{"b": tmRawErr{}}}))
 }


### PR DESCRIPTION
Splitting #1088: this PR carries one optimization technique so its impact and review surface stay isolated. Stacked on #1107; last of the encoder chain.

## What

Encoding a `map[string]interface{}` document wrapped every access in a `reflect.Value` even though the concrete types are known. Entries collected from generic maps (at the root or nested) now carry plain interface values (`entry.anyValue`), and the tree encodes through type switches (`appendAnyValue`/`appendAnyArray`), sharing all layout code with the reflection encoder. Only table recursion and non-generic values return to the reflection path; `classify` decides generic classes with type assertions instead of reflection.

This is the symmetric counterpart of the fused decoder, and takes the generic-marshal family (ViperWrite, dataset marshaling, `Marshal(map[string]interface{})`) 2-3x in the combined branch.

The `unstable.Marshaler` mode integrates over this: generic entries materialize a `reflect.Value` only to check (and classify) Marshaler types, and `SetOmitEmptySuperTables` routes generic entries through the same early resolution as reflection entries.

## Impact

Benchmarked on a dedicated linux/amd64 spot VM (t2d), go1.26.4, interleaved A/B vs the base of this PR, benchstat over 10 samples per side:

- sec/op geomean: **-10.71%**
- `RealWorldViperWrite`: -53.68%
- `Marshal/ReferenceFile/map`: -47.82%
- `Marshal/SimpleDocument/map`: -41.17%
- `Marshal/HugoFrontMatter`: -37.58%
- `Marshal/SimpleDocument/struct`: -2.99%
- `UnmarshalDataset/canada`: -2.81%
- `Unmarshal/SimpleDocument/map`: -2.32%
- `RealWorldViperRead`: -1.96%
- `UnmarshalDataset/citm_catalog`: -1.91%
- `RealWorldPyproject`: -1.77%
- `RealWorldGitleaksRules`: -1.67%
- allocs/op geomean: -30.15%
- allocs `Marshal/ReferenceFile/map`: -96.39%
- allocs `RealWorldViperWrite`: -95.83%
- allocs `Marshal/HugoFrontMatter`: -76.92%
- allocs `Marshal/SimpleDocument/map`: -25.00%

<details>
<summary>Full benchstat (sec/op, allocs/op)</summary>

#### sec/op
```
UnmarshalDataset/config  10.54m ± 3%  10.53m ± 4%  ~ (p=0.436 n=10)
UnmarshalDataset/canada  24.19m ± 1%  23.51m ± 6%  -2.81% (p=0.023 n=10)
UnmarshalDataset/citm_catalog  15.19m ± 1%  14.90m ± 1%  -1.91% (p=0.003 n=10)
UnmarshalDataset/twitter  3.592m ± 1%  3.593m ± 1%  ~ (p=0.971 n=10)
UnmarshalDataset/code  33.22m ± 1%  33.15m ± 4%  ~ (p=0.684 n=10)
UnmarshalDataset/example  77.48µ ± 1%  77.46µ ± 0%  ~ (p=0.912 n=10)
Unmarshal/SimpleDocument/struct  341.6n ± 1%  345.6n ± 1%  +1.19% (p=0.002 n=10)
Unmarshal/SimpleDocument/map  432.7n ± 3%  422.6n ± 1%  -2.32% (p=0.000 n=10)
Unmarshal/ReferenceFile/struct  39.56µ ± 4%  39.27µ ± 2%  ~ (p=0.143 n=10)
Unmarshal/ReferenceFile/map  32.25µ ± 2%  32.00µ ± 1%  ~ (p=0.315 n=10)
Unmarshal/HugoFrontMatter  5.849µ ± 2%  5.778µ ± 1%  -1.22% (p=0.019 n=10)
Marshal/SimpleDocument/struct  331.4n ± 2%  321.5n ± 1%  -2.99% (p=0.000 n=10)
Marshal/SimpleDocument/map  536.3n ± 2%  315.5n ± 2%  -41.17% (p=0.000 n=10)
Marshal/ReferenceFile/struct  13.74µ ± 5%  14.07µ ± 5%  ~ (p=0.481 n=10)
Marshal/ReferenceFile/map  30.93µ ± 3%  16.14µ ± 3%  -47.82% (p=0.000 n=10)
Marshal/HugoFrontMatter  5.517µ ± 3%  3.444µ ± 3%  -37.58% (p=0.000 n=10)
RealWorldContainerdConfig  40.57µ ± 1%  40.02µ ± 0%  -1.36% (p=0.005 n=10)
RealWorldViperRead  8.447µ ± 1%  8.281µ ± 2%  -1.96% (p=0.001 n=10)
RealWorldViperWrite  9.527µ ± 1%  4.414µ ± 1%  -53.68% (p=0.000 n=10)
RealWorldHugoFrontMatterBatch  96.57µ ± 1%  95.63µ ± 1%  -0.97% (p=0.000 n=10)
RealWorldGitleaksRules  66.22µ ± 1%  65.12µ ± 1%  -1.67% (p=0.001 n=10)
RealWorldPyproject  15.33µ ± 2%  15.06µ ± 1%  -1.77% (p=0.001 n=10)
RealWorldGolangciStrict  11.96µ ± 1%  11.86µ ± 0%  -0.89% (p=0.000 n=10)
geomean  44.00µ  39.29µ  -10.71%
```
#### allocs/op
```
UnmarshalDataset/config  70.19k ± 0%  70.19k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/canada  223.2k ± 0%  223.2k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/citm_catalog  49.98k ± 0%  49.98k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/twitter  15.78k ± 0%  15.78k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/code  129.5k ± 0%  129.5k ± 0%  ~ (p=1.000 n=10) ¹
UnmarshalDataset/example  399.0 ± 0%  399.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/struct  2.000 ± 0%  2.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/SimpleDocument/map  5.000 ± 0%  5.000 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/struct  83.00 ± 0%  83.00 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/ReferenceFile/map  194.0 ± 0%  194.0 ± 0%  ~ (p=1.000 n=10) ¹
Unmarshal/HugoFrontMatter  54.00 ± 0%  54.00 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/SimpleDocument/map  4.000 ± 0%  3.000 ± 0%  -25.00% (p=0.000 n=10)
Marshal/ReferenceFile/struct  4.000 ± 0%  4.000 ± 0%  ~ (p=1.000 n=10) ¹
Marshal/ReferenceFile/map  83.000 ± 0%  3.000 ± 0%  -96.39% (p=0.000 n=10)
Marshal/HugoFrontMatter  13.000 ± 0%  3.000 ± 0%  -76.92% (p=0.000 n=10)
RealWorldContainerdConfig  144.0 ± 0%  144.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperRead  65.00 ± 0%  65.00 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldViperWrite  24.000 ± 0%  1.000 ± 0%  -95.83% (p=0.000 n=10)
RealWorldHugoFrontMatterBatch  820.0 ± 0%  820.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGitleaksRules  259.0 ± 0%  259.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldPyproject  142.0 ± 0%  142.0 ± 0%  ~ (p=1.000 n=10) ¹
RealWorldGolangciStrict  48.00 ± 0%  48.00 ± 0%  ~ (p=1.000 n=10) ¹
geomean  203.5  142.1  -30.15%
¹ all samples are equal
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
