### PR TITLE
fix: validate temporal component ranges when marshaling

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -1452,6 +1452,66 @@ func isUnquotedKeyByte(c byte) bool {
 	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_'
 }
 
+// The temporal formatters below (String and time.Format) write their fields
+// blindly, so an out-of-range component would produce a document the parser
+// rejects, or, for a nanosecond >= 1e9 or a zone offset that is not a whole
+// number of minutes, one that silently decodes to a different value. Validate
+// against the ranges the decoder enforces and error instead of emitting
+// invalid or lossy TOML.
+
+func validateLocalDate(d LocalDate) error {
+	if d.Year < 0 || d.Year > 9999 {
+		return fmt.Errorf("toml: cannot encode local date with year %d out of range [0,9999]", d.Year)
+	}
+	if d.Month < 1 || d.Month > 12 {
+		return fmt.Errorf("toml: cannot encode local date with month %d out of range [1,12]", d.Month)
+	}
+	if maxDay := daysIn(d.Month, d.Year); d.Day < 1 || d.Day > maxDay {
+		return fmt.Errorf("toml: cannot encode local date %04d-%02d-%02d with day out of range [1,%d]", d.Year, d.Month, d.Day, maxDay)
+	}
+	return nil
+}
+
+func validateLocalTime(t LocalTime) error {
+	if t.Hour < 0 || t.Hour > 23 {
+		return fmt.Errorf("toml: cannot encode local time with hour %d out of range [0,23]", t.Hour)
+	}
+	if t.Minute < 0 || t.Minute > 59 {
+		return fmt.Errorf("toml: cannot encode local time with minute %d out of range [0,59]", t.Minute)
+	}
+	if t.Second < 0 || t.Second > 59 {
+		return fmt.Errorf("toml: cannot encode local time with second %d out of range [0,59]", t.Second)
+	}
+	if t.Nanosecond < 0 || t.Nanosecond > 999999999 {
+		return fmt.Errorf("toml: cannot encode local time with nanosecond %d out of range [0,999999999]", t.Nanosecond)
+	}
+	if t.Precision > 9 {
+		return fmt.Errorf("toml: cannot encode local time with precision %d out of range [0,9]", t.Precision)
+	}
+	return nil
+}
+
+func validateLocalDateTime(dt LocalDateTime) error {
+	if err := validateLocalDate(dt.LocalDate); err != nil {
+		return err
+	}
+	return validateLocalTime(dt.LocalTime)
+}
+
+func validateTime(t time.Time) error {
+	if y := t.Year(); y < 0 || y > 9999 {
+		return fmt.Errorf("toml: cannot encode time.Time with year %d out of range [0,9999]", y)
+	}
+	_, offset := t.Zone()
+	if offset <= -24*3600 || offset >= 24*3600 {
+		return fmt.Errorf("toml: cannot encode time.Time with zone offset %ds out of range [-24h,+24h]", offset)
+	}
+	if offset%60 != 0 {
+		return fmt.Errorf("toml: cannot encode time.Time with zone offset %ds not aligned to a whole minute", offset)
+	}
+	return nil
+}
+
 // appendValue emits a TOML value.
 func (e *encoderState) appendValue(b []byte, v reflect.Value, opts valueOptions, indent int) ([]byte, error) {
 	t := v.Type()
@@ -1459,13 +1519,29 @@ func (e *encoderState) appendValue(b []byte, v reflect.Value, opts valueOptions,
 	// Special types take precedence over their kind.
 	switch t {
 	case timeType:
-		return v.Interface().(time.Time).AppendFormat(b, "2006-01-02T15:04:05.999999999Z07:00"), nil
+		tv := v.Interface().(time.Time)
+		if err := validateTime(tv); err != nil {
+			return nil, err
+		}
+		return tv.AppendFormat(b, "2006-01-02T15:04:05.999999999Z07:00"), nil
 	case localDateType:
-		return append(b, v.Interface().(LocalDate).String()...), nil
+		d := v.Interface().(LocalDate)
+		if err := validateLocalDate(d); err != nil {
+			return nil, err
+		}
+		return append(b, d.String()...), nil
 	case localTimeType:
-		return append(b, v.Interface().(LocalTime).String()...), nil
+		lt := v.Interface().(LocalTime)
+		if err := validateLocalTime(lt); err != nil {
+			return nil, err
+		}
+		return append(b, lt.String()...), nil
 	case localDateTimeType:
-		return append(b, v.Interface().(LocalDateTime).String()...), nil
+		dt := v.Interface().(LocalDateTime)
+		if err := validateLocalDateTime(dt); err != nil {
+			return nil, err
+		}
+		return append(b, dt.String()...), nil
 	case jsonNumberType:
 		if e.marshalJSONNumbers {
 			return appendJSONNumber(b, v.Interface().(json.Number))

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -2110,6 +2110,117 @@ func TestMarshalUint64Overflow(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestMarshalRejectsInvalidTemporal(t *testing.T) {
+	// The parser enforces component ranges (and since TOML 1.1, seconds <= 59),
+	// so the encoder must not emit a temporal value it would then refuse to
+	// read back. On an unvalidated encoder each case below produced a document
+	// that fails to reparse; Marshal must return an error instead.
+	examples := []struct {
+		desc     string
+		v        interface{}
+		contains string
+	}{
+		{"local time hour 24", toml.LocalTime{Hour: 24}, "hour 24"},
+		{"local time hour negative", toml.LocalTime{Hour: -1}, "hour -1"},
+		{"local time minute 60", toml.LocalTime{Minute: 60}, "minute 60"},
+		{"local time second 60", toml.LocalTime{Second: 60}, "second 60"},
+		{"local time second 99", toml.LocalTime{Second: 99}, "second 99"},
+		{"local time nanosecond negative", toml.LocalTime{Nanosecond: -1}, "nanosecond -1"},
+		{"local time precision above 9", toml.LocalTime{Precision: 10}, "precision 10"},
+		{"local date zero value", toml.LocalDate{}, "month 0"},
+		{"local date month 13", toml.LocalDate{Year: 2024, Month: 13, Day: 5}, "month 13"},
+		{"local date day 0", toml.LocalDate{Year: 2024, Month: 2, Day: 0}, "day out of range"},
+		{"local date day 32", toml.LocalDate{Year: 2024, Month: 1, Day: 32}, "day out of range"},
+		{"local date february 30", toml.LocalDate{Year: 2023, Month: 2, Day: 30}, "day out of range"},
+		{"local date year negative", toml.LocalDate{Year: -1, Month: 1, Day: 1}, "year -1"},
+		{"local date year 10000", toml.LocalDate{Year: 10000, Month: 1, Day: 1}, "year 10000"},
+		{
+			"local date-time invalid date",
+			toml.LocalDateTime{LocalDate: toml.LocalDate{Year: 2024, Month: 13, Day: 40}, LocalTime: toml.LocalTime{Hour: 25}},
+			"month 13",
+		},
+		{
+			"local date-time invalid time",
+			toml.LocalDateTime{LocalDate: toml.LocalDate{Year: 2024, Month: 1, Day: 1}, LocalTime: toml.LocalTime{Hour: 25}},
+			"hour 25",
+		},
+		{"time.Time year 10000", time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC), "year 10000"},
+		{"time.Time year negative", time.Date(-1, 1, 1, 0, 0, 0, 0, time.UTC), "year -1"},
+		{"time.Time offset above 24h", time.Date(2024, 1, 1, 0, 0, 0, 0, time.FixedZone("", 100*3600)), "out of range [-24h,+24h]"},
+		{"time.Time offset exactly 24h", time.Date(2024, 1, 1, 0, 0, 0, 0, time.FixedZone("", 24*3600)), "out of range [-24h,+24h]"},
+	}
+
+	for _, e := range examples {
+		t.Run(e.desc, func(t *testing.T) {
+			b, err := toml.Marshal(map[string]interface{}{"v": e.v})
+			assert.Error(t, err, "expected Marshal to reject %s, got %q", e.desc, string(b))
+			assert.True(t, strings.Contains(err.Error(), e.contains), "error %q should mention %q", err, e.contains)
+		})
+	}
+}
+
+func TestMarshalRejectsLossyTemporal(t *testing.T) {
+	// These reparse successfully but to a *different* value, so an unvalidated
+	// encoder corrupts data silently. Marshal must error rather than emit them.
+	examples := []struct {
+		desc     string
+		v        interface{}
+		wasLike  string // what the unvalidated encoder used to emit
+		contains string
+	}{
+		// Nanosecond >= 1e9 formats as ".100000000": 1s silently becomes 0.1s.
+		{"nanosecond 1e9 overflows into fraction", toml.LocalTime{Nanosecond: 1000000000}, "00:00:00.100000000", "nanosecond 1000000000"},
+		// RFC 3339 offsets are HH:MM, so +01:01:01 loses its trailing second.
+		{"zone offset drops seconds", time.Date(2024, 1, 1, 0, 0, 0, 0, time.FixedZone("", 3661)), "+01:01", "not aligned to a whole minute"},
+		// A purely sub-minute offset collapses to +00:00, i.e. looks like UTC.
+		{"sub-minute zone offset collapses to utc", time.Date(2024, 1, 1, 0, 0, 0, 0, time.FixedZone("", 30)), "+00:00", "not aligned to a whole minute"},
+	}
+	for _, e := range examples {
+		t.Run(e.desc, func(t *testing.T) {
+			_, err := toml.Marshal(map[string]interface{}{"v": e.v})
+			assert.Error(t, err, "expected Marshal to reject %s (previously emitted %q)", e.desc, e.wasLike)
+			assert.True(t, strings.Contains(err.Error(), e.contains), "error %q should mention %q", err, e.contains)
+		})
+	}
+}
+
+func TestMarshalValidTemporalRoundTrip(t *testing.T) {
+	// Valid boundary values must still marshal and survive a
+	// Marshal -> Unmarshal -> Marshal round trip byte-for-byte.
+	examples := []struct {
+		desc string
+		v    interface{}
+	}{
+		{"leap day", toml.LocalDate{Year: 2024, Month: 2, Day: 29}},
+		{"year 0", toml.LocalDate{Year: 0, Month: 1, Day: 1}},
+		{"year 9999", toml.LocalDate{Year: 9999, Month: 12, Day: 31}},
+		{"max local time", toml.LocalTime{Hour: 23, Minute: 59, Second: 59, Nanosecond: 999999999, Precision: 9}},
+		{
+			"local date-time boundary",
+			toml.LocalDateTime{
+				LocalDate: toml.LocalDate{Year: 2024, Month: 2, Day: 29},
+				LocalTime: toml.LocalTime{Hour: 23, Minute: 59, Second: 59, Nanosecond: 999999999, Precision: 9},
+			},
+		},
+		{"utc", time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)},
+		{"minute-aligned offset", time.Date(2024, 1, 1, 0, 0, 0, 0, time.FixedZone("", 3660))},
+		{"max offset 23:59", time.Date(2024, 1, 1, 0, 0, 0, 0, time.FixedZone("", 23*3600+59*60))},
+	}
+	for _, e := range examples {
+		t.Run(e.desc, func(t *testing.T) {
+			first, err := toml.Marshal(map[string]interface{}{"v": e.v})
+			assert.NoError(t, err)
+
+			var back map[string]interface{}
+			assert.NoError(t, toml.Unmarshal(first, &back))
+
+			second, err := toml.Marshal(back)
+			assert.NoError(t, err)
+			assert.Equal(t, string(first), string(second))
+		})
+	}
+}
+
 func TestIndentWithInlineTable(t *testing.T) {
 	x := map[string][]map[string]string{
 		"one": {


### PR DESCRIPTION
Marshal formats the four temporal kinds (`LocalTime`, `LocalDate`, `LocalDateTime`, `time.Time`) through fixed-width formatters that never check their component ranges. Since the parser was tightened for the TOML 1.1 range rules (e.g. seconds must be `<= 59`), Marshal can now emit documents its own `Unmarshal` rejects, and in two cases emit output that silently decodes to a *different* value.

Reparse fails:

```go
b, _ := toml.Marshal(map[string]any{"t": toml.LocalTime{Second: 60}})
// b == "t = 00:00:60\n"
err := toml.Unmarshal(b, &map[string]any{})
// err: toml: seconds cannot be greater than 59
```

Reparses, but to the wrong value:

```go
// Nanosecond >= 1e9 rolls into the fraction: 1s becomes 0.1s
toml.Marshal(map[string]any{"t": toml.LocalTime{Nanosecond: 1_000_000_000}})
// -> "t = 00:00:00.100000000\n"

// An offset that is not a whole minute is truncated by RFC 3339 HH:MM:
// +01:01:01 loses its trailing second; a 30s offset collapses to +00:00 (UTC).
toml.Marshal(map[string]any{"t": time.Date(2024, 1, 1, 0, 0, 0, 0, time.FixedZone("", 30))})
// -> "t = 2024-01-01T00:00:00+00:00\n"
```

A `Precision > 9` additionally panics with `slice bounds out of range` in `LocalTime.String`.

This is the same class as the string (#424) and comment (#1081) fixes: Marshal should not produce TOML that Unmarshal refuses.

Fix: validate the components at the encoder leaf (`appendValue`), mirroring the ranges the decoder enforces, and return a descriptive error instead of emitting invalid or lossy TOML. `String()` is left untouched (it is also used for display). The audit covered all four kinds and every reachable component: hour/minute/second/nanosecond/precision, year/month/day (real calendar dates), and `time.Time` year plus zone-offset magnitude and minute alignment.

Behavior change worth flagging per CONTRIBUTING's compatibility note: these `Marshal` calls previously succeeded (with invalid, lossy, or in one case panicking output) and now return an error, matching `encoding/json`'s `UnsupportedValueError` convention. Values that were already valid are unaffected.

Tests are table-driven over every shape above (encode -> expect error, the two silent-corruption rows pinned), with green boundary controls (leap day, `23:59:59.999999999`, `+01:01`, year `0000`/`9999`, a `23:59` offset) and a Marshal -> Unmarshal -> Marshal round-trip over the valid boundary set.

`go test -race ./...` passes, coverage is unchanged (97.3%, new code fully covered), golangci-lint (pinned version) is clean, `./caps.sh check` reports no new capabilities, and benchstat on `BenchmarkMarshal` shows no regression.
