### PR TITLE
fix: invoke TextUnmarshaler on named types of native scalar kinds

### DIFF
--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -1722,8 +1722,13 @@ func (d *decoder) assignValue(v reflect.Value, expr *unstable.Node, value *unsta
 func (d *decoder) assignString(v reflect.Value, value *unstable.Node) (reflect.Value, error) {
 	switch v.Kind() {
 	case reflect.String:
-		v.SetString(string(value.Data))
-		return v, nil
+		// Only the predeclared string type skips the TextUnmarshaler check
+		// below: named string types may implement it, and it takes
+		// precedence over direct assignment.
+		if v.Type() == stringType {
+			v.SetString(string(value.Data))
+			return v, nil
+		}
 	case reflect.Interface:
 		return boxInto(v, reflect.ValueOf(string(value.Data)))
 	default:
@@ -1735,6 +1740,11 @@ func (d *decoder) assignString(v reflect.Value, value *unstable.Node) (reflect.V
 		}
 		return v, nil
 	}
+	if v.Kind() == reflect.String {
+		// Named string type that does not implement TextUnmarshaler.
+		v.SetString(string(value.Data))
+		return v, nil
+	}
 	return reflect.Value{}, d.typeMismatchError("string", v.Type(), d.p.Raw(value.Raw))
 }
 
@@ -1743,6 +1753,15 @@ func (d *decoder) assignInteger(v reflect.Value, value *unstable.Node) (reflect.
 	// represent (approximately) numbers beyond the int64 range.
 	if k := v.Kind(); k == reflect.Float32 || k == reflect.Float64 {
 		return d.assignFloat(v, value)
+	}
+
+	// TextUnmarshaler takes precedence over native assignment, and must be
+	// tried before parsing: the raw text may carry a number that does not
+	// fit an int64.
+	if mayImplementTextUnmarshaler(v.Type()) {
+		if ok, err := tryTextUnmarshaler(v, value.Data); ok {
+			return v, err
+		}
 	}
 
 	i, err := parseInteger(value.Data)
@@ -1770,9 +1789,6 @@ func (d *decoder) assignInteger(v reflect.Value, value *unstable.Node) (reflect.
 		return boxInto(v, reflect.ValueOf(i))
 	default:
 	}
-	if ok, err := tryTextUnmarshaler(v, value.Data); ok {
-		return v, err
-	}
 	return reflect.Value{}, d.typeMismatchError("integer", v.Type(), d.p.Raw(value.Raw))
 }
 
@@ -1785,7 +1801,46 @@ func tryTextUnmarshaler(v reflect.Value, text []byte) (bool, error) {
 	return false, nil
 }
 
+// predeclaredScalarType maps a scalar reflect.Kind to its predeclared Go
+// type (int64, string, bool, ...). It is sized to cover every reflect.Kind;
+// non-scalar kinds map to nil.
+var predeclaredScalarType = [reflect.UnsafePointer + 1]reflect.Type{
+	reflect.Bool:    reflect.TypeOf(false),
+	reflect.Int:     reflect.TypeOf(int(0)),
+	reflect.Int8:    reflect.TypeOf(int8(0)),
+	reflect.Int16:   reflect.TypeOf(int16(0)),
+	reflect.Int32:   reflect.TypeOf(int32(0)),
+	reflect.Int64:   reflect.TypeOf(int64(0)),
+	reflect.Uint:    reflect.TypeOf(uint(0)),
+	reflect.Uint8:   reflect.TypeOf(uint8(0)),
+	reflect.Uint16:  reflect.TypeOf(uint16(0)),
+	reflect.Uint32:  reflect.TypeOf(uint32(0)),
+	reflect.Uint64:  reflect.TypeOf(uint64(0)),
+	reflect.Uintptr: reflect.TypeOf(uintptr(0)),
+	reflect.Float32: reflect.TypeOf(float32(0)),
+	reflect.Float64: reflect.TypeOf(float64(0)),
+	reflect.String:  stringType,
+}
+
+// mayImplementTextUnmarshaler filters out types that cannot possibly
+// implement encoding.TextUnmarshaler before the more expensive interface
+// check: predeclared scalar types cannot have methods. Named scalar types
+// (e.g. `type Secret string`) can, and must be probed for the interface
+// before their kind is used for native assignment (issue #1109).
+func mayImplementTextUnmarshaler(t reflect.Type) bool {
+	return predeclaredScalarType[t.Kind()] != t
+}
+
 func (d *decoder) assignFloat(v reflect.Value, value *unstable.Node) (reflect.Value, error) {
+	// TextUnmarshaler takes precedence over native assignment. Note that
+	// integer values targeting a named float type also land here, through
+	// the redirect in assignInteger.
+	if mayImplementTextUnmarshaler(v.Type()) {
+		if ok, err := tryTextUnmarshaler(v, value.Data); ok {
+			return v, err
+		}
+	}
+
 	f, err := parseFloat(value.Data)
 	if err != nil {
 		return reflect.Value{}, err
@@ -1805,13 +1860,17 @@ func (d *decoder) assignFloat(v reflect.Value, value *unstable.Node) (reflect.Va
 		return boxInto(v, reflect.ValueOf(f))
 	default:
 	}
-	if ok, err := tryTextUnmarshaler(v, value.Data); ok {
-		return v, err
-	}
 	return reflect.Value{}, d.typeMismatchError("float", v.Type(), d.p.Raw(value.Raw))
 }
 
 func (d *decoder) assignBool(v reflect.Value, value *unstable.Node) (reflect.Value, error) {
+	// TextUnmarshaler takes precedence over native assignment.
+	if mayImplementTextUnmarshaler(v.Type()) {
+		if ok, err := tryTextUnmarshaler(v, value.Data); ok {
+			return v, err
+		}
+	}
+
 	b := value.Data[0] == 't'
 
 	switch v.Kind() {
@@ -1821,9 +1880,6 @@ func (d *decoder) assignBool(v reflect.Value, value *unstable.Node) (reflect.Val
 	case reflect.Interface:
 		return boxInto(v, reflect.ValueOf(b))
 	default:
-	}
-	if ok, err := tryTextUnmarshaler(v, value.Data); ok {
-		return v, err
 	}
 	return reflect.Value{}, d.typeMismatchError("boolean", v.Type(), d.p.Raw(value.Raw))
 }
@@ -1840,6 +1896,9 @@ func (d *decoder) assignDateTime(v reflect.Value, value *unstable.Node) (reflect
 	}
 	if v.Kind() == reflect.Interface {
 		return boxInto(v, reflect.ValueOf(t))
+	}
+	if ok, err := tryTextUnmarshaler(v, value.Data); ok {
+		return v, err
 	}
 	return reflect.Value{}, d.typeMismatchError("datetime", v.Type(), d.p.Raw(value.Raw))
 }
@@ -1874,6 +1933,9 @@ func (d *decoder) assignLocalDateTime(v reflect.Value, value *unstable.Node) (re
 	if v.Kind() == reflect.Interface {
 		return boxInto(v, reflect.ValueOf(dt))
 	}
+	if ok, err := tryTextUnmarshaler(v, value.Data); ok {
+		return v, err
+	}
 	return reflect.Value{}, d.typeMismatchError("local datetime", v.Type(), d.p.Raw(value.Raw))
 }
 
@@ -1893,6 +1955,9 @@ func (d *decoder) assignLocalDate(v reflect.Value, value *unstable.Node) (reflec
 	}
 	if v.Kind() == reflect.Interface {
 		return boxInto(v, reflect.ValueOf(date))
+	}
+	if ok, err := tryTextUnmarshaler(v, value.Data); ok {
+		return v, err
 	}
 	return reflect.Value{}, d.typeMismatchError("local date", v.Type(), d.p.Raw(value.Raw))
 }
@@ -1916,6 +1981,9 @@ func (d *decoder) assignLocalTime(v reflect.Value, value *unstable.Node) (reflec
 	}
 	if v.Kind() == reflect.Interface {
 		return boxInto(v, reflect.ValueOf(t))
+	}
+	if ok, err := tryTextUnmarshaler(v, value.Data); ok {
+		return v, err
 	}
 	return reflect.Value{}, d.typeMismatchError("local time", v.Type(), d.p.Raw(value.Raw))
 }

--- a/unmarshaler_test.go
+++ b/unmarshaler_test.go
@@ -5956,3 +5956,179 @@ type unexportedEmbedTableInner struct {
 type unexportedEmbedTableOuter struct {
 	*unexportedEmbedTableInner
 }
+
+// Issue #1109: encoding.TextUnmarshaler must be invoked for named types even
+// when their underlying kind matches the TOML value's native Go kind (e.g. a
+// TOML string into `type Secret string`). Since v2.4.0 the kind-based fast
+// paths assigned the raw value directly and silently skipped UnmarshalText.
+
+type textScalarStr1109 string
+
+func (s *textScalarStr1109) UnmarshalText(data []byte) error {
+	*s = textScalarStr1109("text:" + string(data))
+	return nil
+}
+
+type textScalarInt1109 int
+
+func (i *textScalarInt1109) UnmarshalText(data []byte) error {
+	v, err := strconv.Atoi(string(data))
+	if err != nil {
+		return err
+	}
+	*i = textScalarInt1109(v + 1000)
+	return nil
+}
+
+type textScalarUint1109 uint8
+
+func (u *textScalarUint1109) UnmarshalText(data []byte) error {
+	v, err := strconv.Atoi(string(data))
+	if err != nil {
+		return err
+	}
+	*u = textScalarUint1109(v + 1)
+	return nil
+}
+
+type textScalarFloat1109 float64
+
+func (f *textScalarFloat1109) UnmarshalText(data []byte) error {
+	v, err := strconv.ParseFloat(string(data), 64)
+	if err != nil {
+		return err
+	}
+	*f = textScalarFloat1109(v * 10)
+	return nil
+}
+
+// textScalarBool1109 inverts the parsed value so that tests can tell
+// UnmarshalText ran instead of the native bool assignment.
+type textScalarBool1109 bool
+
+func (b *textScalarBool1109) UnmarshalText(data []byte) error {
+	*b = textScalarBool1109(string(data) == "false")
+	return nil
+}
+
+type textScalarErr1109 string
+
+func (s *textScalarErr1109) UnmarshalText([]byte) error {
+	return errors.New("boom")
+}
+
+func TestIssue1109_TextUnmarshalerNamedScalarKinds(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		var x struct{ V textScalarStr1109 }
+		assert.NoError(t, toml.Unmarshal([]byte(`V = "raw"`), &x))
+		assert.Equal(t, textScalarStr1109("text:raw"), x.V)
+	})
+
+	t.Run("integer", func(t *testing.T) {
+		var x struct{ V textScalarInt1109 }
+		assert.NoError(t, toml.Unmarshal([]byte(`V = 42`), &x))
+		assert.Equal(t, textScalarInt1109(1042), x.V)
+	})
+
+	t.Run("integer into uint kind", func(t *testing.T) {
+		var x struct{ V textScalarUint1109 }
+		assert.NoError(t, toml.Unmarshal([]byte(`V = 3`), &x))
+		assert.Equal(t, textScalarUint1109(4), x.V)
+	})
+
+	t.Run("float", func(t *testing.T) {
+		var x struct{ V textScalarFloat1109 }
+		assert.NoError(t, toml.Unmarshal([]byte(`V = 1.5`), &x))
+		assert.Equal(t, textScalarFloat1109(15), x.V)
+	})
+
+	t.Run("integer into float kind", func(t *testing.T) {
+		var x struct{ V textScalarFloat1109 }
+		assert.NoError(t, toml.Unmarshal([]byte(`V = 2`), &x))
+		assert.Equal(t, textScalarFloat1109(20), x.V)
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		var x struct{ V textScalarBool1109 }
+		assert.NoError(t, toml.Unmarshal([]byte(`V = true`), &x))
+		assert.Equal(t, textScalarBool1109(false), x.V)
+	})
+
+	t.Run("pointer to named type", func(t *testing.T) {
+		var x struct{ V *textScalarStr1109 }
+		assert.NoError(t, toml.Unmarshal([]byte(`V = "raw"`), &x))
+		assert.Equal(t, textScalarStr1109("text:raw"), *x.V)
+	})
+
+	t.Run("map value", func(t *testing.T) {
+		var x map[string]textScalarStr1109
+		assert.NoError(t, toml.Unmarshal([]byte(`V = "raw"`), &x))
+		assert.Equal(t, textScalarStr1109("text:raw"), x["V"])
+	})
+
+	t.Run("slice element", func(t *testing.T) {
+		var x struct{ V []textScalarStr1109 }
+		assert.NoError(t, toml.Unmarshal([]byte(`V = ["a", "b"]`), &x))
+		assert.Equal(t, []textScalarStr1109{"text:a", "text:b"}, x.V)
+	})
+
+	t.Run("UnmarshalText error is reported", func(t *testing.T) {
+		var x struct{ V textScalarErr1109 }
+		err := toml.Unmarshal([]byte(`V = "raw"`), &x)
+		assert.Error(t, err)
+		assert.True(t, strings.Contains(err.Error(), "boom"), "error %q should mention the UnmarshalText failure", err)
+	})
+
+	// Named scalar types without TextUnmarshaler must keep decoding
+	// natively.
+	t.Run("named types without TextUnmarshaler decode natively", func(t *testing.T) {
+		type S string
+		type I int
+		type F float64
+		type B bool
+		var x struct {
+			S S
+			I I
+			F F
+			B B
+		}
+		doc := "S = \"s\"\nI = 1\nF = 1.5\nB = true"
+		assert.NoError(t, toml.Unmarshal([]byte(doc), &x))
+		assert.Equal(t, S("s"), x.S)
+		assert.Equal(t, I(1), x.I)
+		assert.Equal(t, F(1.5), x.F)
+		assert.Equal(t, B(true), x.B)
+	})
+}
+
+// Issue #1109: same regression for date and time TOML values: in v2.3.x any
+// addressable target implementing encoding.TextUnmarshaler (other than
+// time.Time) received the raw text of the value.
+func TestIssue1109_TextUnmarshalerDateTimeKinds(t *testing.T) {
+	examples := []struct {
+		name string
+		doc  string
+		want textScalarStr1109
+	}{
+		{"datetime", `V = 2021-03-30T21:12:00Z`, "text:2021-03-30T21:12:00Z"},
+		{"local datetime", `V = 2021-03-30T21:12:00`, "text:2021-03-30T21:12:00"},
+		{"local date", `V = 2021-03-30`, "text:2021-03-30"},
+		{"local time", `V = 21:12:00`, "text:21:12:00"},
+	}
+
+	for _, e := range examples {
+		t.Run(e.name, func(t *testing.T) {
+			var x struct{ V textScalarStr1109 }
+			assert.NoError(t, toml.Unmarshal([]byte(e.doc), &x))
+			assert.Equal(t, e.want, x.V)
+		})
+	}
+
+	// time.Time keeps its native datetime decoding: its UnmarshalText only
+	// accepts RFC 3339, which would break local date/time values.
+	t.Run("time.Time still decodes natively", func(t *testing.T) {
+		var x struct{ V time.Time }
+		assert.NoError(t, toml.Unmarshal([]byte(`V = 2021-03-30`), &x))
+		assert.Equal(t, time.Date(2021, 3, 30, 0, 0, 0, 0, time.Local), x.V)
+	})
+}


### PR DESCRIPTION
## What

Since v2.4.0, `assignString`/`assignInteger`/`assignFloat`/`assignBool` switched on the target's `reflect.Kind` *before* probing for `encoding.TextUnmarshaler`, so a named type whose underlying kind matches the TOML value's native Go kind (e.g. `type Secret string` decoding a TOML string) was assigned the raw value directly and its `UnmarshalText` silently skipped. v2.3.x probed the interface first, regardless of kind. The four datetime value kinds had the same regression, failing with a type-mismatch error instead.

This change probes `TextUnmarshaler` before native scalar assignment in all eight assign functions. The probe is gated on a kind→predeclared-type table (`mayImplementTextUnmarshaler`), so plain `string`/`int`/`float`/`bool` targets — the common case, which cannot have methods — keep their fast path at the cost of a single pointer comparison. `time.Time` keeps its native datetime decoding (its `UnmarshalText` only accepts RFC 3339), and inline tables/arrays keep the #974 field-by-field struct fallback.

Fixes #1109

## Testing

- Added `TestIssue1109_TextUnmarshalerNamedScalarKinds` (string, int, uint, float, bool, pointer target, map value, slice element, error propagation, and a guard that named types *without* the interface still decode natively) and `TestIssue1109_TextUnmarshalerDateTimeKinds` (all four datetime kinds + a guard that `time.Time` still decodes natively). All failed before the fix for the reported reason, all pass after.
- The issue's exact repro program now prints `<nil> DECODED:raw`, matching v2.3.1.
- `go test -race ./...` green; `golangci-lint` (v2.8.0, CI's version) clean; `./caps.sh check` unchanged; every added line covered.

## Benchmarks

linux/amd64 spot VM (t2d), 10 interleaved samples per side, `BenchmarkUnmarshal*` vs `v2`: no regressions — sec/op geomean −1.55% (`SimpleDocument/struct` −7.08%, `canada` −4.20%, `config` −2.66%, rest within noise), B/op and allocs/op bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)