### PR TITLE
fix: Encode with nil writer returns error

### DIFF
--- a/encode_nil_writer_test.go
+++ b/encode_nil_writer_test.go
@@ -1,0 +1,15 @@
+package toml
+
+import "testing"
+
+func TestEncodeNilWriter(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	err := NewEncoder(nil).Encode(map[string]int{"a": 1})
+	if err == nil {
+		t.Fatal("want error")
+	}
+}

--- a/marshaler.go
+++ b/marshaler.go
@@ -245,6 +245,9 @@ func (enc *Encoder) EnableMarshalerInterface() *Encoder {
 // inside inline tables. For array tables, the comment is only present before
 // the first element of the array.
 func (enc *Encoder) Encode(v interface{}) error {
+	if enc == nil || enc.w == nil {
+		return fmt.Errorf("toml: Encoder writer is nil")
+	}
 	e := encoderStatePool.Get().(*encoderState)
 	e.Encoder = enc
 	e.marshalerOn = enc.marshalerInterface


### PR DESCRIPTION
```go
toml.NewEncoder(nil).Encode(map[string]int{"a": 1}) // panic
```

Return `toml: Encoder writer is nil`.