### PR TITLE
fix: Decode with nil reader returns error

### DIFF
--- a/decode_nil_reader_test.go
+++ b/decode_nil_reader_test.go
@@ -1,0 +1,16 @@
+package toml
+
+import "testing"
+
+func TestDecodeNilReader(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked: %v", r)
+		}
+	}()
+	var v map[string]any
+	err := NewDecoder(nil).Decode(&v)
+	if err == nil {
+		t.Fatal("want error")
+	}
+}

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -169,6 +169,9 @@ func (d *Decoder) EnableUnmarshalerInterface() *Decoder {
 //	Inline Table     -> same as Table
 //	Array of Tables  -> same as Array and Table
 func (d *Decoder) Decode(v interface{}) error {
+	if d == nil || d.r == nil {
+		return fmt.Errorf("toml: Decoder reader is nil")
+	}
 	b, err := io.ReadAll(d.r)
 	if err != nil {
 		return fmt.Errorf("toml: %w", err)


### PR DESCRIPTION
```go
toml.NewDecoder(nil).Decode(&v) // panic
```

Return `toml: Decoder reader is nil`.