### PR TITLE
fix: strip UTF-8 BOM before unmarshaling

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -26,3 +26,11 @@ func TestParseDateTimeMissingTimezone(t *testing.T) {
 	_, err := parseDateTime([]byte("2021-01-01T00:00:00"))
 	assert.Error(t, err)
 }
+
+func TestUnmarshalUTF8BOM(t *testing.T) {
+	var m map[string]string
+	data := append([]byte{0xEF, 0xBB, 0xBF}, []byte("a = \"hello\"\n")...)
+	err := Unmarshal(data, &m)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", m["a"])
+}

--- a/unmarshaler.go
+++ b/unmarshaler.go
@@ -1,6 +1,7 @@
 package toml
 
 import (
+	"bytes"
 	"encoding"
 	"errors"
 	"fmt"
@@ -15,6 +16,9 @@ import (
 	"github.com/pelletier/go-toml/v2/internal/tracker"
 	"github.com/pelletier/go-toml/v2/unstable"
 )
+
+// utf8BOM is the UTF-8 byte order mark some editors prepend to files.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 
 // decoderPool recycles decoders (and their internal buffers: parser arena,
 // seen-tracker entries, scratch buffers) across calls to Unmarshal and
@@ -495,6 +499,11 @@ func (d *decoder) unmarshal(data []byte, v interface{}) error {
 	}
 	if r.IsNil() {
 		return errors.New("toml: decoding pointer target cannot be nil")
+	}
+
+	// Strip a leading UTF-8 BOM so files saved by Windows editors still parse.
+	if bytes.HasPrefix(data, utf8BOM) {
+		data = data[len(utf8BOM):]
 	}
 
 	root := r.Elem()


### PR DESCRIPTION
## Summary

UTF-8 BOM (`EF BB BF`) at the start of a TOML document made `Unmarshal` / `Decode` fail with an invalid character on the first key. Common when files are saved from Windows editors.

Strip the BOM once at the start of decoding so both `Unmarshal` and `Decoder.Decode` accept these files.

Fixes #250.

## Test plan

- [x] `go test -run TestUnmarshalUTF8BOM`
- [x] Existing package tests