### PR TITLE
feat: push the multiline tag down to table values

### DIFF
--- a/marshaler.go
+++ b/marshaler.go
@@ -228,7 +228,10 @@ func (enc *Encoder) EnableMarshalerInterface() *Encoder {
 // The "multiline" option emits strings as quoted multi-line TOML strings, and
 // arrays with one element per line. For strings, it only takes effect when the
 // value contains a newline; single-line values are emitted as regular strings.
-// It has no effect on fields that would not be encoded as strings or arrays.
+// When set on a field that is encoded as a table (a map or struct), the option
+// is pushed down onto that table's values, so their strings and arrays follow
+// the same rule. Only the value held directly by each key is affected: a
+// map[string][][]string only makes its outer arrays multiline.
 //
 // The "inline" option turns fields that would be emitted as tables into
 // inline tables instead. It has no effect on other fields.
@@ -760,6 +763,20 @@ func (e *encoderState) encodeTableEntries(entries []entry, commented bool, inden
 		subEntries, err := e.collectEntries(tv)
 		if err != nil {
 			return err
+		}
+
+		// A "multiline" option on a table (a map or struct field) is pushed
+		// down onto that table's own entries. Without this it would be a no-op,
+		// since it only takes effect on strings and arrays: propagating it lets
+		// the values follow the multiline rule, so their arrays span multiple
+		// lines and their newline-containing strings use the """...""" form.
+		// Only the value directly held by each entry is affected; the elements
+		// of an array are not, so a map[string][][]string only makes its outer
+		// arrays multiline.
+		if ent.options.multiline {
+			for j := range subEntries {
+				subEntries[j].options.multiline = true
+			}
 		}
 
 		subIndent := indent + 1

--- a/marshaler_test.go
+++ b/marshaler_test.go
@@ -507,6 +507,67 @@ B = [1, 2, 3, 4]
 `,
 		},
 		{
+			desc: "multiline pushed down to map array values",
+			v: struct {
+				A map[string][]string `toml:",multiline"`
+			}{
+				A: map[string][]string{"key": {"one", "two"}},
+			},
+			expected: `[A]
+key = [
+  'one',
+  'two'
+]
+`,
+		},
+		{
+			desc: "multiline pushed down keeps inner arrays inline",
+			v: struct {
+				A map[string][][]string `toml:",multiline"`
+			}{
+				A: map[string][][]string{"key": {{"x", "y"}, {"z"}}},
+			},
+			expected: `[A]
+key = [
+  ['x', 'y'],
+  ['z']
+]
+`,
+		},
+		{
+			desc: "multiline pushed down to map string values",
+			v: struct {
+				A map[string]string `toml:",multiline"`
+			}{
+				A: map[string]string{"key": "line1\nline2"},
+			},
+			expected: `[A]
+key = """
+line1
+line2"""
+`,
+		},
+		{
+			desc: "multiline pushed down to struct field values",
+			v: struct {
+				Inner struct {
+					Tags []string
+				} `toml:",multiline"`
+			}{
+				Inner: struct {
+					Tags []string
+				}{
+					Tags: []string{"a", "b"},
+				},
+			},
+			expected: `[Inner]
+Tags = [
+  'a',
+  'b'
+]
+`,
+		},
+		{
 			desc: "nil interface not supported at root",
 			v:    nil,
 			err:  true,


### PR DESCRIPTION
Closes #828.

## What this does

The `multiline` struct-tag option only took effect on strings and arrays, so setting it on a field that gets encoded as a table (a map or a struct) was silently a no-op. This pushes the option down onto that table's own entries, so their values follow the multiline rule: arrays are emitted one element per line, and strings containing a newline use the `"""..."""` form.

Given the example from the issue:

```go
struct {
    Field map[string][][]string `toml:",multiline"`
}
```

only the outer array of each value becomes multiline, matching the expectation in #828:

```toml
[Field]
a = [
  ['x', 'y'],
  ['z']
]
```

## Details

The propagation happens in `encodeTableEntries`, right where a table-valued entry's sub-entries are collected before recursing. When the parent entry carries `multiline`, it is OR-ed onto each sub-entry's options. Because array elements are always encoded with fresh options (see `appendArray`), only the value held directly by each key is affected — nested arrays stay inline, which is the behaviour the issue asks for.

Scope notes:
- Only the plain sub-table path is touched. Inline tables already disable multiline for their members, and array-of-tables (`[][]struct`) elements are their own tables, so those paths are intentionally left as-is.
- The change is purely additive: fields that previously had no effect from `multiline` now honour it. Fields without the tag are unchanged.

The tag documentation on `Encoder.Encode` is updated to describe the new behaviour, and regression tests cover the map-of-arrays, map-of-nested-arrays, map-of-multiline-strings, and struct-field cases.

## benchstat

No measurable change (single bool check per table entry, no extra allocations):

```
                                │  base        │             this PR                 │
                                │    sec/op    │    sec/op     vs base               │
Marshal/SimpleDocument/struct-4   493.4n ± 12%   488.9n ±  9%       ~ (p=0.529 n=10)
Marshal/SimpleDocument/map-4      587.9n ± 11%   557.2n ± 14%       ~ (p=0.089 n=10)
Marshal/ReferenceFile/struct-4    17.72µ ± 14%   17.29µ ± 45%       ~ (p=0.739 n=10)
Marshal/ReferenceFile/map-4       28.40µ ±  9%   28.97µ ±  7%       ~ (p=0.853 n=10)
Marshal/HugoFrontMatter-4         5.795µ ±  6%   6.016µ ± 16%       ~ (p=0.280 n=10)
geomean                           3.850µ         3.827µ        -0.59%

allocs/op unchanged across all cases (p=1.000, all samples equal).
```
