### PR TITLE
docs: fix hyphenation in StrictMissingError doc comment

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -38,7 +38,7 @@ func (s *StrictMissingError) Error() string {
 	return "strict mode: fields in the document are missing in the target struct"
 }
 
-// String returns a human readable description of all errors.
+// String returns a human-readable description of all errors.
 func (s *StrictMissingError) String() string {
 	var buf strings.Builder
 


### PR DESCRIPTION
### Summary
- Fix hyphenation in doc comment for `StrictMissingError.String()` in `errors.go` (`human readable` -> `human-readable`).